### PR TITLE
Fix first module control detection in summary report

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
@@ -40,10 +40,11 @@ public class SummaryReportPdfGenerator {
     public byte[] generateSummaryReport(
             String groupName,
             List<String> studentFullNames,
-            List<String> disciplineNames,
+            List<DisciplineColumn> disciplineColumns,
             Map<String, List<Integer>> marksByStudent,
             boolean addAverageRow
     ) {
+        System.out.println("[SummaryReportPdfGenerator] Старт генерації PDF для групи: " + groupName);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         try (PdfWriter writer = new PdfWriter(baos);
@@ -52,6 +53,7 @@ public class SummaryReportPdfGenerator {
 
             document.setMargins(20, 20, 20, 20);
             document.setFont(createFont());
+            System.out.println("[SummaryReportPdfGenerator] Створено документ і встановлено шрифт");
 
             Paragraph title = new Paragraph(
                     "Зведений звіт результатів оцінювання студентів групи " + groupName +
@@ -60,36 +62,46 @@ public class SummaryReportPdfGenerator {
                     .setFontSize(14)
                     .setMarginBottom(10);
             document.add(title);
+            System.out.println("[SummaryReportPdfGenerator] Додано заголовок");
 
-            Table table = createTableStructure(disciplineNames.size());
-            addHeaderRows(table, disciplineNames);
-            addStudentRows(table, studentFullNames, disciplineNames, marksByStudent);
+            Table table = createTableStructure(disciplineColumns.size());
+            addHeaderRows(table, disciplineColumns);
+            addStudentRows(table, studentFullNames, disciplineColumns, marksByStudent);
+            System.out.println("[SummaryReportPdfGenerator] Додано рядки студентів");
 
             if (addAverageRow) {
-                addZeroSummaryRow(table, studentFullNames, disciplineNames, marksByStudent);
+                addZeroSummaryRow(table, studentFullNames, disciplineColumns, marksByStudent);
+                System.out.println("[SummaryReportPdfGenerator] Додано підсумковий рядок по нулям");
             }
 
             document.add(table);
+            System.out.println("[SummaryReportPdfGenerator] Таблицю додано до документу");
         } catch (IOException e) {
+            System.out.println("[SummaryReportPdfGenerator] Помилка генерації PDF: " + e.getMessage());
             throw new IllegalStateException("Не вдалося згенерувати PDF звіт", e);
         }
 
+        System.out.println("[SummaryReportPdfGenerator] Генерація PDF завершена");
         return baos.toByteArray();
     }
 
     private PdfFont createFont() throws IOException {
         try (InputStream fontStream = PdfGenerator.class.getResourceAsStream("/fonts/times.ttf")) {
             if (fontStream != null) {
+                System.out.println("[SummaryReportPdfGenerator] Завантажуємо користувацький шрифт");
                 FontProgram fontProgram = FontProgramFactory.createFont(fontStream.readAllBytes());
                 return PdfFontFactory.createFont(fontProgram, PdfEncodings.IDENTITY_H);
             }
         } catch (IOException ex) {
             // fall back to default font below
+            System.out.println("[SummaryReportPdfGenerator] Не вдалося завантажити користувацький шрифт, використаємо дефолтний");
         }
+        System.out.println("[SummaryReportPdfGenerator] Використовується стандартний шрифт");
         return PdfFontFactory.createFont(StandardFonts.TIMES_ROMAN);
     }
 
     private Table createTableStructure(int disciplineCount) {
+        System.out.println("[SummaryReportPdfGenerator] Створюємо структуру таблиці. Кількість дисциплін: " + disciplineCount);
         int totalColumns = 2 + disciplineCount;
         float[] columnWidths = new float[totalColumns];
         columnWidths[0] = FIRST_COLUMN_WIDTH;
@@ -101,11 +113,13 @@ public class SummaryReportPdfGenerator {
         Table table = new Table(columnWidths);
         table.setWidth(UnitValue.createPercentValue(100));
         table.setFixedLayout();
+        System.out.println("[SummaryReportPdfGenerator] Таблиця створена з " + totalColumns + " колонками");
         return table;
     }
 
-    private void addHeaderRows(Table table, List<String> disciplineNames) {
-        int disciplineCount = disciplineNames.size();
+    private void addHeaderRows(Table table, List<DisciplineColumn> disciplineColumns) {
+        System.out.println("[SummaryReportPdfGenerator] Додаємо заголовки колонок");
+        int disciplineCount = disciplineColumns.size();
 
         Cell blankForName = new Cell().setBorder(new SolidBorder(1));
         table.addHeaderCell(blankForName);
@@ -129,8 +143,14 @@ public class SummaryReportPdfGenerator {
                 .setBorder(new SolidBorder(1));
         table.addHeaderCell(nameHeader);
 
-        for (String discipline : disciplineNames) {
-            Paragraph rotated = new Paragraph(discipline)
+        for (DisciplineColumn discipline : disciplineColumns) {
+            String headerText = discipline.title();
+            if (discipline.elective()) {
+                headerText = headerText + "\n(вибіркова)";
+                System.out.println("[SummaryReportPdfGenerator] Дисципліна вибіркова: " + discipline.title());
+            }
+
+            Paragraph rotated = new Paragraph(headerText)
                     .setRotationAngle(Math.toRadians(90))
                     .setTextAlignment(TextAlignment.CENTER)
                     .setFontSize(10f);
@@ -156,12 +176,14 @@ public class SummaryReportPdfGenerator {
                 .setVerticalAlignment(VerticalAlignment.MIDDLE)
                 .setBorder(new SolidBorder(1));
         table.addHeaderCell(zeroHeaderCell);
+        System.out.println("[SummaryReportPdfGenerator] Заголовки колонок додано");
     }
 
     private void addStudentRows(Table table,
                                 List<String> studentFullNames,
-                                List<String> disciplineNames,
+                                List<DisciplineColumn> disciplineColumns,
                                 Map<String, List<Integer>> marksByStudent) {
+        System.out.println("[SummaryReportPdfGenerator] Додаємо рядки студентів: " + studentFullNames.size());
         for (String student : studentFullNames) {
             Cell nameCell = new Cell()
                     .add(new Paragraph(student))
@@ -173,23 +195,25 @@ public class SummaryReportPdfGenerator {
             List<Integer> marks = marksByStudent.getOrDefault(student, Collections.emptyList());
             int zeroCount = 0;
 
-            for (int i = 0; i < disciplineNames.size(); i++) {
-                int mark = getMark(marks, i);
-                if (mark == 0) {
+            for (int i = 0; i < disciplineColumns.size(); i++) {
+                Integer mark = getMark(marks, i);
+                if (mark != null && mark == 0) {
                     zeroCount++;
                 }
 
-                table.addCell(createNumericCell(mark));
+                table.addCell(createMarkCell(mark));
             }
 
             table.addCell(createNumericCell(zeroCount));
+            System.out.println("[SummaryReportPdfGenerator] Додано рядок студента: " + student + ", кількість нулів: " + zeroCount);
         }
     }
 
     private void addZeroSummaryRow(Table table,
                                    List<String> studentFullNames,
-                                   List<String> disciplineNames,
+                                   List<DisciplineColumn> disciplineColumns,
                                    Map<String, List<Integer>> marksByStudent) {
+        System.out.println("[SummaryReportPdfGenerator] Обчислюємо суму нулів по дисциплінах");
         Cell labelCell = new Cell()
                 .add(new Paragraph("Кількість 0 по дисциплінах"))
                 .setTextAlignment(TextAlignment.LEFT)
@@ -198,20 +222,22 @@ public class SummaryReportPdfGenerator {
         table.addCell(labelCell);
 
         int totalZeros = 0;
-        for (int i = 0; i < disciplineNames.size(); i++) {
+        for (int i = 0; i < disciplineColumns.size(); i++) {
             int zeroPerDiscipline = 0;
             for (String student : studentFullNames) {
                 List<Integer> marks = marksByStudent.getOrDefault(student, Collections.emptyList());
-                int mark = getMark(marks, i);
-                if (mark == 0) {
+                Integer mark = getMark(marks, i);
+                if (mark != null && mark == 0) {
                     zeroPerDiscipline++;
                 }
             }
             totalZeros += zeroPerDiscipline;
             table.addCell(createNumericCell(zeroPerDiscipline));
+            System.out.println("[SummaryReportPdfGenerator] Нулі по дисципліні #" + (i + 1) + ": " + zeroPerDiscipline);
         }
 
         table.addCell(createNumericCell(totalZeros));
+        System.out.println("[SummaryReportPdfGenerator] Загальна кількість нулів: " + totalZeros);
     }
 
     private Cell createNumericCell(int value) {
@@ -223,11 +249,26 @@ public class SummaryReportPdfGenerator {
                 .setBorder(new SolidBorder(1));
     }
 
-    private int getMark(List<Integer> marks, int index) {
-        if (marks == null || index >= marks.size()) {
-            return 0;
+    private Cell createMarkCell(Integer value) {
+        if (value == null) {
+            return createEmptyCell();
         }
-        Integer value = marks.get(index);
-        return value != null ? value : 0;
+        return createNumericCell(value);
+    }
+
+    private Cell createEmptyCell() {
+        return new Cell()
+                .add(new Paragraph(""))
+                .setBorder(new SolidBorder(1));
+    }
+
+    private Integer getMark(List<Integer> marks, int index) {
+        if (marks == null || index >= marks.size()) {
+            return null;
+        }
+        return marks.get(index);
+    }
+
+    public record DisciplineColumn(String title, boolean elective) {
     }
 }

--- a/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
+++ b/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 public class SummaryReportService {
 
     private static final String CONTROL_TYPE_FIRST_MODULE = "Перший модульний контроль";
-    private static final String FIRST_MODULE_KEYWORD = "перший модуль";
 
     private final GroupService groupService;
     private final StudentService studentService;
@@ -46,48 +45,65 @@ public class SummaryReportService {
 
     @Transactional(readOnly = true)
     public SummaryReportResult generateFirstModuleReport(GroupDTO selectedGroup) {
+        System.out.println("[SummaryReportService] Початок генерації звіту для першого модулю");
         if (selectedGroup == null) {
+            System.out.println("[SummaryReportService] Не обрано групу для звіту");
             throw new SummaryReportGenerationException("Оберіть групу для формування звіту");
         }
 
+        System.out.println("[SummaryReportService] Обрано групу: " + selectedGroup.getGroupCode());
         StudentGroupEntity group = Optional.ofNullable(groupService.getGroupByTitle(selectedGroup.getGroupCode()))
                 .orElseThrow(() -> new SummaryReportGenerationException("Групу не знайдено"));
 
+        System.out.println("[SummaryReportService] Завантажуємо студентів групи");
         List<StudentEntity> students = sortStudentsByFullName(studentService.getStudentByGroupId(group.getId()));
         if (students.isEmpty()) {
+            System.out.println("[SummaryReportService] У групі не знайдено студентів");
             throw new SummaryReportGenerationException("У групі немає студентів");
         }
 
+        System.out.println("[SummaryReportService] Знайдено студентів: " + students.size());
+
         int semester = computeFirstModuleSemester(selectedGroup.getCourse());
-        List<PlansEntity> plans = collectPlansForSummaryReport(group, semester, students);
-        if (plans.isEmpty()) {
+        System.out.println("[SummaryReportService] Обчислено семестр першого модулю: " + semester);
+        Map<Long, PlanAssignment> planAssignments = collectPlanAssignments(group, semester, students);
+        if (planAssignments.isEmpty()) {
+            System.out.println("[SummaryReportService] Не знайдено планів для першого модулю");
             throw new SummaryReportGenerationException("Не знайдено дисциплін для першого модульного контролю");
         }
 
-        List<String> disciplineNames = plans.stream()
-                .map(PlansEntity::getDiscipline)
-                .filter(Objects::nonNull)
-                .map(discipline -> discipline.getTitle() == null ? "" : discipline.getTitle())
-                .filter(title -> !title.isBlank())
-                .collect(Collectors.toList());
-        if (disciplineNames.isEmpty()) {
-            throw new SummaryReportGenerationException("Список дисциплін порожній");
-        }
+        System.out.println("[SummaryReportService] Зібрано планів: " + planAssignments.size());
 
         List<String> studentFullNames = students.stream()
                 .map(StudentEntity::getFullName)
                 .collect(Collectors.toList());
 
-        Map<String, List<Integer>> marksByStudent = buildMarksForSummaryReport(students, plans);
+        List<DisciplineSummary> disciplineSummaries = buildDisciplineSummaries(planAssignments.values(), students);
+        if (disciplineSummaries.isEmpty()) {
+            System.out.println("[SummaryReportService] Не сформовано жодної дисципліни");
+            throw new SummaryReportGenerationException("Список дисциплін порожній");
+        }
+
+        System.out.println("[SummaryReportService] Сформовано дисциплін: " + disciplineSummaries.size());
+
+        List<SummaryReportPdfGenerator.DisciplineColumn> disciplineColumns = disciplineSummaries.stream()
+                .map(summary -> new SummaryReportPdfGenerator.DisciplineColumn(summary.title(), summary.elective()))
+                .collect(Collectors.toList());
+
+        System.out.println("[SummaryReportService] Формуємо оцінки по кожному студенту");
+        Map<String, List<Integer>> marksByStudent = buildMarksForSummaryReport(students, disciplineSummaries);
+        System.out.println("[SummaryReportService] Отримано записи оцінок: " + marksByStudent.size());
         byte[] pdfBytes = summaryReportPdfGenerator.generateSummaryReport(
                 group.getGroupCode(),
                 studentFullNames,
-                disciplineNames,
+                disciplineColumns,
                 marksByStudent,
                 true
         );
 
+        System.out.println("[SummaryReportService] Генерація PDF завершена, розмір: " + (pdfBytes == null ? 0 : pdfBytes.length));
         if (pdfBytes == null || pdfBytes.length == 0) {
+            System.out.println("[SummaryReportService] Отримано порожній PDF");
             throw new SummaryReportGenerationException("Не вдалося сформувати звіт");
         }
 
@@ -107,62 +123,113 @@ public class SummaryReportService {
         return course * 2 - 1;
     }
 
-    private List<PlansEntity> collectPlansForSummaryReport(StudentGroupEntity group,
-                                                           int semester,
-                                                           List<StudentEntity> students) {
-        Map<Long, PlansEntity> uniquePlans = new LinkedHashMap<>();
+    private Map<Long, PlanAssignment> collectPlanAssignments(StudentGroupEntity group,
+                                                             int semester,
+                                                             List<StudentEntity> students) {
+        Map<Long, PlanAssignment> assignments = new LinkedHashMap<>();
+        Map<Long, ControlMethodEntity> firstModuleControlCache = new HashMap<>();
 
+        System.out.println("[SummaryReportService] Завантажуємо плани групи для семестру " + semester);
         List<PlansEntity> groupPlans = planService.getAllPlansForGroupAndSemester(group, semester);
         if (groupPlans != null) {
-            groupPlans.stream()
-                    .filter(this::isFirstModulePlan)
-                    .forEach(plan -> uniquePlans.putIfAbsent(plan.getId(), plan));
+            System.out.println("[SummaryReportService] Отримано планів групи: " + groupPlans.size());
+            for (PlansEntity plan : groupPlans) {
+                PlanAssignment assignment = ensurePlanAssignment(assignments, plan, firstModuleControlCache);
+                if (assignment != null) {
+                    System.out.println("[SummaryReportService] Додаємо план групи: " + safeDisciplineTitle(plan));
+                }
+            }
         }
 
         for (StudentEntity student : students) {
-            studentPlansService.getPlansForStudent(student).stream()
-                    .map(StudentPlansEntity::getPlan)
-                    .filter(Objects::nonNull)
-                    .filter(plan -> plan.getSemester() == semester)
-                    .filter(this::isFirstModulePlan)
-                    .forEach(plan -> uniquePlans.putIfAbsent(plan.getId(), plan));
+            System.out.println("[SummaryReportService] Обробка студентського плану: " + student.getFullName());
+            List<StudentPlansEntity> studentPlans = studentPlansService.getPlansForStudent(student);
+            if (studentPlans == null || studentPlans.isEmpty()) {
+                System.out.println("[SummaryReportService] Для студента немає індивідуальних планів");
+                continue;
+            }
+
+            for (StudentPlansEntity studentPlan : studentPlans) {
+                PlansEntity plan = studentPlan.getPlan();
+                if (plan == null || plan.getSemester() != semester) {
+                    System.out.println("[SummaryReportService] Пропускаємо план (не підходить для 1 модулю)");
+                    continue;
+                }
+
+                PlanAssignment assignment = ensurePlanAssignment(assignments, plan, firstModuleControlCache);
+                if (assignment == null) {
+                    System.out.println("[SummaryReportService] Пропускаємо план (не підходить для 1 модулю)");
+                    continue;
+                }
+
+                assignment.assignedStudentIds.add(student.getId());
+                System.out.println("[SummaryReportService] Призначено студента до плану");
+            }
         }
 
-        return uniquePlans.values().stream()
-                .sorted(Comparator.comparing(
-                        plan -> Optional.ofNullable(plan.getDiscipline())
-                                .map(DisciplineEntity::getTitle)
-                                .orElse("")
-                        , ukrainianCollator))
-                .collect(Collectors.toList());
+        System.out.println("[SummaryReportService] Повертаємо зібрані призначення планів: " + assignments.size());
+        return assignments;
     }
 
-    private boolean isFirstModulePlan(PlansEntity plan) {
+    private PlanAssignment ensurePlanAssignment(Map<Long, PlanAssignment> assignments,
+                                                PlansEntity plan,
+                                                Map<Long, ControlMethodEntity> controlCache) {
         if (plan == null) {
-            return false;
+            return null;
         }
-        return isFirstModuleControl(plan.getFirstControl());
+
+        ControlMethodEntity control = resolveFirstModuleControl(plan, controlCache);
+        if (control == null) {
+            System.out.println("[SummaryReportService] План '" + safeDisciplineTitle(plan) + "' не має контролю '" + CONTROL_TYPE_FIRST_MODULE + "'");
+            return null;
+        }
+
+        PlanAssignment assignment = assignments.get(plan.getId());
+        if (assignment == null) {
+            assignment = new PlanAssignment(plan, control);
+            assignments.put(plan.getId(), assignment);
+        }
+        return assignment;
+    }
+
+    private ControlMethodEntity resolveFirstModuleControl(PlansEntity plan,
+                                                          Map<Long, ControlMethodEntity> controlCache) {
+        if (plan == null || plan.getId() == null) {
+            return null;
+        }
+
+        if (controlCache.containsKey(plan.getId())) {
+            return controlCache.get(plan.getId());
+        }
+
+        ControlMethodEntity control = null;
+        if (isFirstModuleControl(plan.getFirstControl())) {
+            control = plan.getFirstControl();
+        } else if (isFirstModuleControl(plan.getSecondControl())) {
+            control = plan.getSecondControl();
+        } else {
+            List<MarksEntity> marks = marksService.findMarksByPlanAndTypeControl(plan, CONTROL_TYPE_FIRST_MODULE);
+            if (marks != null && !marks.isEmpty()) {
+                control = marks.get(0).getControlMethod();
+            }
+        }
+
+        controlCache.put(plan.getId(), control);
+        System.out.println("[SummaryReportService] План '" + safeDisciplineTitle(plan) + "' "
+                + (control != null ? "має" : "не має") + " контроль '" + CONTROL_TYPE_FIRST_MODULE + "'");
+        return control;
     }
 
     private boolean isFirstModuleControl(ControlMethodEntity controlMethod) {
-        if (controlMethod == null) {
+        if (controlMethod == null || controlMethod.getName() == null) {
             return false;
         }
-        String controlName = controlMethod.getName();
-        if (controlName == null) {
-            return false;
-        }
-
-        String normalizedName = controlName.trim();
-        if (normalizedName.equalsIgnoreCase(CONTROL_TYPE_FIRST_MODULE)) {
-            return true;
-        }
-
-        String normalizedLowerCase = normalizedName.toLowerCase(Locale.ROOT);
-        return normalizedLowerCase.contains(FIRST_MODULE_KEYWORD);
+        return controlMethod.getName().trim().equalsIgnoreCase(CONTROL_TYPE_FIRST_MODULE);
     }
 
-    private Map<String, List<Integer>> buildMarksForSummaryReport(List<StudentEntity> students, List<PlansEntity> plans) {
+    private Map<String, List<Integer>> buildMarksForSummaryReport(List<StudentEntity> students,
+                                                                 List<DisciplineSummary> disciplineSummaries) {
+        System.out.println("[SummaryReportService] Початок формування оцінок");
         List<String> studentNames = students.stream()
                 .map(StudentEntity::getFullName)
                 .collect(Collectors.toList());
@@ -172,10 +239,13 @@ public class SummaryReportService {
             marksByStudent.put(studentName, new ArrayList<>());
         }
 
-        for (PlansEntity plan : plans) {
-            ControlMethodEntity firstControl = plan.getFirstControl();
-            List<MarksEntity> marks = marksService.findMarksByPlanAndControlMethod(plan, firstControl);
+        for (DisciplineSummary disciplineSummary : disciplineSummaries) {
+            System.out.println("[SummaryReportService] Обробка дисципліни при формуванні оцінок: " + disciplineSummary.title());
+            PlansEntity plan = disciplineSummary.plan();
+            ControlMethodEntity controlMethod = disciplineSummary.controlMethod();
+            List<MarksEntity> marks = marksService.findMarksByPlanAndControlMethod(plan, controlMethod);
             if (marks == null) {
+                System.out.println("[SummaryReportService] Для дисципліни немає оцінок");
                 marks = Collections.emptyList();
             }
 
@@ -189,15 +259,116 @@ public class SummaryReportService {
             for (int i = 0; i < students.size(); i++) {
                 StudentEntity student = students.get(i);
                 String studentName = studentNames.get(i);
+
+                if (!disciplineSummary.assignedStudentIds().contains(student.getId())) {
+                    System.out.println("[SummaryReportService] Студент " + studentName + " не відвідує дисципліну " + disciplineSummary.title());
+                    marksByStudent.get(studentName).add(null);
+                    continue;
+                }
+
                 int markValue = marksByStudentId.getOrDefault(student.getId(), 0);
+                System.out.println("[SummaryReportService] Додаємо оцінку " + markValue + " студенту " + studentName);
                 marksByStudent.get(studentName).add(markValue);
             }
         }
 
+        System.out.println("[SummaryReportService] Формування оцінок завершено");
         return marksByStudent;
     }
 
+    private List<DisciplineSummary> buildDisciplineSummaries(Collection<PlanAssignment> assignments,
+                                                             List<StudentEntity> students) {
+        System.out.println("[SummaryReportService] Формуємо підсумок по дисциплінах");
+        if (assignments == null || assignments.isEmpty()) {
+            System.out.println("[SummaryReportService] Список призначень порожній");
+            return List.of();
+        }
+
+        Set<Long> groupStudentIds = students.stream()
+                .map(StudentEntity::getId)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        List<DisciplineSummary> summaries = new ArrayList<>();
+        for (PlanAssignment assignment : assignments) {
+            PlansEntity plan = assignment.plan;
+            ControlMethodEntity controlMethod = assignment.firstModuleControl;
+            if (controlMethod == null) {
+                System.out.println("[SummaryReportService] Пропущено план без контролю першого модулю");
+                continue;
+            }
+            DisciplineEntity discipline = plan.getDiscipline();
+            if (discipline == null) {
+                System.out.println("[SummaryReportService] Пропущено план без дисципліни");
+                continue;
+            }
+
+            String title = discipline.getTitle();
+            if (title == null) {
+                System.out.println("[SummaryReportService] Пропущено дисципліну без назви");
+                continue;
+            }
+
+            title = title.trim();
+            if (title.isBlank()) {
+                System.out.println("[SummaryReportService] Пропущено дисципліну з порожньою назвою");
+                continue;
+            }
+
+            Set<Long> assignedStudentIds = new LinkedHashSet<>(assignment.assignedStudentIds);
+            if (assignedStudentIds.isEmpty() && !plan.isElective()) {
+                System.out.println("[SummaryReportService] План обов'язковий, додаємо всіх студентів");
+                assignedStudentIds.addAll(groupStudentIds);
+            } else if (!assignedStudentIds.isEmpty()) {
+                assignedStudentIds.retainAll(groupStudentIds);
+            }
+
+            if (assignedStudentIds.isEmpty()) {
+                System.out.println("[SummaryReportService] Пропущено дисципліну без студентів");
+                continue;
+            }
+
+            boolean matchesGroup = assignedStudentIds.containsAll(groupStudentIds)
+                    && groupStudentIds.containsAll(assignedStudentIds);
+            boolean elective = plan.isElective() || !matchesGroup;
+
+            System.out.println("[SummaryReportService] Додаємо дисципліну: " + title + ", вибіркова=" + elective);
+            summaries.add(new DisciplineSummary(plan, controlMethod, title, elective, assignedStudentIds));
+        }
+
+        List<DisciplineSummary> sorted = summaries.stream()
+                .sorted(Comparator.comparing(DisciplineSummary::title, ukrainianCollator))
+                .collect(Collectors.toList());
+        System.out.println("[SummaryReportService] Підсумок дисциплін сформовано: " + sorted.size());
+        return sorted;
+    }
+
+    private String safeDisciplineTitle(PlansEntity plan) {
+        DisciplineEntity discipline = plan.getDiscipline();
+        if (discipline == null || discipline.getTitle() == null) {
+            return "<без назви>";
+        }
+        return discipline.getTitle();
+    }
+
     public record SummaryReportResult(String groupCode, byte[] pdfBytes) {
+    }
+
+    private record DisciplineSummary(PlansEntity plan,
+                                     ControlMethodEntity controlMethod,
+                                     String title,
+                                     boolean elective,
+                                     Set<Long> assignedStudentIds) {
+    }
+
+    private static class PlanAssignment {
+        private final PlansEntity plan;
+        private final ControlMethodEntity firstModuleControl;
+        private final Set<Long> assignedStudentIds = new LinkedHashSet<>();
+
+        private PlanAssignment(PlansEntity plan, ControlMethodEntity firstModuleControl) {
+            this.plan = plan;
+            this.firstModuleControl = firstModuleControl;
+        }
     }
 
     public static class SummaryReportGenerationException extends RuntimeException {


### PR DESCRIPTION
## Summary
- resolve first module control for plans by checking both control slots and cached mark lookups before registering assignments
- carry the resolved control method through discipline summaries to retrieve first module marks consistently and retain elective handling

## Testing
- ./mvnw -q -DskipTests compile *(fails: unable to download Maven distribution in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_6909e77950948326833d3404e945d274