### PR TITLE
Improve rating filters layout

### DIFF
--- a/src/main/java/com/esvar/dekanat/rating/RatingView.java
+++ b/src/main/java/com/esvar/dekanat/rating/RatingView.java
@@ -1,0 +1,94 @@
+package com.esvar.dekanat.rating;
+
+import com.esvar.dekanat.view.MainLayout;
+import com.esvar.dekanat.service.RatingService;
+import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import jakarta.annotation.security.PermitAll;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@PermitAll
+@PageTitle("Рейтинг | Деканат")
+@Route(value = "rating", layout = MainLayout.class)
+public class RatingView extends Div {
+
+    private final RatingService ratingService;
+
+    private final Select<String> specialtySelect = new Select<>();
+    private final Select<String> courseSelect = new Select<>();
+    private final Select<String> groupSelect = new Select<>();
+    private final Select<Integer> yearSelect = new Select<>();
+    private final Checkbox technikumCheckbox = new Checkbox("Технікум");
+    private final Checkbox budgetCheckbox = new Checkbox("Бюджет");
+    private final Grid<RatingRow> ratingGrid = new Grid<>(RatingRow.class, false);
+
+    public RatingView(RatingService ratingService) {
+        this.ratingService = ratingService;
+        configureFilters();
+        configureGrid();
+        VerticalLayout checkboxColumn = new VerticalLayout(technikumCheckbox, budgetCheckbox);
+        checkboxColumn.setSpacing(false);
+        checkboxColumn.setPadding(false);
+
+        HorizontalLayout filters = new HorizontalLayout(
+                specialtySelect,
+                courseSelect,
+                groupSelect,
+                yearSelect,
+                checkboxColumn
+        );
+        filters.setPadding(true);
+        filters.setDefaultVerticalComponentAlignment(FlexComponent.Alignment.START);
+        filters.setVerticalComponentAlignment(FlexComponent.Alignment.END, checkboxColumn);
+
+        VerticalLayout layout = new VerticalLayout(new H2("Сторінка рейтингу"), filters, ratingGrid);
+        layout.setPadding(false);
+        add(layout);
+    }
+
+    private void configureFilters() {
+        specialtySelect.setLabel("Спеціальність");
+        specialtySelect.setItems(ratingService.getSpecialties());
+        specialtySelect.addValueChangeListener(e -> search());
+
+        courseSelect.setLabel("Курс");
+        courseSelect.setItems(ratingService.getCourses());
+        courseSelect.addValueChangeListener(e -> search());
+
+        groupSelect.setLabel("Група");
+        groupSelect.setItems(ratingService.getGroupCodes());
+        groupSelect.addValueChangeListener(e -> search());
+
+        yearSelect.setLabel("Рік");
+        yearSelect.setItems(ratingService.getYears());
+        yearSelect.addValueChangeListener(e -> search());
+
+        technikumCheckbox.addValueChangeListener(e -> search());
+        budgetCheckbox.addValueChangeListener(e -> search());
+    }
+
+    private void configureGrid() {
+        ratingGrid.addColumn(RatingRow::student).setHeader("Студент");
+        ratingGrid.addColumn(RatingRow::rating).setHeader("Рейтинг");
+        ratingGrid.setItems(new ArrayList<>());
+        ratingGrid.setWidthFull();
+    }
+
+    private void search() {
+        // TODO: реалізувати пошук за обраними фільтрами
+        ratingGrid.setItems(List.of());
+    }
+
+    private record RatingRow(String student, String rating) {
+    }
+}

--- a/src/main/java/com/esvar/dekanat/service/RatingService.java
+++ b/src/main/java/com/esvar/dekanat/service/RatingService.java
@@ -1,0 +1,48 @@
+package com.esvar.dekanat.service;
+
+import com.esvar.dekanat.dto.GroupDTO;
+import org.springframework.stereotype.Service;
+import java.util.Comparator;
+import java.util.List;
+@Service
+public class RatingService {
+
+    private final GroupService groupService;
+
+    public RatingService(GroupService groupService) {
+        this.groupService = groupService;
+    }
+
+    public List<String> getSpecialties() {
+        return groupService.getGroupsDTO().stream()
+                .map(GroupDTO::getSpecialtyAbbreviation)
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    public List<String> getCourses() {
+        return groupService.getGroupsDTO().stream()
+                .map(GroupDTO::getCourse)
+                .map(String::valueOf)
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    public List<String> getGroupCodes() {
+        return groupService.getGroupsDTO().stream()
+                .map(GroupDTO::getGroupCode)
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    public List<Integer> getYears() {
+        return groupService.getGroupsDTO().stream()
+                .map(GroupDTO::getYear)
+                .distinct()
+                .sorted(Comparator.reverseOrder())
+                .toList();
+    }
+}

--- a/src/main/java/com/esvar/dekanat/view/MainLayout.java
+++ b/src/main/java/com/esvar/dekanat/view/MainLayout.java
@@ -4,6 +4,7 @@ import com.esvar.dekanat.DekanatApplication;
 import com.esvar.dekanat.mark.EnterMarksView;
 import com.esvar.dekanat.plan.PlanView;
 import com.esvar.dekanat.card.CardView;
+import com.esvar.dekanat.rating.RatingView;
 import com.esvar.dekanat.security.SecurityService;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
@@ -70,7 +71,8 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
             tabs.add(
                     createTab(VaadinIcon.CLIPBOARD_CHECK, "Навчальні плани", PlanView.class),
                     createTab(VaadinIcon.USER_CARD, "Перегляд карток", CardView.class),
-                    createTab(VaadinIcon.PENCIL, "Введення оцінок", EnterMarksView.class)
+                    createTab(VaadinIcon.PENCIL, "Введення оцінок", EnterMarksView.class),
+                    createTab(VaadinIcon.BAR_CHART, "Рейтинг", RatingView.class)
             );
             tabs.setOrientation(Tabs.Orientation.VERTICAL);
             addToDrawer(tabs);


### PR DESCRIPTION
## Summary
- align rating page checkboxes vertically and bottom-aligned with the selects
- load rating filters from the database using a new service

## Testing
- `./mvnw -q -DskipTests package` *(fails to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685958f730548326bfafcccffadeb04c