### PR TITLE
Limit dekanat group lists by study form

### DIFF
--- a/src/main/java/com/esvar/dekanat/repository/StudentRepository.java
+++ b/src/main/java/com/esvar/dekanat/repository/StudentRepository.java
@@ -4,6 +4,7 @@ import com.esvar.dekanat.entity.StudentEntity;
 import com.esvar.dekanat.entity.StudentGroupEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,7 +12,15 @@ import java.util.List;
 @Repository
 public interface StudentRepository extends JpaRepository<StudentEntity, Long> {
     @Query("SELECT DISTINCT s.group.id FROM StudentEntity s WHERE s.faculty.id = :facultyId")
-    List<Long> findDistinctGroupIdsByFacultyId(Long facultyId);
+    List<Long> findDistinctGroupIdsByFacultyId(@Param("facultyId") Long facultyId);
+
+    @Query("""
+            SELECT DISTINCT s.group.id FROM StudentEntity s
+            WHERE s.faculty.id = :facultyId
+              AND (:fullTime IS NULL OR s.fullTime = :fullTime)
+            """)
+    List<Long> findDistinctGroupIdsByFacultyIdAndStudyForm(@Param("facultyId") Long facultyId,
+                                                           @Param("fullTime") Boolean fullTime);
 
     List<StudentEntity> findByGroupId(long groupId);
 

--- a/src/main/java/com/esvar/dekanat/service/GroupService.java
+++ b/src/main/java/com/esvar/dekanat/service/GroupService.java
@@ -1,14 +1,14 @@
 package com.esvar.dekanat.service;
 
 import com.esvar.dekanat.dto.GroupDTO;
-import com.esvar.dekanat.entity.SpecialtyEntity;
 import com.esvar.dekanat.entity.StudentEntity;
 import com.esvar.dekanat.entity.StudentGroupEntity;
 import com.esvar.dekanat.repository.GroupRepository;
 import com.esvar.dekanat.security.SecurityService;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+
+import com.esvar.dekanat.user.UserModel;
 
 import java.text.Collator;
 import java.util.*;
@@ -36,27 +36,36 @@ public class GroupService {
     }
 
     public List<GroupDTO> getGroupsDTO() {
-        // 1. Завантажуємо всі групи
         List<StudentGroupEntity> groups = groupRepository.findAll();
 
-        // 2. Отримуємо ролі й roleType поточного користувача
         UserDetails user = securityService.getAuthenticatedUser();
-        boolean isAdmin   = user.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
-        boolean isDekanat = user.getAuthorities().stream()
+        boolean isDekanat = user != null && user.getAuthorities().stream()
                 .anyMatch(a -> a.getAuthority().startsWith("ROLE_DEKANAT"));
-        String roleType   = securityService.getCurrentRoleType();
 
-        // 3. Якщо користувач — методист, готуємо набір ID груп його факультету
-        Set<Long> groupIdsForFaculty = isDekanat
-                ? studentService.getGroupIdsByFaculty(Long.valueOf(roleType))
-                : Collections.emptySet();
+        RoleScope roleScope = parseRoleScope(securityService.getCurrentRoleType());
+        Boolean preferredFullTime = roleScope.fullTime();
+
+        if (preferredFullTime == null) {
+            preferredFullTime = securityService.getCurrentUserModel()
+                    .map(UserModel::getRole)
+                    .filter(role -> role != null && role.startsWith("ROLE_DEKANAT"))
+                    .map(this::parseStudyFormToken)
+                    .orElse(null);
+        }
+
+        Set<Long> groupIdsForFaculty = null;
+        if (isDekanat && roleScope.facultyId() != null) {
+            groupIdsForFaculty = studentService.getGroupIdsByFaculty(roleScope.facultyId(), preferredFullTime);
+        }
+
+        boolean applyFacultyFilter = isDekanat && groupIdsForFaculty != null;
+        boolean applyStudyFormFilter = isDekanat && preferredFullTime != null;
 
         Collator ukrainianCollator = Collator.getInstance(new Locale("uk", "UA"));
 
-        // 4. Фільтруємо та мапимо
         return groups.stream()
-                .filter(group -> !isDekanat || groupIdsForFaculty.contains(group.getId()))
+                .filter(group -> !applyFacultyFilter || groupIdsForFaculty.contains(group.getId()))
+                .filter(group -> !applyStudyFormFilter || matchesPreferredForm(preferredFullTime, group))
                 .map(group -> new GroupDTO(
                         group.getGroupCode(),
                         group.getSpecialty().getTitle(),
@@ -66,6 +75,97 @@ public class GroupService {
                 ))
                 .sorted(Comparator.comparing(GroupDTO::getGroupCode, ukrainianCollator))
                 .collect(Collectors.toList());
+    }
+
+    private boolean matchesPreferredForm(Boolean preferredFullTime, StudentGroupEntity group) {
+        if (preferredFullTime == null) {
+            return true;
+        }
+
+        return studentService.determineGroupStudyForm(group)
+                .map(preferredFullTime::equals)
+                .orElse(false);
+    }
+
+    private RoleScope parseRoleScope(String rawRoleType) {
+        if (rawRoleType == null || rawRoleType.isBlank()) {
+            return new RoleScope(null, null);
+        }
+
+        String trimmed = rawRoleType.trim();
+        String[] parts = trimmed.split(":", 2);
+
+        Long facultyId = parseFacultyId(parts[0]);
+        Boolean fullTime = null;
+        if (parts.length > 1) {
+            fullTime = parseStudyFormToken(parts[1]);
+        }
+
+        if (fullTime == null && parts.length == 1) {
+            fullTime = parseStudyFormToken(parts[0]);
+        }
+
+        return new RoleScope(facultyId, fullTime);
+    }
+
+    private Long parseFacultyId(String token) {
+        if (token == null) {
+            return null;
+        }
+
+        String candidate = token.trim();
+        if (candidate.isEmpty()) {
+            return null;
+        }
+
+        StringBuilder digits = new StringBuilder();
+        for (int i = 0; i < candidate.length(); i++) {
+            char ch = candidate.charAt(i);
+            if (Character.isDigit(ch)) {
+                digits.append(ch);
+            } else if (!Character.isWhitespace(ch)) {
+                break;
+            }
+        }
+
+        if (digits.length() == 0) {
+            return null;
+        }
+
+        try {
+            return Long.valueOf(digits.toString());
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private Boolean parseStudyFormToken(String token) {
+        if (token == null) {
+            return null;
+        }
+
+        String normalized = token.trim().toLowerCase(Locale.ROOT);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+
+        if (normalized.equals("pt") || normalized.equals("part") || normalized.contains("part_time")
+                || normalized.contains("part-time") || normalized.contains("zaoch")
+                || normalized.contains("заоч") || normalized.contains("extramur")
+                || normalized.contains("distance") || normalized.contains("вечір")) {
+            return Boolean.FALSE;
+        }
+
+        if (normalized.equals("ft") || normalized.contains("full_time") || normalized.contains("full-time")
+                || normalized.contains("fulltime") || normalized.contains("денн")
+                || normalized.contains("day") || normalized.contains("денна")) {
+            return Boolean.TRUE;
+        }
+
+        return null;
+    }
+
+    private record RoleScope(Long facultyId, Boolean fullTime) {
     }
 
 

--- a/src/main/java/com/esvar/dekanat/service/StudentService.java
+++ b/src/main/java/com/esvar/dekanat/service/StudentService.java
@@ -92,10 +92,19 @@ public class StudentService {
     }
 
     public Set<Long> getGroupIdsByFaculty(Long facultyId) {
+        return getGroupIdsByFaculty(facultyId, null);
+    }
+
+    public Set<Long> getGroupIdsByFaculty(Long facultyId, Boolean fullTime) {
         if (facultyId == null) {
             return Collections.emptySet();
         }
-        return new HashSet<>(studentRepository.findDistinctGroupIdsByFacultyId(facultyId));
+
+        List<Long> groupIds = (fullTime == null)
+                ? studentRepository.findDistinctGroupIdsByFacultyId(facultyId)
+                : studentRepository.findDistinctGroupIdsByFacultyIdAndStudyForm(facultyId, fullTime);
+
+        return new HashSet<>(groupIds);
     }
 
     public StudentEntity findStudentById(Long id) {
@@ -137,6 +146,29 @@ public class StudentService {
         }
 
         return student;
+    }
+
+    public Optional<Boolean> determineGroupStudyForm(StudentGroupEntity group) {
+        if (group == null) {
+            return Optional.empty();
+        }
+
+        List<StudentEntity> students = studentRepository.findByGroup(group);
+        if (students == null || students.isEmpty()) {
+            return Optional.empty();
+        }
+
+        boolean allFullTime = students.stream().allMatch(StudentEntity::isFullTime);
+        if (allFullTime) {
+            return Optional.of(Boolean.TRUE);
+        }
+
+        boolean allPartTime = students.stream().noneMatch(StudentEntity::isFullTime);
+        if (allPartTime) {
+            return Optional.of(Boolean.FALSE);
+        }
+
+        return Optional.empty();
     }
 
     private static String normalizeFullName(String fullName) {


### PR DESCRIPTION
## Summary
- extend student repository queries to filter group ids by faculty and study form
- expose study-form aware lookups in StudentService and reuse them in GroupService
- detect part-time vs full-time context for dekanat users and hide mismatching groups

## Testing
- `./mvnw -q -DskipTests package` *(fails: unable to download Maven distribution in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915c0a4a0788326ada0c28601b23eb7)