### PR TITLE
Handle elective disciplines in first module summary report

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
@@ -40,7 +40,7 @@ public class SummaryReportPdfGenerator {
     public byte[] generateSummaryReport(
             String groupName,
             List<String> studentFullNames,
-            List<String> disciplineNames,
+            List<DisciplineColumn> disciplineColumns,
             Map<String, List<Integer>> marksByStudent,
             boolean addAverageRow
     ) {
@@ -61,12 +61,12 @@ public class SummaryReportPdfGenerator {
                     .setMarginBottom(10);
             document.add(title);
 
-            Table table = createTableStructure(disciplineNames.size());
-            addHeaderRows(table, disciplineNames);
-            addStudentRows(table, studentFullNames, disciplineNames, marksByStudent);
+            Table table = createTableStructure(disciplineColumns.size());
+            addHeaderRows(table, disciplineColumns);
+            addStudentRows(table, studentFullNames, disciplineColumns, marksByStudent);
 
             if (addAverageRow) {
-                addZeroSummaryRow(table, studentFullNames, disciplineNames, marksByStudent);
+                addZeroSummaryRow(table, studentFullNames, disciplineColumns, marksByStudent);
             }
 
             document.add(table);
@@ -104,8 +104,8 @@ public class SummaryReportPdfGenerator {
         return table;
     }
 
-    private void addHeaderRows(Table table, List<String> disciplineNames) {
-        int disciplineCount = disciplineNames.size();
+    private void addHeaderRows(Table table, List<DisciplineColumn> disciplineColumns) {
+        int disciplineCount = disciplineColumns.size();
 
         Cell blankForName = new Cell().setBorder(new SolidBorder(1));
         table.addHeaderCell(blankForName);
@@ -129,8 +129,13 @@ public class SummaryReportPdfGenerator {
                 .setBorder(new SolidBorder(1));
         table.addHeaderCell(nameHeader);
 
-        for (String discipline : disciplineNames) {
-            Paragraph rotated = new Paragraph(discipline)
+        for (DisciplineColumn discipline : disciplineColumns) {
+            String headerText = discipline.title();
+            if (discipline.elective()) {
+                headerText = headerText + "\n(вибіркова)";
+            }
+
+            Paragraph rotated = new Paragraph(headerText)
                     .setRotationAngle(Math.toRadians(90))
                     .setTextAlignment(TextAlignment.CENTER)
                     .setFontSize(10f);
@@ -160,7 +165,7 @@ public class SummaryReportPdfGenerator {
 
     private void addStudentRows(Table table,
                                 List<String> studentFullNames,
-                                List<String> disciplineNames,
+                                List<DisciplineColumn> disciplineColumns,
                                 Map<String, List<Integer>> marksByStudent) {
         for (String student : studentFullNames) {
             Cell nameCell = new Cell()
@@ -173,13 +178,13 @@ public class SummaryReportPdfGenerator {
             List<Integer> marks = marksByStudent.getOrDefault(student, Collections.emptyList());
             int zeroCount = 0;
 
-            for (int i = 0; i < disciplineNames.size(); i++) {
-                int mark = getMark(marks, i);
-                if (mark == 0) {
+            for (int i = 0; i < disciplineColumns.size(); i++) {
+                Integer mark = getMark(marks, i);
+                if (mark != null && mark == 0) {
                     zeroCount++;
                 }
 
-                table.addCell(createNumericCell(mark));
+                table.addCell(createMarkCell(mark));
             }
 
             table.addCell(createNumericCell(zeroCount));
@@ -188,7 +193,7 @@ public class SummaryReportPdfGenerator {
 
     private void addZeroSummaryRow(Table table,
                                    List<String> studentFullNames,
-                                   List<String> disciplineNames,
+                                   List<DisciplineColumn> disciplineColumns,
                                    Map<String, List<Integer>> marksByStudent) {
         Cell labelCell = new Cell()
                 .add(new Paragraph("Кількість 0 по дисциплінах"))
@@ -198,12 +203,12 @@ public class SummaryReportPdfGenerator {
         table.addCell(labelCell);
 
         int totalZeros = 0;
-        for (int i = 0; i < disciplineNames.size(); i++) {
+        for (int i = 0; i < disciplineColumns.size(); i++) {
             int zeroPerDiscipline = 0;
             for (String student : studentFullNames) {
                 List<Integer> marks = marksByStudent.getOrDefault(student, Collections.emptyList());
-                int mark = getMark(marks, i);
-                if (mark == 0) {
+                Integer mark = getMark(marks, i);
+                if (mark != null && mark == 0) {
                     zeroPerDiscipline++;
                 }
             }
@@ -223,11 +228,26 @@ public class SummaryReportPdfGenerator {
                 .setBorder(new SolidBorder(1));
     }
 
-    private int getMark(List<Integer> marks, int index) {
-        if (marks == null || index >= marks.size()) {
-            return 0;
+    private Cell createMarkCell(Integer value) {
+        if (value == null) {
+            return createEmptyCell();
         }
-        Integer value = marks.get(index);
-        return value != null ? value : 0;
+        return createNumericCell(value);
+    }
+
+    private Cell createEmptyCell() {
+        return new Cell()
+                .add(new Paragraph(""))
+                .setBorder(new SolidBorder(1));
+    }
+
+    private Integer getMark(List<Integer> marks, int index) {
+        if (marks == null || index >= marks.size()) {
+            return null;
+        }
+        return marks.get(index);
+    }
+
+    public record DisciplineColumn(String title, boolean elective) {
     }
 }

--- a/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
+++ b/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
@@ -64,25 +64,24 @@ public class SummaryReportService {
             throw new SummaryReportGenerationException("Не знайдено дисциплін для першого модульного контролю");
         }
 
-        List<String> disciplineNames = plans.stream()
-                .map(PlansEntity::getDiscipline)
-                .filter(Objects::nonNull)
-                .map(discipline -> discipline.getTitle() == null ? "" : discipline.getTitle())
-                .filter(title -> !title.isBlank())
-                .collect(Collectors.toList());
-        if (disciplineNames.isEmpty()) {
-            throw new SummaryReportGenerationException("Список дисциплін порожній");
-        }
-
         List<String> studentFullNames = students.stream()
                 .map(StudentEntity::getFullName)
                 .collect(Collectors.toList());
 
-        Map<String, List<Integer>> marksByStudent = buildMarksForSummaryReport(students, plans);
+        List<DisciplineSummary> disciplineSummaries = buildDisciplineSummaries(plans, students);
+        if (disciplineSummaries.isEmpty()) {
+            throw new SummaryReportGenerationException("Список дисциплін порожній");
+        }
+
+        List<SummaryReportPdfGenerator.DisciplineColumn> disciplineColumns = disciplineSummaries.stream()
+                .map(summary -> new SummaryReportPdfGenerator.DisciplineColumn(summary.title(), summary.elective()))
+                .collect(Collectors.toList());
+
+        Map<String, List<Integer>> marksByStudent = buildMarksForSummaryReport(students, disciplineSummaries);
         byte[] pdfBytes = summaryReportPdfGenerator.generateSummaryReport(
                 group.getGroupCode(),
                 studentFullNames,
-                disciplineNames,
+                disciplineColumns,
                 marksByStudent,
                 true
         );
@@ -162,7 +161,8 @@ public class SummaryReportService {
         return normalizedLowerCase.contains(FIRST_MODULE_KEYWORD);
     }
 
-    private Map<String, List<Integer>> buildMarksForSummaryReport(List<StudentEntity> students, List<PlansEntity> plans) {
+    private Map<String, List<Integer>> buildMarksForSummaryReport(List<StudentEntity> students,
+                                                                 List<DisciplineSummary> disciplineSummaries) {
         List<String> studentNames = students.stream()
                 .map(StudentEntity::getFullName)
                 .collect(Collectors.toList());
@@ -172,7 +172,8 @@ public class SummaryReportService {
             marksByStudent.put(studentName, new ArrayList<>());
         }
 
-        for (PlansEntity plan : plans) {
+        for (DisciplineSummary disciplineSummary : disciplineSummaries) {
+            PlansEntity plan = disciplineSummary.plan();
             ControlMethodEntity firstControl = plan.getFirstControl();
             List<MarksEntity> marks = marksService.findMarksByPlanAndControlMethod(plan, firstControl);
             if (marks == null) {
@@ -189,6 +190,12 @@ public class SummaryReportService {
             for (int i = 0; i < students.size(); i++) {
                 StudentEntity student = students.get(i);
                 String studentName = studentNames.get(i);
+
+                if (!disciplineSummary.assignedStudentIds().contains(student.getId())) {
+                    marksByStudent.get(studentName).add(null);
+                    continue;
+                }
+
                 int markValue = marksByStudentId.getOrDefault(student.getId(), 0);
                 marksByStudent.get(studentName).add(markValue);
             }
@@ -197,7 +204,56 @@ public class SummaryReportService {
         return marksByStudent;
     }
 
+    private List<DisciplineSummary> buildDisciplineSummaries(List<PlansEntity> plans, List<StudentEntity> students) {
+        if (plans == null || plans.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> groupStudentIds = students.stream()
+                .map(StudentEntity::getId)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        List<DisciplineSummary> summaries = new ArrayList<>();
+        for (PlansEntity plan : plans) {
+            DisciplineEntity discipline = plan.getDiscipline();
+            if (discipline == null) {
+                continue;
+            }
+
+            String title = discipline.getTitle();
+            if (title == null) {
+                continue;
+            }
+
+            title = title.trim();
+            if (title.isBlank()) {
+                continue;
+            }
+
+            Set<Long> assignedStudentIds = studentPlansService.getStudentByPlan(plan).stream()
+                    .map(StudentEntity::getId)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+
+            if (assignedStudentIds.isEmpty() && !plan.isElective()) {
+                assignedStudentIds.addAll(groupStudentIds);
+            }
+
+            boolean matchesGroup = assignedStudentIds.containsAll(groupStudentIds)
+                    && groupStudentIds.containsAll(assignedStudentIds);
+            boolean elective = plan.isElective() || !matchesGroup;
+
+            summaries.add(new DisciplineSummary(plan, title, elective, assignedStudentIds));
+        }
+
+        return summaries.stream()
+                .sorted(Comparator.comparing(DisciplineSummary::title, ukrainianCollator))
+                .collect(Collectors.toList());
+    }
+
     public record SummaryReportResult(String groupCode, byte[] pdfBytes) {
+    }
+
+    private record DisciplineSummary(PlansEntity plan, String title, boolean elective, Set<Long> assignedStudentIds) {
     }
 
     public static class SummaryReportGenerationException extends RuntimeException {


### PR DESCRIPTION
## Summary
- derive unified first-module discipline list from plan assignments and flag entries missing any students as elective
- propagate elective discipline metadata to the PDF generator, leaving cells blank for students without the discipline and annotating headers
- ensure zero counters ignore non-assigned students so optional subjects no longer skew totals

## Testing
- ./mvnw -q -DskipTests compile *(fails: unable to download Maven distribution in sandbox)*


------
https://chatgpt.com/codex/tasks/task_e_6909e77950948326833d3404e945d274