### PR TITLE
Adjust signature handling for module reports

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/pdf/FirstModulePdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/FirstModulePdfGenerator.java
@@ -71,6 +71,7 @@ public class FirstModulePdfGenerator implements PdfGenerator {
 
                 addHeader(document, regular, bold, moduleData);
                 addStudentsTable(document, regular, moduleData.students());
+                addSignatureSection(document, regular, moduleData);
 
                 log.info("Generated first module control PDF at {}", outputPath);
             }
@@ -330,6 +331,66 @@ public class FirstModulePdfGenerator implements PdfGenerator {
         }
 
         document.add(table);
+    }
+
+    private void addSignatureSection(Document document, PdfFont font, DataModelForMC1 data) {
+        document.add(new Paragraph("")
+                .setFont(font)
+                .setFontSize(11)
+                .setMarginTop(12)
+                .setTextAlignment(TextAlignment.CENTER));
+
+        Table signatureTable = new Table(UnitValue.createPercentArray(new float[]{20, 50, 30}))
+                .useAllAvailableWidth();
+
+        signatureTable.addCell(new Cell().setPadding(0)
+                .setBorder(Border.NO_BORDER)
+                .add(new Paragraph("Викладач")
+                        .setFont(font)
+                        .setFontSize(11)));
+
+        signatureTable.addCell(new Cell().setPadding(0)
+                .setBorderTop(Border.NO_BORDER)
+                .setBorderLeft(Border.NO_BORDER)
+                .setBorderRight(Border.NO_BORDER)
+                .setBorderBottom(new SolidBorder(0.5f))
+                .add(new Paragraph(resolveSignatureName(data))
+                        .setFont(font)
+                        .setFontSize(11)
+                        .setTextAlignment(TextAlignment.CENTER)));
+
+        signatureTable.addCell(new Cell().setPadding(0)
+                .setBorderTop(Border.NO_BORDER)
+                .setBorderLeft(Border.NO_BORDER)
+                .setBorderRight(Border.NO_BORDER)
+                .setBorderBottom(new SolidBorder(0.5f))
+                .add(new Paragraph("")
+                        .setFont(font)
+                        .setFontSize(11)));
+
+        document.add(signatureTable);
+
+        document.add(new Paragraph("(прізвище, ім’я та по батькові викладача, який виставляє підсумкову оцінку)            (підпис)")
+                .setFont(font)
+                .setFontSize(8)
+                .setTextAlignment(TextAlignment.CENTER));
+    }
+
+    private String resolveSignatureName(DataModelForMC1 data) {
+        if (!isBlank(data.secondTeacher())) {
+            return data.secondTeacher();
+        }
+        if (!isBlank(data.gradeTeacher())) {
+            return data.gradeTeacher();
+        }
+        if (!isBlank(data.firstTeacher())) {
+            return data.firstTeacher();
+        }
+        return "";
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 
     private Cell createHeaderCell(String text, PdfFont font) {

--- a/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
@@ -57,7 +57,8 @@ public class SummaryReportPdfGenerator {
                 marksByStudent,
                 addAverageRow,
                 null,        // examiner
-                false        // numericHeader
+                false,       // numericHeader
+                false        // includeSignature
         );
     }
 
@@ -70,6 +71,29 @@ public class SummaryReportPdfGenerator {
             boolean addAverageRow,
             String examiner,
             boolean numericHeader
+    ) {
+        boolean includeSignature = examiner != null && !examiner.isBlank();
+        return generateSummaryReport(
+                groupName,
+                studentFullNames,
+                disciplineColumns,
+                marksByStudent,
+                addAverageRow,
+                examiner,
+                numericHeader,
+                includeSignature
+        );
+    }
+
+    public byte[] generateSummaryReport(
+            String groupName,
+            List<String> studentFullNames,
+            List<DisciplineColumn> disciplineColumns,
+            Map<String, List<Integer>> marksByStudent,
+            boolean addAverageRow,
+            String examiner,
+            boolean numericHeader,
+            boolean includeSignature
     ) {
         System.out.println("[SummaryReportPdfGenerator] Старт генерації PDF для групи: " + groupName);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -104,17 +128,17 @@ public class SummaryReportPdfGenerator {
             document.add(table);
             System.out.println("[SummaryReportPdfGenerator] Таблицю додано до документу");
 
-            // === НОВЕ: додаємо футер, якщо задано екзаменатора ===
-            if (examiner != null && !examiner.isBlank()) {
-                // Створюємо службову нижню таблицю з такою ж сіткою,
-                // щоб NumericHeader вирівнявся по основній таблиці
+            if (includeSignature) {
                 Table lastRowTable = createTableStructure(disciplineColumns.size());
                 lastRowTable.setWidth(UnitValue.createPercentValue(100));
                 lastRowTable.setFixedLayout();
 
                 Div footer = generate(examiner, lastRowTable, numericHeader);
                 document.add(footer);
-                System.out.println("[SummaryReportPdfGenerator] Додано футер (numericHeader=" + numericHeader + ")");
+                System.out.println("[SummaryReportPdfGenerator] Додано футер (numericHeader=" + numericHeader
+                        + ", includeSignature=true)");
+            } else {
+                System.out.println("[SummaryReportPdfGenerator] Футер з підписом пропущено");
             }
 
         } catch (IOException e) {
@@ -402,7 +426,7 @@ public class SummaryReportPdfGenerator {
         public static Div generateSignature(String examiner) {
             List<String> teachers = parseTeachers(examiner);
             if (teachers.isEmpty()) {
-                return new Div();
+                teachers = Collections.singletonList("");
             }
 
             Table table = new Table(UnitValue.createPercentArray(SIGNATURE_TABLE_COLUMNS))

--- a/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
+++ b/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
@@ -107,6 +107,7 @@ public class SummaryReportService {
                 marksByStudent,
                 true,
                 examiner,
+                false,
                 false
         );
 


### PR DESCRIPTION
## Summary
- skip rendering the teacher signature block in the first module summary report
- add an explicit signature section to the first module control PDF using the provided teacher name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690a100f04d88326ad0cf4a5a79d3fe3