### PR TITLE
Fix group filtering in rating search

### DIFF
--- a/src/main/java/com/esvar/dekanat/repository/StudentRatingRepository.java
+++ b/src/main/java/com/esvar/dekanat/repository/StudentRatingRepository.java
@@ -17,7 +17,7 @@ public interface StudentRatingRepository extends JpaRepository<StudentRatingEnti
             LEFT JOIN StudentInfoEntity info ON info.student = st
         WHERE (:specialty IS NULL OR sr.specialty.abbreviation = :specialty)
           AND (:course IS NULL OR sr.course = :course)
-          AND (:groupCode IS NULL OR sr.group.groupCode = :groupCode)
+          AND (:groupNumber IS NULL OR sr.group.groupNumber = :groupNumber)
           AND (:year IS NULL OR sr.group.year = :year)
           AND (:budget = false OR info.typeOfIndividual = 'Держбюджет')
           AND (:technikum = false OR LOWER(sr.specialty.title) LIKE '%тех%')
@@ -26,7 +26,7 @@ public interface StudentRatingRepository extends JpaRepository<StudentRatingEnti
     List<StudentRatingEntity> searchRatings(
             @Param("specialty") String specialty,
             @Param("course") Integer course,
-            @Param("groupCode") String groupCode,
+            @Param("groupNumber") Integer groupNumber,
             @Param("year") String year,
             @Param("technikum") boolean technikum,
             @Param("budget") boolean budget

--- a/src/main/java/com/esvar/dekanat/service/RatingService.java
+++ b/src/main/java/com/esvar/dekanat/service/RatingService.java
@@ -76,10 +76,17 @@ public class RatingService {
             } catch (NumberFormatException ignored) {
             }
         }
+        Integer groupNumber = null;
+        if (group != null && !group.isEmpty()) {
+            try {
+                groupNumber = Integer.parseInt(group);
+            } catch (NumberFormatException ignored) {
+            }
+        }
         return ratingRepository.searchRatings(
                 specialty,
                 courseNumber,
-                group,
+                groupNumber,
                 year,
                 technikum,
                 budget


### PR DESCRIPTION
## Summary
- update `StudentRatingRepository` to filter by `groupNumber`
- parse group number in `RatingService`

## Testing
- `./mvnw -q -DskipTests package` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_685d12b5e88c8326ab72331f7fecc10b