### PR TITLE
Fix PlanView student list

### DIFF
--- a/src/main/java/com/esvar/dekanat/plan/PlanView.java
+++ b/src/main/java/com/esvar/dekanat/plan/PlanView.java
@@ -176,6 +176,8 @@ public class PlanView extends Div {
         String departmentName = plan.getDepartment().getTitle();
         String parts = String.valueOf(plan.getParts()); // За замовчуванням
 
+        // Оновлюємо список студентів у діалозі відповідно до обраної групи
+        updateStudentListInDialog();
 
         List<String> selectedStudents = isElective
                 ? planService.getSelectedStudentsForPlan(plan) // Отримуємо студентів з student_plans


### PR DESCRIPTION
## Summary
- refresh the student list whenever editing a plan to avoid outdated selections

## Testing
- `./mvnw -q test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68590ec518a8832687efd2ea665937e4