### PR TITLE
Ensure elective first module control reports use plan students

### DIFF
--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -912,7 +912,7 @@ public class EnterMarksView extends Div {
 
         // Формуємо список студентів для друку
         List<StudentModelToDocumentGenerate> students = new ArrayList<>();
-        List<StudentEntity> studentEntities = sortStudentsByFullName(studentService.getStudentByGroupId(plansEntity.getGroup().getId()));
+        List<StudentEntity> studentEntities = getSortedStudentsForPlan(plansEntity.getGroup());
         int index = 1;
         for (StudentEntity student : studentEntities) {
             // Припустимо, student.getRecordBookNumber() використовується як studentNumber


### PR DESCRIPTION
## Summary
- use the existing plan-aware student retrieval when building the first module control report model

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69035213620083268508e8de0d450145