### PR TITLE
Add student success synchronization

### DIFF
--- a/src/main/java/com/esvar/dekanat/progress/MarkEditDialog.java
+++ b/src/main/java/com/esvar/dekanat/progress/MarkEditDialog.java
@@ -1,0 +1,84 @@
+package com.esvar.dekanat.progress;
+
+import com.esvar.dekanat.entity.ControlMethodEntity;
+import com.esvar.dekanat.entity.DisciplineEntity;
+import com.esvar.dekanat.service.ControlMethodService;
+import com.esvar.dekanat.service.DisciplineService;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.component.textfield.IntegerField;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+/**
+ * Dialog for editing a student's mark information.
+ */
+public class MarkEditDialog extends Dialog {
+
+    @Setter
+    private SaveListener saveListener;
+
+    private final ComboBox<String> discipline = new ComboBox<>("Дисципліна");
+    private final Select<Integer> semester = new Select<>();
+    private final IntegerField hours = new IntegerField("Години");
+    private final ComboBox<String> controlType = new ComboBox<>("Тип контролю");
+    private final IntegerField grade = new IntegerField("Оцінка");
+
+    private final Button save = new Button("Зберегти");
+    private final Button cancel = new Button("Відміна");
+
+    public MarkEditDialog(DisciplineService disciplineService,
+                          ControlMethodService controlMethodService) {
+        List<String> disciplines = disciplineService.getAllDisciplines().stream()
+                .map(DisciplineEntity::getTitle).toList();
+        discipline.setItems(disciplines);
+        List<String> controls = controlMethodService.getTypeControlMethod(0).stream()
+                .map(ControlMethodEntity::getName).toList();
+        controlType.setItems(controls);
+
+        semester.setLabel("Семестр");
+        semester.setItems(IntStream.rangeClosed(1, 4).boxed().toList());
+        grade.setHasControls(true);
+        grade.setMin(0);
+        grade.setMax(100);
+
+        save.addThemeVariants(ButtonVariant.LUMO_PRIMARY, ButtonVariant.LUMO_SUCCESS);
+        cancel.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        save.addClickListener(e -> handleSave());
+        cancel.addClickListener(e -> close());
+
+        HorizontalLayout actions = new HorizontalLayout(save, cancel);
+        add(discipline, semester, hours, controlType, grade, actions);
+    }
+
+    public void open(String disc, int sem, int hrs, String ctrl, int grd) {
+        discipline.setValue(disc);
+        semester.setValue(sem);
+        hours.setValue(hrs);
+        controlType.setValue(ctrl);
+        grade.setValue(grd);
+        super.open();
+    }
+
+    private void handleSave() {
+        if (saveListener != null) {
+            saveListener.onSave(discipline.getValue(),
+                    semester.getValue(),
+                    hours.getValue() == null ? 0 : hours.getValue(),
+                    controlType.getValue(),
+                    grade.getValue() == null ? 0 : grade.getValue());
+        }
+        close();
+    }
+
+    /** Listener for save action. */
+    public interface SaveListener {
+        void onSave(String discipline, int semester, int hours, String controlType, int grade);
+    }
+}

--- a/src/main/java/com/esvar/dekanat/progress/SuccessView.java
+++ b/src/main/java/com/esvar/dekanat/progress/SuccessView.java
@@ -1,0 +1,249 @@
+package com.esvar.dekanat.progress;
+
+import com.esvar.dekanat.dto.GroupDTO;
+import com.esvar.dekanat.entity.MarksEntity;
+import com.esvar.dekanat.entity.PlansEntity;
+import com.esvar.dekanat.entity.StudentEntity;
+import com.esvar.dekanat.service.*;
+import com.esvar.dekanat.service.SyncService;
+import com.esvar.dekanat.view.MainLayout;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import jakarta.annotation.security.PermitAll;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * View showing academic performance for a student.
+ */
+@PermitAll
+@PageTitle("Успішність | Деканат")
+@Route(value = "success", layout = MainLayout.class)
+public class SuccessView extends Div {
+
+    private final GroupService groupService;
+    private final StudentService studentService;
+    private final MarksService marksService;
+    private final DisciplineService disciplineService;
+    private final ControlMethodService controlMethodService;
+    private final PlanService planService;
+
+    private final Select<String> groupSelect = new Select<>();
+    private final ComboBox<String> studentSelect = new ComboBox<>();
+    private final ComboBox<String> otherStudentSelect = new ComboBox<>();
+    private final Button syncButton = new Button("Синхронізувати");
+    private final Button applySyncButton = new Button("Провести синхронізацію");
+    private final Button cancelSyncButton = new Button("Скасувати");
+    private final Grid<Row> grid = new Grid<>(Row.class, false);
+    private final Grid<Row> otherGrid = new Grid<>(Row.class, false);
+    private final MarkEditDialog editDialog;
+    private final SyncService syncService;
+
+    public SuccessView(GroupService groupService,
+                       StudentService studentService,
+                       MarksService marksService,
+                       DisciplineService disciplineService,
+                       ControlMethodService controlMethodService,
+                       PlanService planService,
+                       SyncService syncService) {
+        this.groupService = groupService;
+        this.studentService = studentService;
+        this.marksService = marksService;
+        this.disciplineService = disciplineService;
+        this.controlMethodService = controlMethodService;
+        this.planService = planService;
+        this.syncService = syncService;
+        this.editDialog = new MarkEditDialog(disciplineService, controlMethodService);
+        configureSelectors();
+        configureGrid();
+        configureSyncControls();
+
+        HorizontalLayout filters = new HorizontalLayout(groupSelect, studentSelect, syncButton, otherStudentSelect, applySyncButton, cancelSyncButton);
+        filters.setPadding(true);
+        HorizontalLayout tables = new HorizontalLayout(grid, otherGrid);
+        VerticalLayout layout = new VerticalLayout(new H2("Успішність студента"), filters, tables);
+        layout.setPadding(false);
+        add(layout, editDialog);
+    }
+
+    private void configureSelectors() {
+        groupSelect.setLabel("Група");
+        groupSelect.setItems(groupService.getGroupsDTO().stream()
+                .map(GroupDTO::toString).collect(Collectors.toList()));
+        groupSelect.addValueChangeListener(e -> updateStudents());
+
+        studentSelect.setLabel("Студент");
+        studentSelect.addValueChangeListener(e -> updateGrid());
+        studentSelect.setClearButtonVisible(true);
+    }
+
+    private void configureGrid() {
+        grid.addColumn(row -> String.valueOf(grid.getListDataView().getItems().toList().indexOf(row) + 1))
+                .setHeader("№");
+        grid.addColumn(Row::discipline).setHeader("Дисципліна");
+        grid.addColumn(Row::semester).setHeader("Семестр");
+        grid.addColumn(Row::hours).setHeader("Години");
+        grid.addColumn(Row::controlType).setHeader("Тип контролю");
+        grid.addColumn(Row::grade).setHeader("Оцінка");
+        grid.addComponentColumn(row -> {
+            Button edit = new Button("Редагувати");
+            edit.addClickListener(e -> openEditor(row));
+            return edit;
+        }).setHeader("Дії");
+        grid.setWidthFull();
+        grid.setItems(List.of());
+    }
+
+    private void configureSyncControls() {
+        otherStudentSelect.setLabel("Інший студент");
+        otherStudentSelect.setVisible(false);
+        otherStudentSelect.addValueChangeListener(e -> updateOtherGrid());
+
+        otherGrid.addColumn(row -> String.valueOf(otherGrid.getListDataView().getItems().toList().indexOf(row) + 1))
+                .setHeader("№");
+        otherGrid.addColumn(Row::discipline).setHeader("Дисципліна");
+        otherGrid.addColumn(Row::semester).setHeader("Семестр");
+        otherGrid.addColumn(Row::hours).setHeader("Години");
+        otherGrid.addColumn(Row::controlType).setHeader("Тип контролю");
+        otherGrid.addColumn(Row::grade).setHeader("Оцінка");
+        otherGrid.setWidthFull();
+        otherGrid.setItems(List.of());
+        otherGrid.setVisible(false);
+
+        syncButton.addClickListener(e -> enterSyncMode());
+        applySyncButton.addThemeVariants(ButtonVariant.LUMO_SUCCESS);
+        cancelSyncButton.addThemeVariants(ButtonVariant.LUMO_ERROR);
+        applySyncButton.setVisible(false);
+        cancelSyncButton.setVisible(false);
+        applySyncButton.addClickListener(e -> performSync());
+        cancelSyncButton.addClickListener(e -> exitSyncMode());
+    }
+
+    private void updateStudents() {
+        String group = groupSelect.getValue();
+        if (group != null) {
+            List<String> students = groupService.getAllStudentsForSelectedGroup(group);
+            studentSelect.setItems(students);
+        } else {
+            studentSelect.setItems(List.of());
+        }
+        grid.setItems(List.of());
+        exitSyncMode();
+    }
+
+    private void updateGrid() {
+        String studentName = studentSelect.getValue();
+        String group = groupSelect.getValue();
+        if (studentName == null || group == null) {
+            grid.setItems(List.of());
+            return;
+        }
+        StudentEntity student = studentService.getStudentForCard(group, studentName);
+        List<Row> rows = marksService.getMarksByStudent(student).stream()
+                .map(m -> new Row(
+                        m.getId(),
+                        m.getPlan().getDiscipline().getTitle(),
+                        m.getSemester(),
+                        m.getPlan().getHours(),
+                        m.getControlMethod().getName(),
+                        m.getFinalGrade()))
+                .toList();
+        grid.setItems(rows);
+    }
+
+    private void openEditor(Row row) {
+        editDialog.setSaveListener((disc, sem, hrs, ctrl, grade) -> saveRow(row, disc, sem, hrs, ctrl, grade));
+        editDialog.open(row.discipline, row.semester, row.hours, row.controlType, row.grade);
+    }
+
+    private void saveRow(Row row, String disc, int sem, int hrs, String ctrl, int grade) {
+        MarksEntity mark = marksService.getMarkById(row.id);
+        if (mark == null) return;
+        PlansEntity plan = mark.getPlan();
+        plan.setDiscipline(disciplineService.getDisciplineByTitle(disc));
+        plan.setSemester(sem);
+        plan.setHours(hrs);
+        planService.updatePlan(plan);
+
+        mark.setSemester(sem);
+        mark.setControlMethod(controlMethodService.getControlMethodByName(ctrl));
+        mark.setFinalGrade(grade);
+        marksService.saveMark(mark);
+        updateGrid();
+    }
+
+    private void enterSyncMode() {
+        String group = groupSelect.getValue();
+        String current = studentSelect.getValue();
+        if (group == null || current == null) {
+            return;
+        }
+        otherStudentSelect.setItems(groupService.getAllStudentsForSelectedGroup(group)
+                .stream().filter(s -> !s.equals(current)).toList());
+        studentSelect.setEnabled(false);
+        syncButton.setVisible(false);
+        otherStudentSelect.setVisible(true);
+        applySyncButton.setVisible(true);
+        cancelSyncButton.setVisible(true);
+    }
+
+    private void exitSyncMode() {
+        otherStudentSelect.clear();
+        otherStudentSelect.setVisible(false);
+        otherGrid.setVisible(false);
+        studentSelect.setEnabled(true);
+        syncButton.setVisible(true);
+        applySyncButton.setVisible(false);
+        cancelSyncButton.setVisible(false);
+    }
+
+    private void updateOtherGrid() {
+        String otherName = otherStudentSelect.getValue();
+        String group = groupSelect.getValue();
+        if (otherName == null || group == null) {
+            otherGrid.setItems(List.of());
+            otherGrid.setVisible(false);
+            return;
+        }
+        StudentEntity student = studentService.getStudentForCard(group, otherName);
+        List<Row> rows = marksService.getMarksByStudent(student).stream()
+                .map(m -> new Row(
+                        null,
+                        m.getPlan().getDiscipline().getTitle(),
+                        m.getSemester(),
+                        m.getPlan().getHours(),
+                        m.getControlMethod().getName(),
+                        0))
+                .toList();
+        otherGrid.setItems(rows);
+        otherGrid.setVisible(true);
+    }
+
+    private void performSync() {
+        String otherName = otherStudentSelect.getValue();
+        String group = groupSelect.getValue();
+        String currentName = studentSelect.getValue();
+        if (otherName == null || group == null || currentName == null) {
+            return;
+        }
+        StudentEntity target = studentService.getStudentForCard(group, currentName);
+        StudentEntity source = studentService.getStudentForCard(group, otherName);
+        syncService.synchronize(target, source);
+        exitSyncMode();
+        updateGrid();
+    }
+
+    /** Row DTO for grid. */
+    private record Row(Long id, String discipline, int semester, int hours, String controlType, int grade) {
+    }
+}

--- a/src/main/java/com/esvar/dekanat/repository/StudentPlansRepository.java
+++ b/src/main/java/com/esvar/dekanat/repository/StudentPlansRepository.java
@@ -1,6 +1,7 @@
 package com.esvar.dekanat.repository;
 
 import com.esvar.dekanat.entity.PlansEntity;
+import com.esvar.dekanat.entity.StudentEntity;
 import com.esvar.dekanat.entity.StudentPlansEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -49,4 +50,12 @@ public interface StudentPlansRepository extends JpaRepository<StudentPlansEntity
     void deleteByPlanId(@Param("planId") Long planId);
 
     List<StudentPlansEntity> findByPlan(PlansEntity plan); // Повертає записи для конкретного плану
+
+    /**
+     * Отримати усі зв'язки планів для конкретного студента.
+     *
+     * @param student студент
+     * @return список StudentPlansEntity
+     */
+    List<StudentPlansEntity> findByStudent(StudentEntity student);
 }

--- a/src/main/java/com/esvar/dekanat/service/MarksService.java
+++ b/src/main/java/com/esvar/dekanat/service/MarksService.java
@@ -90,10 +90,6 @@ public class MarksService {
         return marksRepository.findByPlanAndControlMethod(plansEntity, controlMethodRepository.findByName(typeControl));
     }
 
-    public MarksEntity getMarkById(Long id) {
-        return marksRepository.findById(id).orElse(null);
-    }
-
     public String getMarkForFirstModalControl(StudentEntity studentEntity, PlansEntity plansEntity, String typeControl) {
         Optional<MarksEntity> opt = marksRepository.findByStudentIdAndPlanIdAndControlMethodId(
                 studentEntity.getId(),
@@ -104,6 +100,29 @@ public class MarksService {
             return String.valueOf(opt.get().getFinalGrade());
         }
         return "0";
+    }
+
+    /**
+     * Returns all marks for the given student.
+     *
+     * @param student StudentEntity - student for which marks are requested.
+     * @return list of MarksEntity
+     */
+    public List<MarksEntity> getMarksByStudent(StudentEntity student) {
+        if (student == null) {
+            return List.of();
+        }
+        return marksRepository.findByStudentId(student.getId());
+    }
+
+    /**
+     * Get mark by its id.
+     *
+     * @param id identifier of mark
+     * @return MarksEntity or null if not found
+     */
+    public MarksEntity getMarkById(Long id) {
+        return marksRepository.findById(id).orElse(null);
     }
 
 }

--- a/src/main/java/com/esvar/dekanat/service/StudentPlansService.java
+++ b/src/main/java/com/esvar/dekanat/service/StudentPlansService.java
@@ -103,4 +103,17 @@ public class StudentPlansService{
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Повертає усі записи student_plans для вказаного студента.
+     *
+     * @param student студент
+     * @return список StudentPlansEntity
+     */
+    public List<StudentPlansEntity> getPlansForStudent(StudentEntity student) {
+        if (student == null) {
+            return new ArrayList<>();
+        }
+        return studentPlansRepository.findByStudent(student);
+    }
+
 }

--- a/src/main/java/com/esvar/dekanat/service/SyncService.java
+++ b/src/main/java/com/esvar/dekanat/service/SyncService.java
@@ -1,0 +1,61 @@
+package com.esvar.dekanat.service;
+
+import com.esvar.dekanat.entity.PlansEntity;
+import com.esvar.dekanat.entity.StudentEntity;
+import com.esvar.dekanat.entity.StudentPlansEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Service for synchronizing plans between students.
+ */
+@Service
+public class SyncService {
+
+    private final StudentPlansService studentPlansService;
+    private final PlanService planService;
+    private final MarksInitializerService marksInitializerService;
+
+    public SyncService(StudentPlansService studentPlansService,
+                       PlanService planService,
+                       MarksInitializerService marksInitializerService) {
+        this.studentPlansService = studentPlansService;
+        this.planService = planService;
+        this.marksInitializerService = marksInitializerService;
+    }
+
+    /**
+     * Copy all study plans from source student to target student.
+     * Created plans are exact copies with grades initialized to zero.
+     *
+     * @param target студент, до якого копіюємо
+     * @param source студент, з якого копіюємо
+     */
+    public void synchronize(StudentEntity target, StudentEntity source) {
+        List<StudentPlansEntity> sourcePlans = studentPlansService.getPlansForStudent(source);
+        for (StudentPlansEntity sp : sourcePlans) {
+            PlansEntity srcPlan = sp.getPlan();
+            PlansEntity newPlan = new PlansEntity();
+            newPlan.setSpecialty(srcPlan.getSpecialty());
+            newPlan.setDiscipline(srcPlan.getDiscipline());
+            newPlan.setDepartment(srcPlan.getDepartment());
+            newPlan.setSemester(srcPlan.getSemester());
+            newPlan.setHours(srcPlan.getHours());
+            newPlan.setElective(srcPlan.isElective());
+            newPlan.setParts(srcPlan.getParts());
+            newPlan.setFirstControl(srcPlan.getFirstControl());
+            newPlan.setSecondControl(srcPlan.getSecondControl());
+            newPlan.setFaculty(srcPlan.getFaculty());
+            newPlan.setGroup(target.getGroup());
+            planService.savePlan(newPlan);
+
+            StudentPlansEntity mapping = new StudentPlansEntity();
+            mapping.setStudent(target);
+            mapping.setPlan(newPlan);
+            studentPlansService.saveStudentPlan(mapping);
+
+            marksInitializerService.initializeMarksForPlan(newPlan, List.of(target));
+        }
+    }
+}

--- a/src/main/java/com/esvar/dekanat/view/MainLayout.java
+++ b/src/main/java/com/esvar/dekanat/view/MainLayout.java
@@ -5,6 +5,7 @@ import com.esvar.dekanat.mark.EnterMarksView;
 import com.esvar.dekanat.plan.PlanView;
 import com.esvar.dekanat.card.CardView;
 import com.esvar.dekanat.rating.RatingView;
+import com.esvar.dekanat.progress.SuccessView;
 import com.esvar.dekanat.security.SecurityService;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
@@ -76,7 +77,8 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
                     createTab(VaadinIcon.CLIPBOARD_CHECK, "Навчальні плани", PlanView.class),
                     createTab(VaadinIcon.USER_CARD, "Перегляд карток", CardView.class),
                     createTab(VaadinIcon.PENCIL, "Введення оцінок", EnterMarksView.class),
-                    createTab(VaadinIcon.BAR_CHART, "Рейтинг", RatingView.class)
+                    createTab(VaadinIcon.BAR_CHART, "Рейтинг", RatingView.class),
+                    createTab(VaadinIcon.BOOK, "Успішність", SuccessView.class)
             );
             tabs.setOrientation(Tabs.Orientation.VERTICAL);
             addToDrawer(tabs);


### PR DESCRIPTION
## Summary
- add repository method to fetch student plans
- expose retrieval in `StudentPlansService`
- implement `SyncService` for plan copy and marks init
- extend `SuccessView` with UI for synchronizing plans between students

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c55d7f5d083268ef91b7af21edec0