### PR TITLE
Fix summary report generation when control method missing

### DIFF
--- a/src/main/java/com/esvar/dekanat/service/MarksService.java
+++ b/src/main/java/com/esvar/dekanat/service/MarksService.java
@@ -109,7 +109,21 @@ public class MarksService {
     }
 
     public List<MarksEntity> findMarksByPlanAndTypeControl(PlansEntity plansEntity, String typeControl) {
-        return marksRepository.findByPlanAndControlMethod(plansEntity, controlMethodRepository.findByName(typeControl));
+        if (plansEntity == null || typeControl == null) {
+            return List.of();
+        }
+
+        String trimmedTypeControl = typeControl.trim();
+        if (trimmedTypeControl.isEmpty()) {
+            return List.of();
+        }
+
+        ControlMethodEntity controlMethod = controlMethodRepository.findByName(trimmedTypeControl);
+        if (controlMethod == null) {
+            return List.of();
+        }
+
+        return marksRepository.findByPlanAndControlMethod(plansEntity, controlMethod);
     }
 
     public String getMarkForFirstModalControl(StudentEntity studentEntity, PlansEntity plansEntity, String typeControl) {


### PR DESCRIPTION
## Summary
- guard mark lookup by control type against null input and unknown control methods
- return an empty mark list when the requested control method is not configured to prevent runtime failures during summary report generation

## Testing
- ./mvnw -q -DskipTests compile *(fails: no network access to download Maven binaries)*

------
https://chatgpt.com/codex/tasks/task_e_690389c8307c8326a063c80192878130