### PR TITLE
Fix first module summary report mark lookup

### DIFF
--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -1358,7 +1358,8 @@ public class EnterMarksView extends Div {
         }
 
         for (PlansEntity plan : plans) {
-            List<MarksEntity> marks = marksService.findMarksByPlanAndTypeControl(plan, CONTROL_TYPE_FIRST_MODULE);
+            ControlMethodEntity firstControl = plan.getFirstControl();
+            List<MarksEntity> marks = marksService.findMarksByPlanAndControlMethod(plan, firstControl);
             if (marks == null) {
                 marks = Collections.emptyList();
             }

--- a/src/main/java/com/esvar/dekanat/service/MarksService.java
+++ b/src/main/java/com/esvar/dekanat/service/MarksService.java
@@ -109,7 +109,29 @@ public class MarksService {
     }
 
     public List<MarksEntity> findMarksByPlanAndTypeControl(PlansEntity plansEntity, String typeControl) {
-        return marksRepository.findByPlanAndControlMethod(plansEntity, controlMethodRepository.findByName(typeControl));
+        if (plansEntity == null || typeControl == null) {
+            return List.of();
+        }
+
+        String trimmedTypeControl = typeControl.trim();
+        if (trimmedTypeControl.isEmpty()) {
+            return List.of();
+        }
+
+        ControlMethodEntity controlMethod = controlMethodRepository.findByName(trimmedTypeControl);
+        if (controlMethod == null) {
+            return List.of();
+        }
+
+        return marksRepository.findByPlanAndControlMethod(plansEntity, controlMethod);
+    }
+
+    public List<MarksEntity> findMarksByPlanAndControlMethod(PlansEntity plan, ControlMethodEntity controlMethod) {
+        if (plan == null || controlMethod == null) {
+            return List.of();
+        }
+
+        return marksRepository.findByPlanAndControlMethod(plan, controlMethod);
     }
 
     public String getMarkForFirstModalControl(StudentEntity studentEntity, PlansEntity plansEntity, String typeControl) {


### PR DESCRIPTION
## Summary
- add a dedicated marks service helper that queries marks by plan and control method
- use the plan's first control when collecting marks for the first module summary report so all disciplines populate the PDF

## Testing
- ./mvnw -q -DskipTests compile *(fails: Maven distribution cannot be downloaded without network access)*

------
https://chatgpt.com/codex/tasks/task_e_690389c8307c8326a063c80192878130