### PR TITLE
Fix elective discipline gathering for first module summary report

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
@@ -40,7 +40,7 @@ public class SummaryReportPdfGenerator {
     public byte[] generateSummaryReport(
             String groupName,
             List<String> studentFullNames,
-            List<String> disciplineNames,
+            List<DisciplineColumn> disciplineColumns,
             Map<String, List<Integer>> marksByStudent,
             boolean addAverageRow
     ) {
@@ -61,12 +61,12 @@ public class SummaryReportPdfGenerator {
                     .setMarginBottom(10);
             document.add(title);
 
-            Table table = createTableStructure(disciplineNames.size());
-            addHeaderRows(table, disciplineNames);
-            addStudentRows(table, studentFullNames, disciplineNames, marksByStudent);
+            Table table = createTableStructure(disciplineColumns.size());
+            addHeaderRows(table, disciplineColumns);
+            addStudentRows(table, studentFullNames, disciplineColumns, marksByStudent);
 
             if (addAverageRow) {
-                addZeroSummaryRow(table, studentFullNames, disciplineNames, marksByStudent);
+                addZeroSummaryRow(table, studentFullNames, disciplineColumns, marksByStudent);
             }
 
             document.add(table);
@@ -104,8 +104,8 @@ public class SummaryReportPdfGenerator {
         return table;
     }
 
-    private void addHeaderRows(Table table, List<String> disciplineNames) {
-        int disciplineCount = disciplineNames.size();
+    private void addHeaderRows(Table table, List<DisciplineColumn> disciplineColumns) {
+        int disciplineCount = disciplineColumns.size();
 
         Cell blankForName = new Cell().setBorder(new SolidBorder(1));
         table.addHeaderCell(blankForName);
@@ -129,8 +129,13 @@ public class SummaryReportPdfGenerator {
                 .setBorder(new SolidBorder(1));
         table.addHeaderCell(nameHeader);
 
-        for (String discipline : disciplineNames) {
-            Paragraph rotated = new Paragraph(discipline)
+        for (DisciplineColumn discipline : disciplineColumns) {
+            String headerText = discipline.title();
+            if (discipline.elective()) {
+                headerText = headerText + "\n(вибіркова)";
+            }
+
+            Paragraph rotated = new Paragraph(headerText)
                     .setRotationAngle(Math.toRadians(90))
                     .setTextAlignment(TextAlignment.CENTER)
                     .setFontSize(10f);
@@ -160,7 +165,7 @@ public class SummaryReportPdfGenerator {
 
     private void addStudentRows(Table table,
                                 List<String> studentFullNames,
-                                List<String> disciplineNames,
+                                List<DisciplineColumn> disciplineColumns,
                                 Map<String, List<Integer>> marksByStudent) {
         for (String student : studentFullNames) {
             Cell nameCell = new Cell()
@@ -173,13 +178,13 @@ public class SummaryReportPdfGenerator {
             List<Integer> marks = marksByStudent.getOrDefault(student, Collections.emptyList());
             int zeroCount = 0;
 
-            for (int i = 0; i < disciplineNames.size(); i++) {
-                int mark = getMark(marks, i);
-                if (mark == 0) {
+            for (int i = 0; i < disciplineColumns.size(); i++) {
+                Integer mark = getMark(marks, i);
+                if (mark != null && mark == 0) {
                     zeroCount++;
                 }
 
-                table.addCell(createNumericCell(mark));
+                table.addCell(createMarkCell(mark));
             }
 
             table.addCell(createNumericCell(zeroCount));
@@ -188,7 +193,7 @@ public class SummaryReportPdfGenerator {
 
     private void addZeroSummaryRow(Table table,
                                    List<String> studentFullNames,
-                                   List<String> disciplineNames,
+                                   List<DisciplineColumn> disciplineColumns,
                                    Map<String, List<Integer>> marksByStudent) {
         Cell labelCell = new Cell()
                 .add(new Paragraph("Кількість 0 по дисциплінах"))
@@ -198,12 +203,12 @@ public class SummaryReportPdfGenerator {
         table.addCell(labelCell);
 
         int totalZeros = 0;
-        for (int i = 0; i < disciplineNames.size(); i++) {
+        for (int i = 0; i < disciplineColumns.size(); i++) {
             int zeroPerDiscipline = 0;
             for (String student : studentFullNames) {
                 List<Integer> marks = marksByStudent.getOrDefault(student, Collections.emptyList());
-                int mark = getMark(marks, i);
-                if (mark == 0) {
+                Integer mark = getMark(marks, i);
+                if (mark != null && mark == 0) {
                     zeroPerDiscipline++;
                 }
             }
@@ -223,11 +228,26 @@ public class SummaryReportPdfGenerator {
                 .setBorder(new SolidBorder(1));
     }
 
-    private int getMark(List<Integer> marks, int index) {
-        if (marks == null || index >= marks.size()) {
-            return 0;
+    private Cell createMarkCell(Integer value) {
+        if (value == null) {
+            return createEmptyCell();
         }
-        Integer value = marks.get(index);
-        return value != null ? value : 0;
+        return createNumericCell(value);
+    }
+
+    private Cell createEmptyCell() {
+        return new Cell()
+                .add(new Paragraph(""))
+                .setBorder(new SolidBorder(1));
+    }
+
+    private Integer getMark(List<Integer> marks, int index) {
+        if (marks == null || index >= marks.size()) {
+            return null;
+        }
+        return marks.get(index);
+    }
+
+    public record DisciplineColumn(String title, boolean elective) {
     }
 }

--- a/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
+++ b/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
@@ -59,30 +59,29 @@ public class SummaryReportService {
         }
 
         int semester = computeFirstModuleSemester(selectedGroup.getCourse());
-        List<PlansEntity> plans = collectPlansForSummaryReport(group, semester, students);
-        if (plans.isEmpty()) {
+        Map<Long, PlanAssignment> planAssignments = collectPlanAssignments(group, semester, students);
+        if (planAssignments.isEmpty()) {
             throw new SummaryReportGenerationException("Не знайдено дисциплін для першого модульного контролю");
-        }
-
-        List<String> disciplineNames = plans.stream()
-                .map(PlansEntity::getDiscipline)
-                .filter(Objects::nonNull)
-                .map(discipline -> discipline.getTitle() == null ? "" : discipline.getTitle())
-                .filter(title -> !title.isBlank())
-                .collect(Collectors.toList());
-        if (disciplineNames.isEmpty()) {
-            throw new SummaryReportGenerationException("Список дисциплін порожній");
         }
 
         List<String> studentFullNames = students.stream()
                 .map(StudentEntity::getFullName)
                 .collect(Collectors.toList());
 
-        Map<String, List<Integer>> marksByStudent = buildMarksForSummaryReport(students, plans);
+        List<DisciplineSummary> disciplineSummaries = buildDisciplineSummaries(planAssignments.values(), students);
+        if (disciplineSummaries.isEmpty()) {
+            throw new SummaryReportGenerationException("Список дисциплін порожній");
+        }
+
+        List<SummaryReportPdfGenerator.DisciplineColumn> disciplineColumns = disciplineSummaries.stream()
+                .map(summary -> new SummaryReportPdfGenerator.DisciplineColumn(summary.title(), summary.elective()))
+                .collect(Collectors.toList());
+
+        Map<String, List<Integer>> marksByStudent = buildMarksForSummaryReport(students, disciplineSummaries);
         byte[] pdfBytes = summaryReportPdfGenerator.generateSummaryReport(
                 group.getGroupCode(),
                 studentFullNames,
-                disciplineNames,
+                disciplineColumns,
                 marksByStudent,
                 true
         );
@@ -107,34 +106,36 @@ public class SummaryReportService {
         return course * 2 - 1;
     }
 
-    private List<PlansEntity> collectPlansForSummaryReport(StudentGroupEntity group,
-                                                           int semester,
-                                                           List<StudentEntity> students) {
-        Map<Long, PlansEntity> uniquePlans = new LinkedHashMap<>();
+    private Map<Long, PlanAssignment> collectPlanAssignments(StudentGroupEntity group,
+                                                             int semester,
+                                                             List<StudentEntity> students) {
+        Map<Long, PlanAssignment> assignments = new LinkedHashMap<>();
 
         List<PlansEntity> groupPlans = planService.getAllPlansForGroupAndSemester(group, semester);
         if (groupPlans != null) {
             groupPlans.stream()
                     .filter(this::isFirstModulePlan)
-                    .forEach(plan -> uniquePlans.putIfAbsent(plan.getId(), plan));
+                    .forEach(plan -> assignments.computeIfAbsent(plan.getId(), id -> new PlanAssignment(plan)));
         }
 
         for (StudentEntity student : students) {
-            studentPlansService.getPlansForStudent(student).stream()
-                    .map(StudentPlansEntity::getPlan)
-                    .filter(Objects::nonNull)
-                    .filter(plan -> plan.getSemester() == semester)
-                    .filter(this::isFirstModulePlan)
-                    .forEach(plan -> uniquePlans.putIfAbsent(plan.getId(), plan));
+            List<StudentPlansEntity> studentPlans = studentPlansService.getPlansForStudent(student);
+            if (studentPlans == null || studentPlans.isEmpty()) {
+                continue;
+            }
+
+            for (StudentPlansEntity studentPlan : studentPlans) {
+                PlansEntity plan = studentPlan.getPlan();
+                if (plan == null || plan.getSemester() != semester || !isFirstModulePlan(plan)) {
+                    continue;
+                }
+
+                assignments.computeIfAbsent(plan.getId(), id -> new PlanAssignment(plan))
+                        .assignedStudentIds.add(student.getId());
+            }
         }
 
-        return uniquePlans.values().stream()
-                .sorted(Comparator.comparing(
-                        plan -> Optional.ofNullable(plan.getDiscipline())
-                                .map(DisciplineEntity::getTitle)
-                                .orElse("")
-                        , ukrainianCollator))
-                .collect(Collectors.toList());
+        return assignments;
     }
 
     private boolean isFirstModulePlan(PlansEntity plan) {
@@ -162,7 +163,8 @@ public class SummaryReportService {
         return normalizedLowerCase.contains(FIRST_MODULE_KEYWORD);
     }
 
-    private Map<String, List<Integer>> buildMarksForSummaryReport(List<StudentEntity> students, List<PlansEntity> plans) {
+    private Map<String, List<Integer>> buildMarksForSummaryReport(List<StudentEntity> students,
+                                                                 List<DisciplineSummary> disciplineSummaries) {
         List<String> studentNames = students.stream()
                 .map(StudentEntity::getFullName)
                 .collect(Collectors.toList());
@@ -172,7 +174,8 @@ public class SummaryReportService {
             marksByStudent.put(studentName, new ArrayList<>());
         }
 
-        for (PlansEntity plan : plans) {
+        for (DisciplineSummary disciplineSummary : disciplineSummaries) {
+            PlansEntity plan = disciplineSummary.plan();
             ControlMethodEntity firstControl = plan.getFirstControl();
             List<MarksEntity> marks = marksService.findMarksByPlanAndControlMethod(plan, firstControl);
             if (marks == null) {
@@ -189,6 +192,12 @@ public class SummaryReportService {
             for (int i = 0; i < students.size(); i++) {
                 StudentEntity student = students.get(i);
                 String studentName = studentNames.get(i);
+
+                if (!disciplineSummary.assignedStudentIds().contains(student.getId())) {
+                    marksByStudent.get(studentName).add(null);
+                    continue;
+                }
+
                 int markValue = marksByStudentId.getOrDefault(student.getId(), 0);
                 marksByStudent.get(studentName).add(markValue);
             }
@@ -197,7 +206,70 @@ public class SummaryReportService {
         return marksByStudent;
     }
 
+    private List<DisciplineSummary> buildDisciplineSummaries(Collection<PlanAssignment> assignments,
+                                                             List<StudentEntity> students) {
+        if (assignments == null || assignments.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> groupStudentIds = students.stream()
+                .map(StudentEntity::getId)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        List<DisciplineSummary> summaries = new ArrayList<>();
+        for (PlanAssignment assignment : assignments) {
+            PlansEntity plan = assignment.plan;
+            DisciplineEntity discipline = plan.getDiscipline();
+            if (discipline == null) {
+                continue;
+            }
+
+            String title = discipline.getTitle();
+            if (title == null) {
+                continue;
+            }
+
+            title = title.trim();
+            if (title.isBlank()) {
+                continue;
+            }
+
+            Set<Long> assignedStudentIds = new LinkedHashSet<>(assignment.assignedStudentIds);
+            if (assignedStudentIds.isEmpty() && !plan.isElective()) {
+                assignedStudentIds.addAll(groupStudentIds);
+            } else if (!assignedStudentIds.isEmpty()) {
+                assignedStudentIds.retainAll(groupStudentIds);
+            }
+
+            if (assignedStudentIds.isEmpty()) {
+                continue;
+            }
+
+            boolean matchesGroup = assignedStudentIds.containsAll(groupStudentIds)
+                    && groupStudentIds.containsAll(assignedStudentIds);
+            boolean elective = plan.isElective() || !matchesGroup;
+
+            summaries.add(new DisciplineSummary(plan, title, elective, assignedStudentIds));
+        }
+
+        return summaries.stream()
+                .sorted(Comparator.comparing(DisciplineSummary::title, ukrainianCollator))
+                .collect(Collectors.toList());
+    }
+
     public record SummaryReportResult(String groupCode, byte[] pdfBytes) {
+    }
+
+    private record DisciplineSummary(PlansEntity plan, String title, boolean elective, Set<Long> assignedStudentIds) {
+    }
+
+    private static class PlanAssignment {
+        private final PlansEntity plan;
+        private final Set<Long> assignedStudentIds = new LinkedHashSet<>();
+
+        private PlanAssignment(PlansEntity plan) {
+            this.plan = plan;
+        }
     }
 
     public static class SummaryReportGenerationException extends RuntimeException {


### PR DESCRIPTION
## Summary
- collect first-module plans into assignment buckets that capture per-student participation before generating the discipline list
- ignore elective plans that have no students from the selected group and keep assignments scoped to the group to avoid empty reports
- continue flagging disciplines as elective when only a subset of students attend while leaving required subjects intact

## Testing
- ./mvnw -q -DskipTests compile *(fails: unable to download Maven distribution in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_6909e77950948326833d3404e945d274