### PR TITLE
Align signature sections across module PDFs

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/pdf/FirstModulePdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/FirstModulePdfGenerator.java
@@ -71,6 +71,7 @@ public class FirstModulePdfGenerator implements PdfGenerator {
 
                 addHeader(document, regular, bold, moduleData);
                 addStudentsTable(document, regular, moduleData.students());
+                addSignatureSection(document, regular, bold, moduleData);
 
                 log.info("Generated first module control PDF at {}", outputPath);
             }
@@ -330,6 +331,94 @@ public class FirstModulePdfGenerator implements PdfGenerator {
         }
 
         document.add(table);
+    }
+
+    private void addSignatureSection(Document document, PdfFont regular, PdfFont bold, DataModelForMC1 data) {
+        document.add(new Paragraph("")
+                .setFont(regular)
+                .setFontSize(11)
+                .setMarginTop(12)
+                .setTextAlignment(TextAlignment.CENTER));
+
+        Table signatureTable = new Table(UnitValue.createPercentArray(new float[]{20, 5, 20, 5, 20}))
+                .useAllAvailableWidth();
+
+        signatureTable.addCell(createSignatureLabelCell(bold));
+        signatureTable.addCell(createSignatureSpacerCell());
+        signatureTable.addCell(createSignatureLineCell(bold));
+        signatureTable.addCell(createSignatureSpacerCell());
+        signatureTable.addCell(createSignatureNameCell(resolveSignatureName(data), bold));
+
+        signatureTable.addCell(createSignatureSpacerCell());
+        signatureTable.addCell(createSignatureSpacerCell());
+        signatureTable.addCell(createSignatureHintCell("(підпис)", regular));
+        signatureTable.addCell(createSignatureSpacerCell());
+        signatureTable.addCell(createSignatureHintCell("(прізвище,ініціали)", regular));
+
+        document.add(signatureTable);
+    }
+
+    private Cell createSignatureLabelCell(PdfFont bold) {
+        return new Cell().setPadding(0)
+                .setBorder(Border.NO_BORDER)
+                .add(new Paragraph("Екзаменатор (Викладач)")
+                        .setFont(bold)
+                        .setFontSize(10));
+    }
+
+    private Cell createSignatureLineCell(PdfFont bold) {
+        return new Cell().setPadding(0)
+                .setBorderTop(Border.NO_BORDER)
+                .setBorderLeft(Border.NO_BORDER)
+                .setBorderRight(Border.NO_BORDER)
+                .setBorderBottom(new SolidBorder(0.5f))
+                .add(new Paragraph("")
+                        .setFont(bold)
+                        .setFontSize(10));
+    }
+
+    private Cell createSignatureNameCell(String examiner, PdfFont bold) {
+        return new Cell().setPadding(0)
+                .setBorderTop(Border.NO_BORDER)
+                .setBorderLeft(Border.NO_BORDER)
+                .setBorderRight(Border.NO_BORDER)
+                .setBorderBottom(new SolidBorder(0.5f))
+                .add(new Paragraph(Objects.toString(examiner, ""))
+                        .setFont(bold)
+                        .setFontSize(10)
+                        .setTextAlignment(TextAlignment.CENTER));
+    }
+
+    private Cell createSignatureHintCell(String text, PdfFont font) {
+        return new Cell().setPadding(0)
+                .setBorder(Border.NO_BORDER)
+                .add(new Paragraph(text)
+                        .setFont(font)
+                        .setFontSize(8)
+                        .setTextAlignment(TextAlignment.CENTER));
+    }
+
+    private Cell createSignatureSpacerCell() {
+        return new Cell().setPadding(0)
+                .setBorder(Border.NO_BORDER)
+                .add(new Paragraph(""));
+    }
+
+    private String resolveSignatureName(DataModelForMC1 data) {
+        if (!isBlank(data.secondTeacher())) {
+            return data.secondTeacher();
+        }
+        if (!isBlank(data.gradeTeacher())) {
+            return data.gradeTeacher();
+        }
+        if (!isBlank(data.firstTeacher())) {
+            return data.firstTeacher();
+        }
+        return "";
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 
     private Cell createHeaderCell(String text, PdfFont font) {

--- a/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
@@ -25,11 +25,8 @@ import com.itextpdf.layout.properties.VerticalAlignment;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 
 import org.springframework.stereotype.Component;
@@ -57,7 +54,8 @@ public class SummaryReportPdfGenerator {
                 marksByStudent,
                 addAverageRow,
                 null,        // examiner
-                false        // numericHeader
+                false,       // numericHeader
+                false        // includeSignature
         );
     }
 
@@ -70,6 +68,29 @@ public class SummaryReportPdfGenerator {
             boolean addAverageRow,
             String examiner,
             boolean numericHeader
+    ) {
+        boolean includeSignature = examiner != null && !examiner.isBlank();
+        return generateSummaryReport(
+                groupName,
+                studentFullNames,
+                disciplineColumns,
+                marksByStudent,
+                addAverageRow,
+                examiner,
+                numericHeader,
+                includeSignature
+        );
+    }
+
+    public byte[] generateSummaryReport(
+            String groupName,
+            List<String> studentFullNames,
+            List<DisciplineColumn> disciplineColumns,
+            Map<String, List<Integer>> marksByStudent,
+            boolean addAverageRow,
+            String examiner,
+            boolean numericHeader,
+            boolean includeSignature
     ) {
         System.out.println("[SummaryReportPdfGenerator] Старт генерації PDF для групи: " + groupName);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -104,17 +125,17 @@ public class SummaryReportPdfGenerator {
             document.add(table);
             System.out.println("[SummaryReportPdfGenerator] Таблицю додано до документу");
 
-            // === НОВЕ: додаємо футер, якщо задано екзаменатора ===
-            if (examiner != null && !examiner.isBlank()) {
-                // Створюємо службову нижню таблицю з такою ж сіткою,
-                // щоб NumericHeader вирівнявся по основній таблиці
+            if (includeSignature) {
                 Table lastRowTable = createTableStructure(disciplineColumns.size());
                 lastRowTable.setWidth(UnitValue.createPercentValue(100));
                 lastRowTable.setFixedLayout();
 
                 Div footer = generate(examiner, lastRowTable, numericHeader);
                 document.add(footer);
-                System.out.println("[SummaryReportPdfGenerator] Додано футер (numericHeader=" + numericHeader + ")");
+                System.out.println("[SummaryReportPdfGenerator] Додано футер (numericHeader=" + numericHeader
+                        + ", includeSignature=true)");
+            } else {
+                System.out.println("[SummaryReportPdfGenerator] Футер з підписом пропущено");
             }
 
         } catch (IOException e) {
@@ -389,34 +410,32 @@ public class SummaryReportPdfGenerator {
 
     private static class Signature {
 
-        private static final float[] SIGNATURE_TABLE_COLUMNS = {20f, 45f, 35f};
-        private static final String SIGNATURE_LABEL = "Викладач";
-        private static final String SIGNATURE_HINT = "(прізвище, ім’я та по батькові викладача, який виставляє підсумкову оцінку)";
-        private static final float SIGNATURE_LINE_HEIGHT = 18f;
+        private static final float[] SIGNATURE_TABLE_COLUMNS = {20f, 5f, 20f, 5f, 20f};
+        private static final String SIGNATURE_LABEL = "Екзаменатор (Викладач)";
+        private static final String SIGNATURE_LINE_HINT = "(підпис)";
+        private static final String SIGNATURE_NAME_HINT = "(прізвище,ініціали)";
+        private static final float SIGNATURE_FONT_SIZE = 10f;
+        private static final float SIGNATURE_HINT_FONT_SIZE = 8f;
         private static final float SIGNATURE_MARGIN_TOP = 10f;
 
         private Signature() {
         }
 
-        // ЗМІНА: public static, щоб викликати з зовнішнього класу
         public static Div generateSignature(String examiner) {
-            List<String> teachers = parseTeachers(examiner);
-            if (teachers.isEmpty()) {
-                return new Div();
-            }
-
             Table table = new Table(UnitValue.createPercentArray(SIGNATURE_TABLE_COLUMNS))
                     .useAllAvailableWidth();
 
-            boolean firstRow = true;
-            for (String teacher : teachers) {
-                table.addCell(createLabelCell(firstRow ? SIGNATURE_LABEL : ""));
-                table.addCell(createSignatureLineCell());
-                table.addCell(createTeacherCell(teacher));
-                firstRow = false;
-            }
+            table.addCell(createLabelCell());
+            table.addCell(createSpacerCell());
+            table.addCell(createSignatureLineCell());
+            table.addCell(createSpacerCell());
+            table.addCell(createExaminerCell(examiner));
 
-            table.addCell(createHintCell());
+            table.addCell(createSpacerCell());
+            table.addCell(createSpacerCell());
+            table.addCell(createHintCell(SIGNATURE_LINE_HINT));
+            table.addCell(createSpacerCell());
+            table.addCell(createHintCell(SIGNATURE_NAME_HINT));
 
             Div signatureBlock = new Div();
             signatureBlock.setMarginTop(SIGNATURE_MARGIN_TOP);
@@ -425,48 +444,52 @@ public class SummaryReportPdfGenerator {
             return signatureBlock;
         }
 
-        private static List<String> parseTeachers(String examiner) {
-            if (examiner == null) {
-                return Collections.emptyList();
-            }
-            return Arrays.stream(examiner.split("[\\n;,]+"))
-                    .map(String::trim)
-                    .filter(value -> !value.isEmpty())
-                    .collect(Collectors.toList());
-        }
-
-        private static Cell createLabelCell(String text) {
+        private static Cell createLabelCell() {
             return new Cell()
                     .setBorder(Border.NO_BORDER)
                     .setPadding(0)
-                    .add(new Paragraph(text)
-                            .setFontSize(11));
+                    .add(new Paragraph(SIGNATURE_LABEL)
+                            .setFontSize(SIGNATURE_FONT_SIZE));
         }
 
         private static Cell createSignatureLineCell() {
             return new Cell()
-                    .setBorder(Border.NO_BORDER)
+                    .setBorderTop(Border.NO_BORDER)
+                    .setBorderLeft(Border.NO_BORDER)
+                    .setBorderRight(Border.NO_BORDER)
                     .setBorderBottom(new SolidBorder(0.5f))
                     .setPadding(0)
-                    .setMinHeight(SIGNATURE_LINE_HEIGHT);
+                    .add(new Paragraph("")
+                            .setFontSize(SIGNATURE_FONT_SIZE));
         }
 
-        private static Cell createTeacherCell(String teacher) {
+        private static Cell createExaminerCell(String examiner) {
+            String value = examiner == null ? "" : examiner.trim();
+            return new Cell()
+                    .setBorderTop(Border.NO_BORDER)
+                    .setBorderLeft(Border.NO_BORDER)
+                    .setBorderRight(Border.NO_BORDER)
+                    .setBorderBottom(new SolidBorder(0.5f))
+                    .setPadding(0)
+                    .add(new Paragraph(value)
+                            .setTextAlignment(TextAlignment.CENTER)
+                            .setFontSize(SIGNATURE_FONT_SIZE));
+        }
+
+        private static Cell createHintCell(String text) {
             return new Cell()
                     .setBorder(Border.NO_BORDER)
                     .setPadding(0)
-                    .add(new Paragraph(teacher)
-                            .setTextAlignment(TextAlignment.CENTER)
-                            .setFontSize(11));
+                    .add(new Paragraph(text)
+                            .setFontSize(SIGNATURE_HINT_FONT_SIZE)
+                            .setTextAlignment(TextAlignment.CENTER));
         }
 
-        private static Cell createHintCell() {
-            return new Cell(1, 3)
+        private static Cell createSpacerCell() {
+            return new Cell()
                     .setBorder(Border.NO_BORDER)
                     .setPadding(0)
-                    .add(new Paragraph(SIGNATURE_HINT)
-                            .setFontSize(8)
-                            .setTextAlignment(TextAlignment.CENTER));
+                    .add(new Paragraph(""));
         }
     }
 

--- a/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
+++ b/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
@@ -107,6 +107,7 @@ public class SummaryReportService {
                 marksByStudent,
                 true,
                 examiner,
+                false,
                 false
         );
 


### PR DESCRIPTION
## Summary
- restyle the optional signature block in the summary report to match the required five-column layout while keeping it bound to the table footer
- update the first module control PDF to render the same examiner signature structure with the provided teacher name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690a100f04d88326ad0cf4a5a79d3fe3