### PR TITLE
Fix control method availability when session semester mismatches plan

### DIFF
--- a/src/main/java/com/esvar/dekanat/service/PlanService.java
+++ b/src/main/java/com/esvar/dekanat/service/PlanService.java
@@ -215,13 +215,17 @@ public class PlanService {
                 .filter(p -> p.getSemester() == semester)
                 .toList();
 
-        List<String> controlTypes = semesterPlans.stream()
-                .flatMap(plan -> Stream.of(plan.getFirstControl().getName(), plan.getSecondControl().getName()))
+        List<PlansEntity> relevantPlans = semesterPlans.isEmpty() ? plans : semesterPlans;
+
+        List<String> controlTypes = relevantPlans.stream()
+                .flatMap(plan -> Stream.of(plan.getFirstControl(), plan.getSecondControl()))
+                .filter(Objects::nonNull)
+                .map(ControlMethodEntity::getName)
                 .filter(control -> !"Відсутній".equals(control))
                 .distinct()
                 .collect(Collectors.toList());
 
-        if (shouldIncludeModuleControls(semesterPlans, course, groupNumber)) {
+        if (shouldIncludeModuleControls(relevantPlans, course, groupNumber)) {
             controlTypes.add("Перший модульний контроль");
             controlTypes.add("Другий модульний контроль");
         }

--- a/src/test/java/com/esvar/dekanat/service/PlanServiceTest.java
+++ b/src/test/java/com/esvar/dekanat/service/PlanServiceTest.java
@@ -149,6 +149,29 @@ class PlanServiceTest {
                 .doesNotContain("Перший модульний контроль", "Другий модульний контроль");
     }
 
+    @Test
+    void shouldReturnPlanControlTypesWhenSemesterDoesNotMatchSession() {
+        plan.setSemester(1); // Не відповідає семестру, обчисленому для літньої сесії
+
+        when(planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
+                any(), any(), any(), anyInt(), anyInt(), any()))
+                .thenReturn(List.of(plan));
+        when(studentRepository.findByGroup(group))
+                .thenReturn(List.of(createStudent(true)));
+
+        List<String> controlTypes = planService.getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
+                "Faculty",
+                "Department",
+                "SP",
+                1,
+                1,
+                "Math"
+        );
+
+        assertThat(controlTypes)
+                .contains("Екзамен", "Залік");
+    }
+
     private StudentEntity createStudent(boolean fullTime) {
         StudentEntity student = new StudentEntity();
         student.setId(fullTime ? 11L : 12L);


### PR DESCRIPTION
## Summary
- ensure plan control types fall back to the distributed methods when the computed semester has no matches
- guard against null control methods while building the available control list and reuse the same plans when adding module controls
- cover the fallback behaviour with a dedicated unit test

## Testing
- ./mvnw -q -Dtest=PlanServiceTest test *(fails: Unable to download Maven distribution in sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915c124de0c8326bb9caca9ed334ac8)