### PR TITLE
Fix first module control detection in summary report

### DIFF
--- a/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
+++ b/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 public class SummaryReportService {
 
     private static final String CONTROL_TYPE_FIRST_MODULE = "Перший модульний контроль";
+    private static final String FIRST_MODULE_KEYWORD = "перший модуль";
 
     private final GroupService groupService;
     private final StudentService studentService;
@@ -140,8 +141,25 @@ public class SummaryReportService {
         if (plan == null) {
             return false;
         }
-        ControlMethodEntity firstControl = plan.getFirstControl();
-        return firstControl != null && CONTROL_TYPE_FIRST_MODULE.equals(firstControl.getName());
+        return isFirstModuleControl(plan.getFirstControl());
+    }
+
+    private boolean isFirstModuleControl(ControlMethodEntity controlMethod) {
+        if (controlMethod == null) {
+            return false;
+        }
+        String controlName = controlMethod.getName();
+        if (controlName == null) {
+            return false;
+        }
+
+        String normalizedName = controlName.trim();
+        if (normalizedName.equalsIgnoreCase(CONTROL_TYPE_FIRST_MODULE)) {
+            return true;
+        }
+
+        String normalizedLowerCase = normalizedName.toLowerCase(Locale.ROOT);
+        return normalizedLowerCase.contains(FIRST_MODULE_KEYWORD);
     }
 
     private Map<String, List<Integer>> buildMarksForSummaryReport(List<StudentEntity> students, List<PlansEntity> plans) {


### PR DESCRIPTION
## Summary
- normalise first module control names when detecting plans for the summary report

## Testing
- ⚠️ `./mvnw -q -DskipTests compile` *(fails: unable to download Maven distribution in the container)*

------
https://chatgpt.com/codex/tasks/task_e_69039943a98c83269099a60a3d5888aa