### PR TITLE
Use group code prefixes for marks specialty selection

### DIFF
--- a/src/main/java/com/esvar/dekanat/dto/SpecialtyDTO.java
+++ b/src/main/java/com/esvar/dekanat/dto/SpecialtyDTO.java
@@ -1,0 +1,20 @@
+package com.esvar.dekanat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SpecialtyDTO {
+
+    private final String abbreviation;
+    private final String title;
+
+    @Override
+    public String toString() {
+        if (title != null && !title.isBlank()) {
+            return title;
+        }
+        return abbreviation;
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -185,6 +185,7 @@ public class EnterMarksView extends Div {
         selectSpecialty.setLabel("Спеціальність");
         selectSpecialty.setWidth("100%");
         selectSpecialty.getStyle().set("padding", "0px").set("margin", "0px").set("margin-bottom", "5px");
+        selectSpecialty.setItemLabelGenerator(option -> option == null ? "" : option);
 
         selectCourse.setLabel("Курс");
         selectCourse.setWidth("100%");
@@ -310,7 +311,8 @@ public class EnterMarksView extends Div {
 
         selectSpecialty.addValueChangeListener(event -> {
             clearGrid();
-            if (selectSpecialty.getValue() != null) {
+            String selectedSpecialty = selectSpecialty.getValue();
+            if (selectedSpecialty != null) {
                 selectCourse.setReadOnly(false);
                 selectGroup.setReadOnly(true);
                 selectDiscipline.setReadOnly(true);
@@ -323,7 +325,7 @@ public class EnterMarksView extends Div {
                 selectCourse.setItems(planService.getCourseByFacultyAndDepartmentAndSpecialty(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue()
+                        selectedSpecialty
                 ));
             }
         });
@@ -331,7 +333,8 @@ public class EnterMarksView extends Div {
         selectCourse.addValueChangeListener(event -> {
             clearGrid();
             currentGroup = null;
-            if (selectCourse.getValue() != null) {
+            String selectedSpecialty = selectSpecialty.getValue();
+            if (selectCourse.getValue() != null && selectedSpecialty != null) {
                 selectGroup.setReadOnly(false);
                 selectDiscipline.setReadOnly(true);
                 selectControlType.setReadOnly(true);
@@ -342,7 +345,7 @@ public class EnterMarksView extends Div {
                 selectGroup.setItems(planService.getGroupsByFacultyAndDepartmentAndSpecialtyAndCourse(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
+                        selectedSpecialty,
                         Integer.parseInt(selectCourse.getValue())
                 ));
             }
@@ -353,7 +356,8 @@ public class EnterMarksView extends Div {
             GroupDTO selectedGroup = selectGroup.getValue();
             currentGroup = selectedGroup == null ? null : groupService.getGroupByTitle(selectedGroup.getGroupCode());
             updateReportButtonState();
-            if (selectedGroup != null) {
+            String selectedSpecialty = selectSpecialty.getValue();
+            if (selectedGroup != null && selectedSpecialty != null) {
                 selectDiscipline.setReadOnly(false);
                 selectControlType.setReadOnly(true);
 
@@ -362,7 +366,7 @@ public class EnterMarksView extends Div {
                 selectDiscipline.setItems(planService.getDisciplinesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupGroupNumber(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
+                        selectedSpecialty,
                         selectedGroup.getCourse(),
                         selectedGroup.getGroupNumber()
                 ));
@@ -372,13 +376,14 @@ public class EnterMarksView extends Div {
         selectDiscipline.addValueChangeListener(event -> {
             clearGrid();
             GroupDTO selectedGroup = selectGroup.getValue();
-            if (selectDiscipline.getValue() != null && selectedGroup != null) {
+            String selectedSpecialty = selectSpecialty.getValue();
+            if (selectDiscipline.getValue() != null && selectedGroup != null && selectedSpecialty != null) {
                 selectControlType.setReadOnly(false);
 
                 selectControlType.setItems(planService.getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
+                        selectedSpecialty,
                         selectedGroup.getCourse(),
                         selectedGroup.getGroupNumber(),
                         selectDiscipline.getValue()
@@ -387,7 +392,7 @@ public class EnterMarksView extends Div {
                 plansEntity = planService.getPlanEntityByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
+                        selectedSpecialty,
                         selectedGroup.getCourse(),
                         selectedGroup.getGroupNumber(),
                         selectDiscipline.getValue()

--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -3,6 +3,7 @@ package com.esvar.dekanat.mark;
 import com.esvar.dekanat.document.DocumentGenerationService;
 import com.esvar.dekanat.dto.GroupDTO;
 import com.esvar.dekanat.dto.MarkDTO;
+import com.esvar.dekanat.dto.SpecialtyDTO;
 import com.esvar.dekanat.entity.*;
 import com.esvar.dekanat.generate.*;
 
@@ -115,7 +116,7 @@ public class EnterMarksView extends Div {
 
     private Select<String> selectFaculty = new Select<>();
     private Select<String> selectDepartment = new Select<>();
-    private Select<String> selectSpecialty = new Select<>();
+    private Select<SpecialtyDTO> selectSpecialty = new Select<>();
     private Select<String> selectCourse = new Select<>();
     private final Select<GroupDTO> selectGroup = new Select<>();
     private Select<String> selectDiscipline = new Select<>();
@@ -185,6 +186,13 @@ public class EnterMarksView extends Div {
         selectSpecialty.setLabel("Спеціальність");
         selectSpecialty.setWidth("100%");
         selectSpecialty.getStyle().set("padding", "0px").set("margin", "0px").set("margin-bottom", "5px");
+        selectSpecialty.setItemLabelGenerator(option -> {
+            if (option == null) {
+                return "";
+            }
+            String title = option.getTitle();
+            return (title != null && !title.isBlank()) ? title : option.getAbbreviation();
+        });
 
         selectCourse.setLabel("Курс");
         selectCourse.setWidth("100%");
@@ -310,7 +318,8 @@ public class EnterMarksView extends Div {
 
         selectSpecialty.addValueChangeListener(event -> {
             clearGrid();
-            if (selectSpecialty.getValue() != null) {
+            SpecialtyDTO selectedSpecialty = selectSpecialty.getValue();
+            if (selectedSpecialty != null) {
                 selectCourse.setReadOnly(false);
                 selectGroup.setReadOnly(true);
                 selectDiscipline.setReadOnly(true);
@@ -323,7 +332,7 @@ public class EnterMarksView extends Div {
                 selectCourse.setItems(planService.getCourseByFacultyAndDepartmentAndSpecialty(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue()
+                        selectedSpecialty.getAbbreviation()
                 ));
             }
         });
@@ -331,7 +340,8 @@ public class EnterMarksView extends Div {
         selectCourse.addValueChangeListener(event -> {
             clearGrid();
             currentGroup = null;
-            if (selectCourse.getValue() != null) {
+            SpecialtyDTO selectedSpecialty = selectSpecialty.getValue();
+            if (selectCourse.getValue() != null && selectedSpecialty != null) {
                 selectGroup.setReadOnly(false);
                 selectDiscipline.setReadOnly(true);
                 selectControlType.setReadOnly(true);
@@ -342,7 +352,7 @@ public class EnterMarksView extends Div {
                 selectGroup.setItems(planService.getGroupsByFacultyAndDepartmentAndSpecialtyAndCourse(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
+                        selectedSpecialty.getAbbreviation(),
                         Integer.parseInt(selectCourse.getValue())
                 ));
             }
@@ -353,7 +363,8 @@ public class EnterMarksView extends Div {
             GroupDTO selectedGroup = selectGroup.getValue();
             currentGroup = selectedGroup == null ? null : groupService.getGroupByTitle(selectedGroup.getGroupCode());
             updateReportButtonState();
-            if (selectedGroup != null) {
+            SpecialtyDTO selectedSpecialty = selectSpecialty.getValue();
+            if (selectedGroup != null && selectedSpecialty != null) {
                 selectDiscipline.setReadOnly(false);
                 selectControlType.setReadOnly(true);
 
@@ -362,7 +373,7 @@ public class EnterMarksView extends Div {
                 selectDiscipline.setItems(planService.getDisciplinesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupGroupNumber(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
+                        selectedSpecialty.getAbbreviation(),
                         selectedGroup.getCourse(),
                         selectedGroup.getGroupNumber()
                 ));
@@ -372,13 +383,14 @@ public class EnterMarksView extends Div {
         selectDiscipline.addValueChangeListener(event -> {
             clearGrid();
             GroupDTO selectedGroup = selectGroup.getValue();
-            if (selectDiscipline.getValue() != null && selectedGroup != null) {
+            SpecialtyDTO selectedSpecialty = selectSpecialty.getValue();
+            if (selectDiscipline.getValue() != null && selectedGroup != null && selectedSpecialty != null) {
                 selectControlType.setReadOnly(false);
 
                 selectControlType.setItems(planService.getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
+                        selectedSpecialty.getAbbreviation(),
                         selectedGroup.getCourse(),
                         selectedGroup.getGroupNumber(),
                         selectDiscipline.getValue()
@@ -387,7 +399,7 @@ public class EnterMarksView extends Div {
                 plansEntity = planService.getPlanEntityByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
+                        selectedSpecialty.getAbbreviation(),
                         selectedGroup.getCourse(),
                         selectedGroup.getGroupNumber(),
                         selectDiscipline.getValue()

--- a/src/main/java/com/esvar/dekanat/repository/StudentRepository.java
+++ b/src/main/java/com/esvar/dekanat/repository/StudentRepository.java
@@ -4,6 +4,7 @@ import com.esvar.dekanat.entity.StudentEntity;
 import com.esvar.dekanat.entity.StudentGroupEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,7 +12,15 @@ import java.util.List;
 @Repository
 public interface StudentRepository extends JpaRepository<StudentEntity, Long> {
     @Query("SELECT DISTINCT s.group.id FROM StudentEntity s WHERE s.faculty.id = :facultyId")
-    List<Long> findDistinctGroupIdsByFacultyId(Long facultyId);
+    List<Long> findDistinctGroupIdsByFacultyId(@Param("facultyId") Long facultyId);
+
+    @Query("""
+            SELECT DISTINCT s.group.id FROM StudentEntity s
+            WHERE s.faculty.id = :facultyId
+              AND (:fullTime IS NULL OR s.fullTime = :fullTime)
+            """)
+    List<Long> findDistinctGroupIdsByFacultyIdAndStudyForm(@Param("facultyId") Long facultyId,
+                                                           @Param("fullTime") Boolean fullTime);
 
     List<StudentEntity> findByGroupId(long groupId);
 

--- a/src/main/java/com/esvar/dekanat/service/GroupService.java
+++ b/src/main/java/com/esvar/dekanat/service/GroupService.java
@@ -1,14 +1,14 @@
 package com.esvar.dekanat.service;
 
 import com.esvar.dekanat.dto.GroupDTO;
-import com.esvar.dekanat.entity.SpecialtyEntity;
 import com.esvar.dekanat.entity.StudentEntity;
 import com.esvar.dekanat.entity.StudentGroupEntity;
 import com.esvar.dekanat.repository.GroupRepository;
 import com.esvar.dekanat.security.SecurityService;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+
+import com.esvar.dekanat.user.UserModel;
 
 import java.text.Collator;
 import java.util.*;
@@ -36,27 +36,36 @@ public class GroupService {
     }
 
     public List<GroupDTO> getGroupsDTO() {
-        // 1. Завантажуємо всі групи
         List<StudentGroupEntity> groups = groupRepository.findAll();
 
-        // 2. Отримуємо ролі й roleType поточного користувача
         UserDetails user = securityService.getAuthenticatedUser();
-        boolean isAdmin   = user.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
-        boolean isDekanat = user.getAuthorities().stream()
+        boolean isDekanat = user != null && user.getAuthorities().stream()
                 .anyMatch(a -> a.getAuthority().startsWith("ROLE_DEKANAT"));
-        String roleType   = securityService.getCurrentRoleType();
 
-        // 3. Якщо користувач — методист, готуємо набір ID груп його факультету
-        Set<Long> groupIdsForFaculty = isDekanat
-                ? studentService.getGroupIdsByFaculty(Long.valueOf(roleType))
-                : Collections.emptySet();
+        RoleScope roleScope = parseRoleScope(securityService.getCurrentRoleType());
+        Boolean preferredFullTime = roleScope.fullTime();
+
+        if (preferredFullTime == null) {
+            preferredFullTime = securityService.getCurrentUserModel()
+                    .map(UserModel::getRole)
+                    .filter(role -> role != null && role.startsWith("ROLE_DEKANAT"))
+                    .map(this::parseStudyFormToken)
+                    .orElse(null);
+        }
+
+        Set<Long> groupIdsForFaculty = null;
+        if (isDekanat && roleScope.facultyId() != null) {
+            groupIdsForFaculty = studentService.getGroupIdsByFaculty(roleScope.facultyId(), preferredFullTime);
+        }
+
+        boolean applyFacultyFilter = isDekanat && groupIdsForFaculty != null;
+        boolean applyStudyFormFilter = isDekanat && preferredFullTime != null;
 
         Collator ukrainianCollator = Collator.getInstance(new Locale("uk", "UA"));
 
-        // 4. Фільтруємо та мапимо
         return groups.stream()
-                .filter(group -> !isDekanat || groupIdsForFaculty.contains(group.getId()))
+                .filter(group -> !applyFacultyFilter || groupIdsForFaculty.contains(group.getId()))
+                .filter(group -> !applyStudyFormFilter || matchesPreferredForm(preferredFullTime, group))
                 .map(group -> new GroupDTO(
                         group.getGroupCode(),
                         group.getSpecialty().getTitle(),
@@ -66,6 +75,97 @@ public class GroupService {
                 ))
                 .sorted(Comparator.comparing(GroupDTO::getGroupCode, ukrainianCollator))
                 .collect(Collectors.toList());
+    }
+
+    private boolean matchesPreferredForm(Boolean preferredFullTime, StudentGroupEntity group) {
+        if (preferredFullTime == null) {
+            return true;
+        }
+
+        return studentService.determineGroupStudyForm(group)
+                .map(preferredFullTime::equals)
+                .orElse(false);
+    }
+
+    private RoleScope parseRoleScope(String rawRoleType) {
+        if (rawRoleType == null || rawRoleType.isBlank()) {
+            return new RoleScope(null, null);
+        }
+
+        String trimmed = rawRoleType.trim();
+        String[] parts = trimmed.split(":", 2);
+
+        Long facultyId = parseFacultyId(parts[0]);
+        Boolean fullTime = null;
+        if (parts.length > 1) {
+            fullTime = parseStudyFormToken(parts[1]);
+        }
+
+        if (fullTime == null && parts.length == 1) {
+            fullTime = parseStudyFormToken(parts[0]);
+        }
+
+        return new RoleScope(facultyId, fullTime);
+    }
+
+    private Long parseFacultyId(String token) {
+        if (token == null) {
+            return null;
+        }
+
+        String candidate = token.trim();
+        if (candidate.isEmpty()) {
+            return null;
+        }
+
+        StringBuilder digits = new StringBuilder();
+        for (int i = 0; i < candidate.length(); i++) {
+            char ch = candidate.charAt(i);
+            if (Character.isDigit(ch)) {
+                digits.append(ch);
+            } else if (!Character.isWhitespace(ch)) {
+                break;
+            }
+        }
+
+        if (digits.length() == 0) {
+            return null;
+        }
+
+        try {
+            return Long.valueOf(digits.toString());
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private Boolean parseStudyFormToken(String token) {
+        if (token == null) {
+            return null;
+        }
+
+        String normalized = token.trim().toLowerCase(Locale.ROOT);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+
+        if (normalized.equals("pt") || normalized.equals("part") || normalized.contains("part_time")
+                || normalized.contains("part-time") || normalized.contains("zaoch")
+                || normalized.contains("заоч") || normalized.contains("extramur")
+                || normalized.contains("distance") || normalized.contains("вечір")) {
+            return Boolean.FALSE;
+        }
+
+        if (normalized.equals("ft") || normalized.contains("full_time") || normalized.contains("full-time")
+                || normalized.contains("fulltime") || normalized.contains("денн")
+                || normalized.contains("day") || normalized.contains("денна")) {
+            return Boolean.TRUE;
+        }
+
+        return null;
+    }
+
+    private record RoleScope(Long facultyId, Boolean fullTime) {
     }
 
 

--- a/src/main/java/com/esvar/dekanat/service/PlanService.java
+++ b/src/main/java/com/esvar/dekanat/service/PlanService.java
@@ -1,6 +1,7 @@
 package com.esvar.dekanat.service;
 
 import com.esvar.dekanat.dto.GroupDTO;
+import com.esvar.dekanat.dto.SpecialtyDTO;
 import com.esvar.dekanat.entity.*;
 import com.esvar.dekanat.repository.*;
 import org.springframework.stereotype.Service;
@@ -129,15 +130,27 @@ public class PlanService {
         return planRepository.findById(id).orElse(null);
     }
 
-    public List<String> getSpecialtiesByFacultyAndDepartment(String faculty, String department) {
-        return planRepository.findByFacultyAndDepartment
-                (
+    public List<SpecialtyDTO> getSpecialtiesByFacultyAndDepartment(String faculty, String department) {
+        Collator ukrainianCollator = Collator.getInstance(new Locale("uk", "UA"));
+
+        return planRepository.findByFacultyAndDepartment(
                         facultyRepository.findByTitle(faculty),
                         departmentRepository.findByTitle(department)
                 ).stream()
                 .map(PlansEntity::getSpecialty)
-                .map(SpecialtyEntity::getAbbreviation)
-                .distinct()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(
+                        SpecialtyEntity::getAbbreviation,
+                        specialty -> new SpecialtyDTO(
+                                specialty.getAbbreviation(),
+                                specialty.getTitle()
+                        ),
+                        (existing, duplicate) -> existing,
+                        LinkedHashMap::new
+                ))
+                .values()
+                .stream()
+                .sorted(Comparator.comparing(SpecialtyDTO::getTitle, ukrainianCollator))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/esvar/dekanat/service/PlanService.java
+++ b/src/main/java/com/esvar/dekanat/service/PlanService.java
@@ -130,28 +130,34 @@ public class PlanService {
     }
 
     public List<String> getSpecialtiesByFacultyAndDepartment(String faculty, String department) {
-        return planRepository.findByFacultyAndDepartment
-                (
+        Collator ukrainianCollator = Collator.getInstance(new Locale("uk", "UA"));
+
+        return planRepository.findByFacultyAndDepartment(
                         facultyRepository.findByTitle(faculty),
                         departmentRepository.findByTitle(department)
                 ).stream()
-                .map(PlansEntity::getSpecialty)
-                .map(SpecialtyEntity::getAbbreviation)
+                .flatMap(plan -> plan.getGroups().stream())
+                .filter(Objects::nonNull)
+                .map(this::extractGroupPrefix)
+                .flatMap(Optional::stream)
                 .distinct()
+                .sorted(ukrainianCollator)
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     public List<String> getCourseByFacultyAndDepartmentAndSpecialty(String faculty, String department, String specialty) {
-        return planRepository.findByFacultyAndDepartmentAndSpecialty_Abbreviation(
+        return planRepository.findByFacultyAndDepartment(
                         facultyRepository.findByTitle(faculty),
-                        departmentRepository.findByTitle(department),
-                        specialty
+                        departmentRepository.findByTitle(department)
                 ).stream()
                 .flatMap(plan -> plan.getGroups().stream())
+                .filter(Objects::nonNull)
+                .filter(group -> extractGroupPrefix(group).filter(specialty::equals).isPresent())
                 .map(StudentGroupEntity::getCourse)
-                .map(String::valueOf)
                 .distinct()
+                .sorted()
+                .map(String::valueOf)
                 .collect(Collectors.toList());
     }
 
@@ -159,14 +165,14 @@ public class PlanService {
     public List<GroupDTO> getGroupsByFacultyAndDepartmentAndSpecialtyAndCourse(String faculty, String department, String specialty, int course) {
         Collator ukrainianCollator = Collator.getInstance(new Locale("uk", "UA"));
 
-        List<StudentGroupEntity> uniqueGroups = planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_Course(
+        List<StudentGroupEntity> uniqueGroups = planRepository.findByFacultyAndDepartment(
                         facultyRepository.findByTitle(faculty),
-                        departmentRepository.findByTitle(department),
-                        specialty,
-                        course
+                        departmentRepository.findByTitle(department)
                 ).stream()
                 .flatMap(plan -> plan.getGroups().stream())
                 .filter(Objects::nonNull)
+                .filter(group -> group.getCourse() == course)
+                .filter(group -> extractGroupPrefix(group).filter(specialty::equals).isPresent())
                 .collect(Collectors.toCollection(LinkedHashSet::new))
                 .stream()
                 .toList();
@@ -185,13 +191,14 @@ public class PlanService {
 
     public List<String> getDisciplinesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupGroupNumber(String faculty, String department, String specialty, int course, int groupNumber) {
         int semester = getNumberSemester(String.valueOf(course));
-        return planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumber(
+        return planRepository.findByFacultyAndDepartment(
                         facultyRepository.findByTitle(faculty),
-                        departmentRepository.findByTitle(department),
-                        specialty,
-                        course,
-                        groupNumber
+                        departmentRepository.findByTitle(department)
                 ).stream()
+                .filter(plan -> plan.getGroups().stream()
+                        .filter(Objects::nonNull)
+                        .filter(group -> group.getCourse() == course && group.getGroupNumber() == groupNumber)
+                        .anyMatch(group -> extractGroupPrefix(group).filter(specialty::equals).isPresent()))
                 .filter(p -> p.getSemester() == semester)
                 .map(PlansEntity::getDiscipline)
                 .map(DisciplineEntity::getTitle)
@@ -202,14 +209,16 @@ public class PlanService {
     public List<String> getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
             String faculty, String department, String specialty, int course, int groupNumber, String discipline) {
         int semester = getNumberSemester(String.valueOf(course));
-        List<PlansEntity> plans = planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
-                facultyRepository.findByTitle(faculty),
-                departmentRepository.findByTitle(department),
-                specialty,
-                course,
-                groupNumber,
-                discipline
-        );
+        List<PlansEntity> plans = planRepository.findByFacultyAndDepartment(
+                        facultyRepository.findByTitle(faculty),
+                        departmentRepository.findByTitle(department)
+                ).stream()
+                .filter(plan -> plan.getDiscipline() != null && discipline.equals(plan.getDiscipline().getTitle()))
+                .filter(plan -> plan.getGroups().stream()
+                        .filter(Objects::nonNull)
+                        .filter(group -> group.getCourse() == course && group.getGroupNumber() == groupNumber)
+                        .anyMatch(group -> extractGroupPrefix(group).filter(specialty::equals).isPresent()))
+                .toList();
 
         List<PlansEntity> semesterPlans = plans.stream()
                 .filter(p -> p.getSemester() == semester)
@@ -266,16 +275,42 @@ public class PlanService {
 
     public PlansEntity getPlanEntityByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(String faculty, String department, String specialty, int course, int groupNumber, String discipline){
         int semester = getNumberSemester(String.valueOf(course));
-        return planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
+        return planRepository.findByFacultyAndDepartment(
                         facultyRepository.findByTitle(faculty),
-                        departmentRepository.findByTitle(department),
-                        specialty,
-                        course,
-                        groupNumber,
-                        discipline
+                        departmentRepository.findByTitle(department)
                 ).stream()
+                .filter(plan -> plan.getDiscipline() != null && discipline.equals(plan.getDiscipline().getTitle()))
+                .filter(plan -> plan.getGroups().stream()
+                        .filter(Objects::nonNull)
+                        .filter(group -> group.getCourse() == course && group.getGroupNumber() == groupNumber)
+                        .anyMatch(group -> extractGroupPrefix(group).filter(specialty::equals).isPresent()))
                 .filter(p -> p.getSemester() == semester)
                 .findFirst().orElse(null);
+    }
+
+    private Optional<String> extractGroupPrefix(StudentGroupEntity group) {
+        if (group == null) {
+            return Optional.empty();
+        }
+
+        String groupCode = group.getGroupCode();
+        if (groupCode == null) {
+            return Optional.empty();
+        }
+
+        String trimmed = groupCode.trim();
+        if (trimmed.isEmpty()) {
+            return Optional.empty();
+        }
+
+        int dashIndex = trimmed.indexOf('-');
+        String prefix = dashIndex >= 0 ? trimmed.substring(0, dashIndex) : trimmed;
+        prefix = prefix.trim();
+        if (prefix.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(prefix);
     }
 
     private int getNumberSemester(String course) {

--- a/src/main/java/com/esvar/dekanat/service/PlanService.java
+++ b/src/main/java/com/esvar/dekanat/service/PlanService.java
@@ -202,25 +202,62 @@ public class PlanService {
     public List<String> getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
             String faculty, String department, String specialty, int course, int groupNumber, String discipline) {
         int semester = getNumberSemester(String.valueOf(course));
-        List<String> controlTypes = planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
-                        facultyRepository.findByTitle(faculty),
-                        departmentRepository.findByTitle(department),
-                        specialty,
-                        course,
-                        groupNumber,
-                        discipline
-                ).stream()
+        List<PlansEntity> plans = planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
+                facultyRepository.findByTitle(faculty),
+                departmentRepository.findByTitle(department),
+                specialty,
+                course,
+                groupNumber,
+                discipline
+        );
+
+        List<PlansEntity> semesterPlans = plans.stream()
                 .filter(p -> p.getSemester() == semester)
-                .flatMap(plan -> Stream.of(plan.getFirstControl().getName(), plan.getSecondControl().getName())) // Отримуємо обидва значення
-                .filter(control -> !"Відсутній".equals(control)) // Фільтруємо "Відсутній"
-                .distinct() // Унікальні значення (якщо потрібно)
+                .toList();
+
+        List<String> controlTypes = semesterPlans.stream()
+                .flatMap(plan -> Stream.of(plan.getFirstControl().getName(), plan.getSecondControl().getName()))
+                .filter(control -> !"Відсутній".equals(control))
+                .distinct()
                 .collect(Collectors.toList());
 
-        // Додаємо "Перший модульний контроль" і "Другий модульний контроль"
-        controlTypes.add("Перший модульний контроль");
-        controlTypes.add("Другий модульний контроль");
+        if (shouldIncludeModuleControls(semesterPlans, course, groupNumber)) {
+            controlTypes.add("Перший модульний контроль");
+            controlTypes.add("Другий модульний контроль");
+        }
 
         return controlTypes;
+    }
+
+    private boolean shouldIncludeModuleControls(List<PlansEntity> plans, int course, int groupNumber) {
+        if (plans == null || plans.isEmpty()) {
+            return false;
+        }
+
+        return findGroupForCourseAndNumber(plans, course, groupNumber)
+                .map(this::isFullTimeGroup)
+                .orElse(false);
+    }
+
+    private Optional<StudentGroupEntity> findGroupForCourseAndNumber(List<PlansEntity> plans, int course, int groupNumber) {
+        return plans.stream()
+                .flatMap(plan -> plan.getGroups().stream())
+                .filter(Objects::nonNull)
+                .filter(group -> group.getCourse() == course && group.getGroupNumber() == groupNumber)
+                .findFirst();
+    }
+
+    private boolean isFullTimeGroup(StudentGroupEntity group) {
+        if (group == null) {
+            return false;
+        }
+
+        List<StudentEntity> students = studentRepository.findByGroup(group);
+        if (students == null || students.isEmpty()) {
+            return false;
+        }
+
+        return students.stream().allMatch(StudentEntity::isFullTime);
     }
 
     public PlansEntity getPlanEntityByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(String faculty, String department, String specialty, int course, int groupNumber, String discipline){

--- a/src/main/java/com/esvar/dekanat/service/PlanService.java
+++ b/src/main/java/com/esvar/dekanat/service/PlanService.java
@@ -215,13 +215,17 @@ public class PlanService {
                 .filter(p -> p.getSemester() == semester)
                 .toList();
 
-        List<String> controlTypes = semesterPlans.stream()
-                .flatMap(plan -> Stream.of(plan.getFirstControl().getName(), plan.getSecondControl().getName()))
+        List<PlansEntity> relevantPlans = semesterPlans.isEmpty() ? plans : semesterPlans;
+
+        List<String> controlTypes = relevantPlans.stream()
+                .flatMap(plan -> Stream.of(plan.getFirstControl(), plan.getSecondControl()))
+                .filter(Objects::nonNull)
+                .map(ControlMethodEntity::getName)
                 .filter(control -> !"Відсутній".equals(control))
                 .distinct()
                 .collect(Collectors.toList());
 
-        if (shouldIncludeModuleControls(semesterPlans, course, groupNumber)) {
+        if (shouldIncludeModuleControls(relevantPlans, course, groupNumber)) {
             controlTypes.add("Перший модульний контроль");
             controlTypes.add("Другий модульний контроль");
         }

--- a/src/main/java/com/esvar/dekanat/service/StudentService.java
+++ b/src/main/java/com/esvar/dekanat/service/StudentService.java
@@ -92,10 +92,19 @@ public class StudentService {
     }
 
     public Set<Long> getGroupIdsByFaculty(Long facultyId) {
+        return getGroupIdsByFaculty(facultyId, null);
+    }
+
+    public Set<Long> getGroupIdsByFaculty(Long facultyId, Boolean fullTime) {
         if (facultyId == null) {
             return Collections.emptySet();
         }
-        return new HashSet<>(studentRepository.findDistinctGroupIdsByFacultyId(facultyId));
+
+        List<Long> groupIds = (fullTime == null)
+                ? studentRepository.findDistinctGroupIdsByFacultyId(facultyId)
+                : studentRepository.findDistinctGroupIdsByFacultyIdAndStudyForm(facultyId, fullTime);
+
+        return new HashSet<>(groupIds);
     }
 
     public StudentEntity findStudentById(Long id) {
@@ -137,6 +146,29 @@ public class StudentService {
         }
 
         return student;
+    }
+
+    public Optional<Boolean> determineGroupStudyForm(StudentGroupEntity group) {
+        if (group == null) {
+            return Optional.empty();
+        }
+
+        List<StudentEntity> students = studentRepository.findByGroup(group);
+        if (students == null || students.isEmpty()) {
+            return Optional.empty();
+        }
+
+        boolean allFullTime = students.stream().allMatch(StudentEntity::isFullTime);
+        if (allFullTime) {
+            return Optional.of(Boolean.TRUE);
+        }
+
+        boolean allPartTime = students.stream().noneMatch(StudentEntity::isFullTime);
+        if (allPartTime) {
+            return Optional.of(Boolean.FALSE);
+        }
+
+        return Optional.empty();
     }
 
     private static String normalizeFullName(String fullName) {

--- a/src/test/java/com/esvar/dekanat/service/PlanServiceTest.java
+++ b/src/test/java/com/esvar/dekanat/service/PlanServiceTest.java
@@ -149,6 +149,29 @@ class PlanServiceTest {
                 .doesNotContain("Перший модульний контроль", "Другий модульний контроль");
     }
 
+    @Test
+    void shouldReturnPlanControlTypesWhenSemesterDoesNotMatchSession() {
+        plan.setSemester(1); // Не відповідає семестру, обчисленому для літньої сесії
+
+        when(planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
+                any(), any(), any(), anyInt(), anyInt(), any()))
+                .thenReturn(List.of(plan));
+        when(studentRepository.findByGroup(group))
+                .thenReturn(List.of(createStudent(true)));
+
+        List<String> controlTypes = planService.getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
+                "Faculty",
+                "Department",
+                "SP",
+                1,
+                1,
+                "Math"
+        );
+
+        assertThat(controlTypes)
+                .contains("Екзамен", "Залік");
+    }
+
     private StudentEntity createStudent(boolean fullTime) {
         StudentEntity student = new StudentEntity();
         student.setId(fullTime ? 11L : 12L);

--- a/src/test/java/com/esvar/dekanat/service/PlanServiceTest.java
+++ b/src/test/java/com/esvar/dekanat/service/PlanServiceTest.java
@@ -1,0 +1,164 @@
+package com.esvar.dekanat.service;
+
+import com.esvar.dekanat.entity.*;
+import com.esvar.dekanat.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PlanServiceTest {
+
+    @Mock
+    private PlanRepository planRepository;
+    @Mock
+    private StudentPlansRepository studentPlansRepository;
+    @Mock
+    private StudentRepository studentRepository;
+    @Mock
+    private FacultyRepository facultyRepository;
+    @Mock
+    private DepartmentRepository departmentRepository;
+    @Mock
+    private SessionRepository sessionRepository;
+    @Mock
+    private MarksService marksService;
+    @Mock
+    private MarksPartsService marksPartsService;
+    @Mock
+    private MarksInitializerService marksInitializerService;
+    @Mock
+    private PlanStatementNumberService planStatementNumberService;
+
+    @InjectMocks
+    private PlanService planService;
+
+    private FacultyEntity faculty;
+    private DepartmentEntity department;
+    private DisciplineEntity discipline;
+    private ControlMethodEntity firstControl;
+    private ControlMethodEntity secondControl;
+    private StudentGroupEntity group;
+    private PlansEntity plan;
+
+    @BeforeEach
+    void setUp() {
+        faculty = new FacultyEntity();
+        faculty.setId(1L);
+        faculty.setTitle("Faculty");
+
+        department = new DepartmentEntity();
+        department.setId(2L);
+        department.setTitle("Department");
+
+        SpecialtyEntity specialty = new SpecialtyEntity();
+        specialty.setId(3L);
+        specialty.setAbbreviation("SP");
+
+        discipline = new DisciplineEntity();
+        discipline.setId(4L);
+        discipline.setTitle("Math");
+
+        firstControl = new ControlMethodEntity();
+        firstControl.setId(5L);
+        firstControl.setName("Екзамен");
+        firstControl.setType(1);
+
+        secondControl = new ControlMethodEntity();
+        secondControl.setId(6L);
+        secondControl.setName("Залік");
+        secondControl.setType(2);
+
+        group = new StudentGroupEntity();
+        group.setId(7L);
+        group.setCourse(1);
+        group.setGroupNumber(1);
+        group.setYear(2024);
+        group.setSpecialty(specialty);
+        group.setGroupCode("SP-1-1-2024");
+
+        plan = new PlansEntity();
+        plan.setId(8L);
+        plan.setDiscipline(discipline);
+        plan.setSemester(2);
+        plan.setFirstControl(firstControl);
+        plan.setSecondControl(secondControl);
+        plan.setGroups(Set.of(group));
+
+        when(facultyRepository.findByTitle("Faculty"))
+                .thenReturn(faculty);
+        when(departmentRepository.findByTitle("Department"))
+                .thenReturn(department);
+        when(sessionRepository.findById(1L))
+                .thenReturn(Optional.of(new SessionEntity(1L, false)));
+    }
+
+    @Test
+    void shouldIncludeModuleControlsForFullTimeGroup() {
+        StudentEntity fullTimeStudent = createStudent(true);
+        when(planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
+                any(), any(), any(), anyInt(), anyInt(), any()))
+                .thenReturn(List.of(plan));
+        when(studentRepository.findByGroup(group))
+                .thenReturn(List.of(fullTimeStudent));
+
+        List<String> controlTypes = planService.getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
+                "Faculty",
+                "Department",
+                "SP",
+                1,
+                1,
+                "Math"
+        );
+
+        assertThat(controlTypes)
+                .contains("Перший модульний контроль", "Другий модульний контроль");
+    }
+
+    @Test
+    void shouldSkipModuleControlsForPartTimeGroup() {
+        StudentEntity partTimeStudent = createStudent(false);
+        when(planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
+                any(), any(), any(), anyInt(), anyInt(), any()))
+                .thenReturn(List.of(plan));
+        when(studentRepository.findByGroup(group))
+                .thenReturn(List.of(partTimeStudent));
+
+        List<String> controlTypes = planService.getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
+                "Faculty",
+                "Department",
+                "SP",
+                1,
+                1,
+                "Math"
+        );
+
+        assertThat(controlTypes)
+                .doesNotContain("Перший модульний контроль", "Другий модульний контроль");
+    }
+
+    private StudentEntity createStudent(boolean fullTime) {
+        StudentEntity student = new StudentEntity();
+        student.setId(fullTime ? 11L : 12L);
+        student.setName("Ім'я");
+        student.setSurname("Прізвище");
+        student.setPatronymic("По батькові");
+        student.setFaculty(faculty);
+        student.setGroup(group);
+        student.setRecordBookNumber(fullTime ? "FT" : "PT");
+        student.setFullTime(fullTime);
+        return student;
+    }
+}


### PR DESCRIPTION
## Summary
- derive specialty options for the marks view from student group code prefixes instead of specialty records
- update plan lookups to filter by group code prefixes for courses, groups, disciplines, and controls
- remove the now-unused SpecialtyDTO in favour of simple string values in the marks view selector

## Testing
- ./mvnw -q -DskipTests compile *(fails: unable to download Maven distribution)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e18ca22c8326a9ca263ce9ddf58e)