### PR TITLE
Fix SuccessView button alignment

### DIFF
--- a/src/main/java/com/esvar/dekanat/progress/SuccessView.java
+++ b/src/main/java/com/esvar/dekanat/progress/SuccessView.java
@@ -13,6 +13,7 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.component.combobox.ComboBox;
@@ -68,8 +69,10 @@ public class SuccessView extends Div {
         configureGrid();
         configureSyncControls();
 
-        HorizontalLayout filters = new HorizontalLayout(groupSelect, studentSelect, syncButton, otherStudentSelect, applySyncButton, cancelSyncButton);
+        HorizontalLayout filters = new HorizontalLayout(groupSelect, studentSelect, syncButton,
+                otherStudentSelect, applySyncButton, cancelSyncButton);
         filters.setPadding(true);
+        filters.setAlignItems(FlexComponent.Alignment.BASELINE);
 
         HorizontalLayout tables = new HorizontalLayout(grid, otherGrid);
         tables.setWidthFull();


### PR DESCRIPTION
## Summary
- align buttons in `SuccessView` with the bottom of filter row using baseline alignment

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_685cd82ff988832689623d41cd748a8b