### PR TITLE
Add validation to user creation flow

### DIFF
--- a/src/main/java/com/esvar/dekanat/card/CardAdditionalInfoView.java
+++ b/src/main/java/com/esvar/dekanat/card/CardAdditionalInfoView.java
@@ -1,0 +1,105 @@
+package com.esvar.dekanat.card;
+
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.div.Div;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.component.textfield.TextField;
+
+/**
+ * View responsible for additional student info: education terms, contacts, and address.
+ */
+public class CardAdditionalInfoView extends VerticalLayout {
+
+    public CardAdditionalInfoView(TextField caseNumberField,
+                                  Select<String> educationFormSelect,
+                                  Select<String> degreeSelect,
+                                  Select<String> admissionConditionSelect,
+                                  Select<String> paymentSourceSelect,
+                                  TextField contractNumberField,
+                                  TextField amountField,
+                                  MultiSelectComboBox<String> benefitsSelect,
+                                  Select<String> regionSelect,
+                                  TextField indexField,
+                                  TextField fullAddressField,
+                                  TextField phoneNumberField,
+                                  TextField emailField) {
+
+        Div educationDetailsWrapper = new Div();
+        educationDetailsWrapper.getStyle().set("border", "1px solid #ddd");
+        educationDetailsWrapper.getStyle().set("border-radius", "8px");
+        educationDetailsWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
+        educationDetailsWrapper.getStyle().set("padding", "20px");
+        educationDetailsWrapper.getStyle().set("position", "relative");
+        educationDetailsWrapper.getStyle().set("background", "white");
+        educationDetailsWrapper.getStyle().set("width", "97%");
+
+        Span educationDetailsTitle = new Span("Дані про навчання");
+        educationDetailsTitle.getStyle().set("position", "absolute");
+        educationDetailsTitle.getStyle().set("top", "-10px");
+        educationDetailsTitle.getStyle().set("left", "20px");
+        educationDetailsTitle.getStyle().set("background", "white");
+        educationDetailsTitle.getStyle().set("padding", "0 10px");
+        educationDetailsTitle.getStyle().set("font-weight", "bold");
+
+        FormLayout educationDetailsLayout = new FormLayout();
+        educationDetailsLayout.add(caseNumberField, educationFormSelect, degreeSelect, admissionConditionSelect, paymentSourceSelect, contractNumberField, amountField, benefitsSelect);
+
+        educationDetailsWrapper.add(educationDetailsTitle, educationDetailsLayout);
+
+        Div contactDetailsWrapper = new Div();
+        contactDetailsWrapper.getStyle().set("border", "1px solid #ddd");
+        contactDetailsWrapper.getStyle().set("border-radius", "8px");
+        contactDetailsWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
+        contactDetailsWrapper.getStyle().set("padding", "20px");
+        contactDetailsWrapper.getStyle().set("position", "relative");
+        contactDetailsWrapper.getStyle().set("background", "white");
+        contactDetailsWrapper.getStyle().set("width", "97%");
+
+        Span contactDetailsTitle = new Span("Контактні дані");
+        contactDetailsTitle.getStyle().set("position", "absolute");
+        contactDetailsTitle.getStyle().set("top", "-10px");
+        contactDetailsTitle.getStyle().set("left", "20px");
+        contactDetailsTitle.getStyle().set("background", "white");
+        contactDetailsTitle.getStyle().set("padding", "0 10px");
+        contactDetailsTitle.getStyle().set("font-weight", "bold");
+
+        FormLayout contactDetailsLayout = new FormLayout();
+        contactDetailsLayout.add(phoneNumberField, emailField);
+
+        contactDetailsWrapper.add(contactDetailsTitle, contactDetailsLayout);
+
+        Div addressDetailsWrapper = new Div();
+        addressDetailsWrapper.getStyle().set("border", "1px solid #ddd");
+        addressDetailsWrapper.getStyle().set("border-radius", "8px");
+        addressDetailsWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
+        addressDetailsWrapper.getStyle().set("padding", "20px");
+        addressDetailsWrapper.getStyle().set("position", "relative");
+        addressDetailsWrapper.getStyle().set("background", "white");
+        addressDetailsWrapper.getStyle().set("width", "97%");
+
+        Span addressDetailsTitle = new Span("Адреса");
+        addressDetailsTitle.getStyle().set("position", "absolute");
+        addressDetailsTitle.getStyle().set("top", "-10px");
+        addressDetailsTitle.getStyle().set("left", "20px");
+        addressDetailsTitle.getStyle().set("background", "white");
+        addressDetailsTitle.getStyle().set("padding", "0 10px");
+        addressDetailsTitle.getStyle().set("font-weight", "bold");
+
+        FormLayout addressDetailsLayout = new FormLayout();
+        addressDetailsLayout.add(regionSelect, indexField, fullAddressField);
+        addressDetailsLayout.setResponsiveSteps(
+                new FormLayout.ResponsiveStep("0", 1),
+                new FormLayout.ResponsiveStep("500px", 2)
+        );
+        addressDetailsLayout.setColspan(fullAddressField, 2);
+
+        addressDetailsWrapper.add(addressDetailsTitle, addressDetailsLayout);
+
+        setWidth("100%");
+        getStyle().set("padding", "0px");
+        add(educationDetailsWrapper, contactDetailsWrapper, addressDetailsWrapper);
+    }
+}

--- a/src/main/java/com/esvar/dekanat/card/CardEducationDocumentsView.java
+++ b/src/main/java/com/esvar/dekanat/card/CardEducationDocumentsView.java
@@ -1,0 +1,123 @@
+package com.esvar.dekanat.card;
+
+import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.div.Div;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.component.textfield.TextField;
+
+/**
+ * View responsible for prior education documents and diploma data blocks.
+ */
+public class CardEducationDocumentsView extends VerticalLayout {
+
+    private final Div generalEducationDocumentsWrapper;
+    private final Div diplomaDocumentsWrapper;
+
+    public CardEducationDocumentsView(Select<String> documentTypeSelect,
+                                      Checkbox distinctionCheckbox,
+                                      TextField documentSeriesField,
+                                      TextField documentNumberField,
+                                      DatePicker documentIssueDatePicker,
+                                      TextField institutionNameField,
+                                      TextField institutionNameEngField,
+                                      TextField diplomaSeriesField,
+                                      TextField diplomaNumberField,
+                                      DatePicker graduationDatePicker,
+                                      TextField appendixNumberField,
+                                      TextField thesisTitleUkrField,
+                                      TextField thesisTitleEngField) {
+
+        generalEducationDocumentsWrapper = new Div();
+        generalEducationDocumentsWrapper.getStyle().set("border", "1px solid #ddd");
+        generalEducationDocumentsWrapper.getStyle().set("border-radius", "8px");
+        generalEducationDocumentsWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
+        generalEducationDocumentsWrapper.getStyle().set("padding", "20px");
+        generalEducationDocumentsWrapper.getStyle().set("position", "relative");
+        generalEducationDocumentsWrapper.getStyle().set("background", "white");
+        generalEducationDocumentsWrapper.getStyle().set("width", "97%");
+
+        Span generalEducationDocumentsTitle = new Span("Попередня освіта");
+        generalEducationDocumentsTitle.getStyle().set("position", "absolute");
+        generalEducationDocumentsTitle.getStyle().set("top", "-10px");
+        generalEducationDocumentsTitle.getStyle().set("left", "20px");
+        generalEducationDocumentsTitle.getStyle().set("background", "white");
+        generalEducationDocumentsTitle.getStyle().set("padding", "0 10px");
+        generalEducationDocumentsTitle.getStyle().set("font-weight", "bold");
+
+        FormLayout generalEducationDocumentsLayout = new FormLayout();
+        generalEducationDocumentsLayout.add(
+                documentTypeSelect,
+                distinctionCheckbox,
+                documentSeriesField,
+                documentNumberField,
+                documentIssueDatePicker,
+                institutionNameField,
+                institutionNameEngField
+        );
+
+        generalEducationDocumentsLayout.setResponsiveSteps(
+                new FormLayout.ResponsiveStep("0", 2),
+                new FormLayout.ResponsiveStep("600px", 2)
+        );
+        generalEducationDocumentsLayout.setColspan(documentTypeSelect, 1);
+        generalEducationDocumentsLayout.setColspan(distinctionCheckbox, 1);
+        generalEducationDocumentsLayout.setColspan(institutionNameField, 2);
+        generalEducationDocumentsLayout.setColspan(institutionNameEngField, 2);
+
+        generalEducationDocumentsWrapper.add(generalEducationDocumentsTitle, generalEducationDocumentsLayout);
+
+        diplomaDocumentsWrapper = new Div();
+        diplomaDocumentsWrapper.getStyle().set("border", "1px solid #ddd");
+        diplomaDocumentsWrapper.getStyle().set("border-radius", "8px");
+        diplomaDocumentsWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
+        diplomaDocumentsWrapper.getStyle().set("padding", "20px");
+        diplomaDocumentsWrapper.getStyle().set("position", "relative");
+        diplomaDocumentsWrapper.getStyle().set("background", "white");
+        diplomaDocumentsWrapper.getStyle().set("width", "97%");
+
+        Span diplomaSectionTitle = new Span("Диплом");
+        diplomaSectionTitle.getStyle().set("position", "absolute");
+        diplomaSectionTitle.getStyle().set("top", "-10px");
+        diplomaSectionTitle.getStyle().set("left", "20px");
+        diplomaSectionTitle.getStyle().set("background", "white");
+        diplomaSectionTitle.getStyle().set("padding", "0 10px");
+        diplomaSectionTitle.getStyle().set("font-weight", "bold");
+
+        HorizontalLayout diplomaLayout = new HorizontalLayout();
+        diplomaLayout.setWidthFull();
+        diplomaLayout.setSpacing(true);
+        diplomaLayout.add(diplomaSeriesField, diplomaNumberField, graduationDatePicker);
+        diplomaLayout.setFlexGrow(1, diplomaSeriesField, diplomaNumberField, graduationDatePicker);
+
+        FormLayout diplomaDocumentsLayout = new FormLayout();
+        diplomaDocumentsLayout.add(
+                diplomaLayout,
+                appendixNumberField,
+                thesisTitleUkrField,
+                thesisTitleEngField
+        );
+        diplomaDocumentsLayout.setResponsiveSteps(
+                new FormLayout.ResponsiveStep("0", 1),
+                new FormLayout.ResponsiveStep("500px", 1)
+        );
+
+        diplomaDocumentsWrapper.add(diplomaSectionTitle, diplomaDocumentsLayout);
+
+        setWidth("100%");
+        getStyle().set("padding", "0px");
+        add(generalEducationDocumentsWrapper, diplomaDocumentsWrapper);
+    }
+
+    public Div getGeneralEducationDocumentsWrapper() {
+        return generalEducationDocumentsWrapper;
+    }
+
+    public Div getDiplomaDocumentsWrapper() {
+        return diplomaDocumentsWrapper;
+    }
+}

--- a/src/main/java/com/esvar/dekanat/card/CardFieldUtil.java
+++ b/src/main/java/com/esvar/dekanat/card/CardFieldUtil.java
@@ -1,0 +1,98 @@
+package com.esvar.dekanat.card;
+
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.component.textfield.TextField;
+import com.esvar.dekanat.entity.Gender;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Small helpers for updating UI field values consistently without duplicating null checks.
+ */
+public final class CardFieldUtil {
+
+    private CardFieldUtil() {
+    }
+
+    public static void setTextFieldValue(TextField field, String value) {
+        if (value != null) {
+            field.setValue(value);
+        } else {
+            field.clear();
+        }
+    }
+
+    public static void setSelectValue(Select<String> select, String value) {
+        if (value != null) {
+            select.setValue(value);
+        } else {
+            select.clear();
+        }
+    }
+
+    public static void setDatePickerValue(DatePicker picker, String value) {
+        if (value != null && !value.isBlank()) {
+            try {
+                picker.setValue(LocalDate.parse(value));
+            } catch (DateTimeParseException ignored) {
+                picker.clear();
+            }
+        } else {
+            picker.clear();
+        }
+    }
+
+    public static void setDatePickerValue(DatePicker picker, Date value) {
+        if (value != null) {
+            picker.setValue(value.toLocalDate());
+        } else {
+            picker.clear();
+        }
+    }
+
+    public static void setGenderValue(Select<String> genderSelect, Gender gender) {
+        if (gender != null) {
+            genderSelect.setValue(gender.name());
+        } else {
+            genderSelect.clear();
+        }
+    }
+
+    public static void setBenefitsValue(MultiSelectComboBox<String> benefitsSelect, String benefits) {
+        if (benefits != null && !benefits.isBlank()) {
+            Set<String> values = Arrays.stream(benefits.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            if (values.isEmpty()) {
+                benefitsSelect.clear();
+            } else {
+                benefitsSelect.setValue(values);
+            }
+        } else {
+            benefitsSelect.clear();
+        }
+    }
+
+    public static Gender resolveGenderValue(Select<String> select, Gender fallback) {
+        String value = select.getValue();
+        if (value != null) {
+            value = value.trim();
+            if (!value.isEmpty()) {
+                try {
+                    return Gender.valueOf(value);
+                } catch (IllegalArgumentException ignored) {
+                }
+            }
+        }
+        return fallback;
+    }
+}

--- a/src/main/java/com/esvar/dekanat/card/CardMainInfoView.java
+++ b/src/main/java/com/esvar/dekanat/card/CardMainInfoView.java
@@ -1,0 +1,88 @@
+package com.esvar.dekanat.card;
+
+import com.vaadin.flow.component.dependency.CssImport;
+import com.vaadin.flow.component.div.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.component.textfield.TextField;
+
+/**
+ * View responsible for the main (personal and academic) student data block.
+ * It keeps only layout and styling concerns; CardView orchestrates data flow.
+ */
+@CssImport(value = "./styles/card-main-info-view.css", themeFor = "vaadin-text-field")
+public class CardMainInfoView extends VerticalLayout {
+
+    public CardMainInfoView(TextField lastNameUkrField,
+                            TextField firstNameUkrField,
+                            TextField middleNameUkrField,
+                            TextField lastNameEngField,
+                            TextField firstNameEngField,
+                            Select<String> groupSelect,
+                            Select<String> courseSelect,
+                            TextField groupNumberField,
+                            Select<String> admissionYearSelect,
+                            TextField recordBookNumberField) {
+        HorizontalLayout leftLayout1Page = new HorizontalLayout();
+        HorizontalLayout rightLayout1Page = new HorizontalLayout();
+
+        Div leftLayoutWrapper = new Div();
+        leftLayoutWrapper.getStyle().set("border", "1px solid #ddd");
+        leftLayoutWrapper.getStyle().set("border-radius", "8px");
+        leftLayoutWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
+        leftLayoutWrapper.getStyle().set("padding", "20px");
+        leftLayoutWrapper.getStyle().set("position", "relative");
+        leftLayoutWrapper.getStyle().set("background", "white");
+
+        Span leftLayoutTitle = new Span("Персональні дані");
+        leftLayoutTitle.getStyle().set("position", "absolute");
+        leftLayoutTitle.getStyle().set("top", "-10px");
+        leftLayoutTitle.getStyle().set("left", "20px");
+        leftLayoutTitle.getStyle().set("background", "white");
+        leftLayoutTitle.getStyle().set("padding", "0 10px");
+        leftLayoutTitle.getStyle().set("font-weight", "bold");
+
+        leftLayoutWrapper.add(leftLayoutTitle, leftLayout1Page);
+
+        Div rightLayoutWrapper = new Div();
+        rightLayoutWrapper.getStyle().set("border", "1px solid #ddd");
+        rightLayoutWrapper.getStyle().set("border-radius", "8px");
+        rightLayoutWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
+        rightLayoutWrapper.getStyle().set("padding", "20px");
+        rightLayoutWrapper.getStyle().set("position", "relative");
+        rightLayoutWrapper.getStyle().set("background", "white");
+
+        Span rightLayoutTitle = new Span("Академічні дані");
+        rightLayoutTitle.getStyle().set("position", "absolute");
+        rightLayoutTitle.getStyle().set("top", "-10px");
+        rightLayoutTitle.getStyle().set("left", "20px");
+        rightLayoutTitle.getStyle().set("background", "white");
+        rightLayoutTitle.getStyle().set("padding", "0 10px");
+        rightLayoutTitle.getStyle().set("font-weight", "bold");
+
+        rightLayoutWrapper.add(rightLayoutTitle, rightLayout1Page);
+
+        lastNameUkrField.setWidth("24%");
+        firstNameUkrField.setWidth("24%");
+        middleNameUkrField.setWidth("24%");
+        lastNameEngField.setWidth("24%");
+        firstNameEngField.setWidth("24%");
+        groupSelect.setWidth("24%");
+        courseSelect.setWidth("24%");
+        groupNumberField.setWidth("24%");
+        admissionYearSelect.setWidth("24%");
+        recordBookNumberField.setWidth("24%");
+
+        leftLayout1Page.add(lastNameUkrField, firstNameUkrField, middleNameUkrField, lastNameEngField, firstNameEngField);
+        rightLayout1Page.add(groupSelect, courseSelect, groupNumberField, admissionYearSelect, recordBookNumberField);
+
+        setWidth("100%");
+        getStyle().set("padding", "0px");
+        leftLayoutWrapper.getStyle().set("width", "97%");
+        rightLayoutWrapper.getStyle().set("width", "97%");
+
+        add(leftLayoutWrapper, rightLayoutWrapper);
+    }
+}

--- a/src/main/java/com/esvar/dekanat/card/CardPassportInfoView.java
+++ b/src/main/java/com/esvar/dekanat/card/CardPassportInfoView.java
@@ -1,0 +1,54 @@
+package com.esvar.dekanat.card;
+
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.div.Div;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.component.textfield.TextField;
+
+/**
+ * View responsible for the passport-related data block.
+ */
+public class CardPassportInfoView extends VerticalLayout {
+
+    public CardPassportInfoView(TextField passportSeriesField,
+                                TextField passportNumberField,
+                                DatePicker passportIssueDatePicker,
+                                DatePicker passportExpiryDatePicker,
+                                TextField passportIssuedByField,
+                                TextField idCodeField,
+                                TextField unzrField,
+                                DatePicker birthDatePicker,
+                                Select<String> nationalityField,
+                                Select<String> genderSelect,
+                                TextField personNumberEDEBOField,
+                                TextField studentCardNumberEDEBOField) {
+
+        Div passportDetailsWrapper = new Div();
+        passportDetailsWrapper.getStyle().set("border", "1px solid #ddd");
+        passportDetailsWrapper.getStyle().set("border-radius", "8px");
+        passportDetailsWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
+        passportDetailsWrapper.getStyle().set("padding", "20px");
+        passportDetailsWrapper.getStyle().set("position", "relative");
+        passportDetailsWrapper.getStyle().set("background", "white");
+
+        Span passportDetailsTitle = new Span("Паспортні дані");
+        passportDetailsTitle.getStyle().set("position", "absolute");
+        passportDetailsTitle.getStyle().set("top", "-10px");
+        passportDetailsTitle.getStyle().set("left", "20px");
+        passportDetailsTitle.getStyle().set("background", "white");
+        passportDetailsTitle.getStyle().set("padding", "0 10px");
+        passportDetailsTitle.getStyle().set("font-weight", "bold");
+
+        FormLayout passportDetailsLayout = new FormLayout();
+        passportDetailsLayout.add(passportSeriesField, passportNumberField, passportIssueDatePicker, passportExpiryDatePicker, passportIssuedByField, idCodeField, unzrField, birthDatePicker, nationalityField, genderSelect, personNumberEDEBOField, studentCardNumberEDEBOField);
+
+        passportDetailsWrapper.add(passportDetailsTitle, passportDetailsLayout);
+
+        setWidth("100%");
+        getStyle().set("padding", "0px");
+        add(passportDetailsWrapper);
+    }
+}

--- a/src/main/java/com/esvar/dekanat/card/CardView.java
+++ b/src/main/java/com/esvar/dekanat/card/CardView.java
@@ -1,22 +1,29 @@
 package com.esvar.dekanat.card;
 
+// Responsibility groups observed in this view:
+// - UI rendering/layout: building tabs, form layouts, and styling for personal, academic, passport, and education sections.
+// - Event handling: reacting to selector changes, button clicks, and enabling/disabling form fields.
+// - Data coordination: loading student/group data from services, validating selections, and persisting academic changes.
+// - Group code management: constructing and interpreting group codes from prefixes, courses, numbers, and graduation years.
+// - PDF export: generating printable group student lists.
+// - Helper utilities: repetitive field value setters and parsing helpers.
+
+/*
+Proposed target structure after refactoring:
+- CardView: orchestration layer that wires UI sections, delegates to helpers, and remains the Vaadin route.
+- CardFieldUtil: shared helper for safely updating field values and parsing user input (extracted).
+- GroupCodeBuilder: encapsulates group code construction logic (extracted).
+- StudentListPdfGenerator: encapsulates PDF creation and streaming for student lists (extracted).
+Future candidates:
+- Dedicated UI section components (personal data, academic data, passport data) to reduce constructor size. // TODO: decouple further
+*/
+
 
 import com.esvar.dekanat.dto.GroupDTO;
 import com.esvar.dekanat.entity.*;
 import com.esvar.dekanat.repository.StudentRatingRepository;
 import com.esvar.dekanat.service.*;
 import com.esvar.dekanat.view.MainLayout;
-import com.itextpdf.io.font.PdfEncodings;
-import com.itextpdf.kernel.font.PdfFont;
-import com.itextpdf.kernel.font.PdfFontFactory;
-import com.itextpdf.kernel.geom.PageSize;
-import com.itextpdf.kernel.pdf.PdfDocument;
-import com.itextpdf.kernel.pdf.PdfWriter;
-import com.itextpdf.kernel.pdf.canvas.draw.SolidLine;
-import com.itextpdf.layout.Document;
-import com.itextpdf.layout.element.LineSeparator;
-import com.itextpdf.layout.element.Paragraph;
-import com.itextpdf.layout.properties.TextAlignment;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.checkbox.Checkbox;
@@ -39,20 +46,21 @@ import com.vaadin.flow.component.tabs.Tabs;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.server.StreamRegistration;
-import com.vaadin.flow.server.StreamResource;
-import com.vaadin.flow.server.StreamResourceWriter;
 import jakarta.annotation.security.PermitAll;
 
-import java.io.*;
 import java.sql.Date;
 import java.text.Collator;
 import java.time.LocalDate;
 import java.time.Year;
-import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static com.esvar.dekanat.card.CardFieldUtil.setBenefitsValue;
+import static com.esvar.dekanat.card.CardFieldUtil.setDatePickerValue;
+import static com.esvar.dekanat.card.CardFieldUtil.setGenderValue;
+import static com.esvar.dekanat.card.CardFieldUtil.setSelectValue;
+import static com.esvar.dekanat.card.CardFieldUtil.setTextFieldValue;
 
 
 //todo: Додати попередження при виході з сторінки чи оновленні сторінки якщо є незбережені дані
@@ -74,11 +82,10 @@ public class CardView extends Div {
     private final StudentReportService studentReportService;
     private final ReportService reportService;
     private final StudentRatingRepository ratingRepository;
+    private final GroupCodeBuilder groupCodeBuilder;
 
 
     private VerticalLayout mainLayout = new VerticalLayout();
-    private HorizontalLayout leftLayout1Page = new HorizontalLayout();
-    private HorizontalLayout rightLayout1Page = new HorizontalLayout();
     private HorizontalLayout selectors = new HorizontalLayout();
     private Select<String> selectStudent = new Select<>();
     private ComboBox<String> selectGroup = new ComboBox<>();
@@ -169,6 +176,7 @@ public class CardView extends Div {
         this.reportService = reportService;
         this.ratingRepository = ratingRepository;
         this.specialtyService = specialtyService;
+        this.groupCodeBuilder = new GroupCodeBuilder(specialtyService);
         this.ukrainianCollator = Collator.getInstance(new Locale("uk", "UA"));
         this.pendingCreatedGroupId = null;
 
@@ -431,7 +439,7 @@ public class CardView extends Div {
                 return;
             }
 
-            generateAndSend(selectedGroup, students);
+            StudentListPdfGenerator.generateAndSend(selectedGroup, students);
         });
 
 
@@ -455,54 +463,7 @@ public class CardView extends Div {
             }
         });
 
-        // Add border and title to leftLayout1Page
-        Div leftLayoutWrapper = new Div();
-        leftLayoutWrapper.getStyle().set("border", "1px solid #ddd");
-        leftLayoutWrapper.getStyle().set("border-radius", "8px");
-        leftLayoutWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
-        leftLayoutWrapper.getStyle().set("padding", "20px");
-        leftLayoutWrapper.getStyle().set("position", "relative");
-        leftLayoutWrapper.getStyle().set("background", "white");
-
-        Span leftLayoutTitle = new Span("Персональні дані");
-        leftLayoutTitle.getStyle().set("position", "absolute");
-        leftLayoutTitle.getStyle().set("top", "-10px");
-        leftLayoutTitle.getStyle().set("left", "20px");
-        leftLayoutTitle.getStyle().set("background", "white");
-        leftLayoutTitle.getStyle().set("padding", "0 10px");
-        leftLayoutTitle.getStyle().set("font-weight", "bold");
-
-        leftLayoutWrapper.add(leftLayoutTitle, leftLayout1Page);
-
-        // Add border and title to rightLayout1Page
-        Div rightLayoutWrapper = new Div();
-        rightLayoutWrapper.getStyle().set("border", "1px solid #ddd");
-        rightLayoutWrapper.getStyle().set("border-radius", "8px");
-        rightLayoutWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
-        rightLayoutWrapper.getStyle().set("padding", "20px");
-        rightLayoutWrapper.getStyle().set("position", "relative");
-        rightLayoutWrapper.getStyle().set("background", "white");
-
-        Span rightLayoutTitle = new Span("Академічні дані");
-        rightLayoutTitle.getStyle().set("position", "absolute");
-        rightLayoutTitle.getStyle().set("top", "-10px");
-        rightLayoutTitle.getStyle().set("left", "20px");
-        rightLayoutTitle.getStyle().set("background", "white");
-        rightLayoutTitle.getStyle().set("padding", "0 10px");
-        rightLayoutTitle.getStyle().set("font-weight", "bold");
-
-        rightLayoutWrapper.add(rightLayoutTitle, rightLayout1Page);
-
-        leftLayout1Page.add(lastNameUkrField, firstNameUkrField, middleNameUkrField, lastNameEngField, firstNameEngField);
-        rightLayout1Page.add(groupSelect, courseSelect, groupNumberField, admissionYearSelect, recordBookNumberField);
-
-        // Layout for main info text fields
-        VerticalLayout mainInfoLayout = new VerticalLayout();
-        mainInfoLayout.setWidth("100%");
-        mainInfoLayout.add(leftLayoutWrapper, rightLayoutWrapper);
-        mainInfoLayout.getStyle().set("padding", "0px");
-        leftLayoutWrapper.getStyle().set("width", "97%");
-        rightLayoutWrapper.getStyle().set("width", "97%");
+        CardMainInfoView mainInfoView = new CardMainInfoView(lastNameUkrField, firstNameUkrField, middleNameUkrField, lastNameEngField, firstNameEngField, groupSelect, courseSelect, groupNumberField, admissionYearSelect, recordBookNumberField);
 
 // Additional info text fields
         caseNumberField = new TextField("Номер справи");
@@ -690,272 +651,25 @@ public class CardView extends Div {
         });
 
 
-// Group 2: Address Details
-        Div addressDetailsWrapper = new Div();
-        addressDetailsWrapper.getStyle().set("border", "1px solid #ddd");
-        addressDetailsWrapper.getStyle().set("border-radius", "8px");
-        addressDetailsWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
-        addressDetailsWrapper.getStyle().set("padding", "20px");
-        addressDetailsWrapper.getStyle().set("position", "relative");
-        addressDetailsWrapper.getStyle().set("background", "white");
-        addressDetailsWrapper.getStyle().set("width", "97%"); // Set the width to 97%
 
-        Span addressDetailsTitle = new Span("Адреса");
-        addressDetailsTitle.getStyle().set("position", "absolute");
-        addressDetailsTitle.getStyle().set("top", "-10px");
-        addressDetailsTitle.getStyle().set("left", "20px");
-        addressDetailsTitle.getStyle().set("background", "white");
-        addressDetailsTitle.getStyle().set("padding", "0 10px");
-        addressDetailsTitle.getStyle().set("font-weight", "bold");
+        CardAdditionalInfoView additionalInfoView = new CardAdditionalInfoView(caseNumberField, educationFormSelect, degreeSelect, admissionConditionSelect, paymentSourceSelect, contractNumberField, amountField, benefitsSelect, regionSelect, indexField, fullAddressField, phoneNumberField, emailField);
+        CardPassportInfoView passportInfoView = new CardPassportInfoView(passportSeriesField, passportNumberField, passportIssueDatePicker, passportExpiryDatePicker, passportIssuedByField, idCodeField, unzrField, birthDatePicker, nationalityField, genderSelect, personNumberEDEBOField, studentCardNumberEDEBOField);
+        CardEducationDocumentsView educationDocumentsView = new CardEducationDocumentsView(documentTypeSelect, distinctionCheckbox, documentSeriesField, documentNumberField, documentIssueDatePicker, institutionNameField, institutionNameEngField, diplomaSeriesField, diplomaNumberField, graduationDatePicker, appendixNumberField, thesisTitleUkrField, thesisTitleEngField);
 
-        FormLayout addressDetailsLayout = new FormLayout();
-        addressDetailsLayout.add(regionSelect, indexField, fullAddressField);
-        addressDetailsLayout.setResponsiveSteps(
-                new FormLayout.ResponsiveStep("0", 1), // 1 column for narrow layout
-                new FormLayout.ResponsiveStep("500px", 2) // 2 columns for wider layout
-        );
-        addressDetailsLayout.setColspan(fullAddressField, 2);
-
-        addressDetailsWrapper.add(addressDetailsTitle, addressDetailsLayout);
-
-// Group 3: Passport Details
-        Div passportDetailsWrapper = new Div();
-        passportDetailsWrapper.getStyle().set("border", "1px solid #ddd");
-        passportDetailsWrapper.getStyle().set("border-radius", "8px");
-        passportDetailsWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
-        passportDetailsWrapper.getStyle().set("padding", "20px");
-        passportDetailsWrapper.getStyle().set("position", "relative");
-        passportDetailsWrapper.getStyle().set("background", "white");
-
-        Span passportDetailsTitle = new Span("Паспортні дані");
-        passportDetailsTitle.getStyle().set("position", "absolute");
-        passportDetailsTitle.getStyle().set("top", "-10px");
-        passportDetailsTitle.getStyle().set("left", "20px");
-        passportDetailsTitle.getStyle().set("background", "white");
-        passportDetailsTitle.getStyle().set("padding", "0 10px");
-        passportDetailsTitle.getStyle().set("font-weight", "bold");
-
-        FormLayout passportDetailsLayout = new FormLayout();
-        passportDetailsLayout.add(passportSeriesField, passportNumberField, passportIssueDatePicker, passportExpiryDatePicker, passportIssuedByField, idCodeField, unzrField, birthDatePicker, nationalityField, genderSelect, personNumberEDEBOField, studentCardNumberEDEBOField);
-
-        passportDetailsWrapper.add(passportDetailsTitle, passportDetailsLayout);
-
-// Group 4: Education Details
-        Div educationDetailsWrapper = new Div();
-        educationDetailsWrapper.getStyle().set("border", "1px solid #ddd");
-        educationDetailsWrapper.getStyle().set("border-radius", "8px");
-        educationDetailsWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
-        educationDetailsWrapper.getStyle().set("padding", "20px");
-        educationDetailsWrapper.getStyle().set("position", "relative");
-        educationDetailsWrapper.getStyle().set("background", "white");
-        educationDetailsWrapper.getStyle().set("width", "97%"); // Set the width to 97%
-
-        Span educationDetailsTitle = new Span("Дані про навчання");
-        educationDetailsTitle.getStyle().set("position", "absolute");
-        educationDetailsTitle.getStyle().set("top", "-10px");
-        educationDetailsTitle.getStyle().set("left", "20px");
-        educationDetailsTitle.getStyle().set("background", "white");
-        educationDetailsTitle.getStyle().set("padding", "0 10px");
-        educationDetailsTitle.getStyle().set("font-weight", "bold");
-
-        FormLayout educationDetailsLayout = new FormLayout();
-        educationDetailsLayout.add(caseNumberField, educationFormSelect, degreeSelect, admissionConditionSelect, paymentSourceSelect, contractNumberField, amountField, benefitsSelect);
-
-        educationDetailsWrapper.add(educationDetailsTitle, educationDetailsLayout);
-
-        // Group 4: Education Details
-        Div contactDetailsWrapper = new Div();
-        contactDetailsWrapper.getStyle().set("border", "1px solid #ddd");
-        contactDetailsWrapper.getStyle().set("border-radius", "8px");
-        contactDetailsWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
-        contactDetailsWrapper.getStyle().set("padding", "20px");
-        contactDetailsWrapper.getStyle().set("position", "relative");
-        contactDetailsWrapper.getStyle().set("background", "white");
-        contactDetailsWrapper.getStyle().set("width", "97%"); // Set the width to 97%
-
-        Span contactDetailsTitle = new Span("Контактні дані");
-        contactDetailsTitle.getStyle().set("position", "absolute");
-        contactDetailsTitle.getStyle().set("top", "-10px");
-        contactDetailsTitle.getStyle().set("left", "20px");
-        contactDetailsTitle.getStyle().set("background", "white");
-        contactDetailsTitle.getStyle().set("padding", "0 10px");
-        contactDetailsTitle.getStyle().set("font-weight", "bold");
-
-        FormLayout contactDetailsLayout = new FormLayout();
-        contactDetailsLayout.add(phoneNumberField, emailField);
-
-        contactDetailsWrapper.add(contactDetailsTitle, contactDetailsLayout);
-
-// Layout for additional info text fields
-        VerticalLayout additionalInfoLayout = new VerticalLayout();
-        additionalInfoLayout.setWidth("100%");
-        additionalInfoLayout.add(educationDetailsWrapper, contactDetailsWrapper, addressDetailsWrapper);
-        additionalInfoLayout.getStyle().set("padding", "0px");
-
-        VerticalLayout passportInfoLayout = new VerticalLayout();
-        passportInfoLayout.setWidth("100%");
-        passportInfoLayout.add(passportDetailsWrapper);
-        passportInfoLayout.getStyle().set("padding", "0px");
-
-// Group 1: General Education Documents
-        Div generalEducationDocumentsWrapper = new Div();
-        generalEducationDocumentsWrapper.getStyle().set("border", "1px solid #ddd");
-        generalEducationDocumentsWrapper.getStyle().set("border-radius", "8px");
-        generalEducationDocumentsWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
-        generalEducationDocumentsWrapper.getStyle().set("padding", "20px");
-        generalEducationDocumentsWrapper.getStyle().set("position", "relative");
-        generalEducationDocumentsWrapper.getStyle().set("background", "white");
-        generalEducationDocumentsWrapper.getStyle().set("width", "97%"); // Set the width to 97%
-
-        Span generalEducationDocumentsTitle = new Span("Попередня освіта");
-        generalEducationDocumentsTitle.getStyle().set("position", "absolute");
-        generalEducationDocumentsTitle.getStyle().set("top", "-10px");
-        generalEducationDocumentsTitle.getStyle().set("left", "20px");
-        generalEducationDocumentsTitle.getStyle().set("background", "white");
-        generalEducationDocumentsTitle.getStyle().set("padding", "0 10px");
-        generalEducationDocumentsTitle.getStyle().set("font-weight", "bold");
-
-        documentSeriesField = new TextField("Серія документу");
-        documentNumberField = new TextField("№ документу");
-        documentNumberField.setPattern("[0-9]{1,}");
-        documentNumberField.addValueChangeListener(event -> {
-            String value = event.getValue();
-            if (value.matches("[0-9]+")) {
-                documentNumberField.setErrorMessage(null);
-            } else {
-                documentNumberField.setErrorMessage("Введіть тільки цифри");
-                Notification.show("Неправильний ввід. Введіть тільки цифри.");
-            }
-        });
-        documentIssueDatePicker = new DatePicker("Дата видачі");
-        documentIssueDatePicker.setI18n(setLocal());
-        institutionNameField = new TextField("Назва навчального закладу");
-        institutionNameEngField = new TextField("Назва навчального закладу (англ)");
-        distinctionCheckbox = new Checkbox("З відзнакою");
-
-// Create the dropdown (select) field for document type
-        documentTypeSelect = new Select<>();
-        documentTypeSelect.setLabel("Тип документу");
-        documentTypeSelect.setItems("Атестат", "Диплом", "Сертифікат", "Інший");
-        documentTypeSelect.setPlaceholder("Оберіть тип документу");
-
-// Arrange the fields in a FormLayout
-        FormLayout generalEducationDocumentsLayout = new FormLayout();
-
-// Create a horizontal layout for the series, number, and date fields
-        HorizontalLayout seriesNumberDateLayout = new HorizontalLayout();
-        seriesNumberDateLayout.setWidthFull(); // Make the horizontal layout full width
-        seriesNumberDateLayout.setSpacing(true); // Add spacing between the fields
-        seriesNumberDateLayout.add(documentSeriesField, documentNumberField, documentIssueDatePicker);
-        seriesNumberDateLayout.setFlexGrow(1, documentSeriesField, documentNumberField, documentIssueDatePicker); // Make each field take up equal space
-
-// Add components to the FormLayout
-        generalEducationDocumentsLayout.add(
-                documentTypeSelect,
-                distinctionCheckbox,
-                seriesNumberDateLayout,
-                institutionNameField,
-                institutionNameEngField
-        );
-
-// Set responsive steps
-        generalEducationDocumentsLayout.setResponsiveSteps(
-                new FormLayout.ResponsiveStep("0", 1), // 1 column for narrow layout
-                new FormLayout.ResponsiveStep("500px", 1) // 2 columns for wider layout
-        );
-
-// Set colspan for distinctionCheckbox to align it properly
-        generalEducationDocumentsLayout.setColspan(distinctionCheckbox, 1);
-
-        generalEducationDocumentsWrapper.add(generalEducationDocumentsTitle, generalEducationDocumentsLayout);
-
-// Group 2: Diploma-Specific Fields
-        Div diplomaDocumentsWrapper = new Div();
-        diplomaDocumentsWrapper.getStyle().set("border", "1px solid #ddd");
-        diplomaDocumentsWrapper.getStyle().set("border-radius", "8px");
-        diplomaDocumentsWrapper.getStyle().set("box-shadow", "0 2px 4px rgba(0, 0, 0, 0.1)");
-        diplomaDocumentsWrapper.getStyle().set("padding", "20px");
-        diplomaDocumentsWrapper.getStyle().set("position", "relative");
-        diplomaDocumentsWrapper.getStyle().set("background", "white");
-        diplomaDocumentsWrapper.getStyle().set("width", "97%"); // Set the width to 97%
-
-        Span diplomaSectionTitle = new Span("Диплом");
-        diplomaSectionTitle.getStyle().set("position", "absolute");
-        diplomaSectionTitle.getStyle().set("top", "-10px");
-        diplomaSectionTitle.getStyle().set("left", "20px");
-        diplomaSectionTitle.getStyle().set("background", "white");
-        diplomaSectionTitle.getStyle().set("padding", "0 10px");
-        diplomaSectionTitle.getStyle().set("font-weight", "bold");
-
-// Add new fields for the diploma
-        diplomaSeriesField = new TextField("Серія диплому");
-        diplomaNumberField = new TextField("№ диплому");
-        diplomaNumberField.setPattern("[0-9]{1,}");
-        diplomaNumberField.addValueChangeListener(event -> {
-            String value = event.getValue();
-            if (value.matches("[0-9]+")) {
-                diplomaNumberField.setErrorMessage(null);
-            } else {
-                diplomaNumberField.setErrorMessage("Введіть тільки цифри");
-                Notification.show("Неправильний ввід. Введіть тільки цифри.");
-            }
-        });
-        graduationDatePicker = new DatePicker("Дата випуску");
-        graduationDatePicker.setI18n(setLocal());
-        appendixNumberField = new TextField("Номер додатку");
-        appendixNumberField.setPattern("[0-9]{1,}");
-        appendixNumberField.addValueChangeListener(event -> {
-            String value = event.getValue();
-            if (value.matches("[0-9]+")) {
-                appendixNumberField.setErrorMessage(null);
-            } else {
-                appendixNumberField.setErrorMessage("Введіть тільки цифри");
-                Notification.show("Неправильний ввід. Введіть тільки цифри.");
-            }
-        });
-        thesisTitleUkrField = new TextField("Тема дипломної роботи (укр)");
-        thesisTitleEngField = new TextField("Тема дипломної роботи (англ)");
-
-// Create a horizontal layout for the diploma series, number, and graduation date fields
-        HorizontalLayout diplomaLayout = new HorizontalLayout();
-        diplomaLayout.setWidthFull();
-        diplomaLayout.setSpacing(true);
-        diplomaLayout.add(diplomaSeriesField, diplomaNumberField, graduationDatePicker);
-        diplomaLayout.setFlexGrow(1, diplomaSeriesField, diplomaNumberField, graduationDatePicker); // Equal space for fields
-
-// Arrange diploma-specific fields in a FormLayout
-        FormLayout diplomaDocumentsLayout = new FormLayout();
-        diplomaDocumentsLayout.add(
-                diplomaLayout,
-                appendixNumberField,
-                thesisTitleUkrField,
-                thesisTitleEngField
-        );
-
-// Set responsive steps
-        diplomaDocumentsLayout.setResponsiveSteps(
-                new FormLayout.ResponsiveStep("0", 1),
-                new FormLayout.ResponsiveStep("500px", 1)
-        );
-
-        diplomaDocumentsWrapper.add(diplomaSectionTitle, diplomaDocumentsLayout);
-
-
-        // Update tab selection listener to include the new tab
         tabs.addSelectedChangeListener(event -> {
             mainLayout.removeAll();
             if (tabs.getSelectedTab().equals(mainInfoTab)) {
-                mainLayout.add(buttonLayout, tabs, mainInfoLayout, orderLayout);
+                mainLayout.add(buttonLayout, tabs, mainInfoView, orderLayout);
             } else if (tabs.getSelectedTab().equals(additionalInfoTab)) {
-                mainLayout.add(buttonLayout, tabs, additionalInfoLayout);
+                mainLayout.add(buttonLayout, tabs, additionalInfoView);
             } else if (tabs.getSelectedTab().equals(passportInfoTab)) {
-                mainLayout.add(buttonLayout, tabs, passportInfoLayout);
+                mainLayout.add(buttonLayout, tabs, passportInfoView);
             } else if (tabs.getSelectedTab().equals(educationDocumentsTab)) {
-                mainLayout.add(buttonLayout, tabs, generalEducationDocumentsWrapper, diplomaDocumentsWrapper);
+                mainLayout.add(buttonLayout, tabs, educationDocumentsView.getGeneralEducationDocumentsWrapper(), educationDocumentsView.getDiplomaDocumentsWrapper());
             }
         });
 
-        mainLayout.add(buttonLayout, tabs, mainInfoLayout, orderLayout);
+        mainLayout.add(buttonLayout, tabs, mainInfoView, orderLayout);
         mainLayout.setWidth("100%");
         mainLayout.setHeight("100%");
         mainLayout.setAlignItems(FlexComponent.Alignment.CENTER);
@@ -1382,46 +1096,23 @@ public class CardView extends Div {
     }
 
     private String buildGroupCode(String groupPrefix, String course, String groupNumber, String graduationYear) {
-        SpecialtyEntity specialty = specialtyService.getSpecialtyByAbbreviation(groupPrefix);
-        String eduProgramCode = buildGroupCodeWithEduProgram(groupPrefix, course, groupNumber, graduationYear, specialty);
-        if (eduProgramCode != null) {
-            return eduProgramCode;
-        }
-        String specialtyCode = buildGroupCodeWithSpecialtySuffix(groupPrefix, course, groupNumber, graduationYear, specialty);
-        if (specialtyCode != null) {
-            return specialtyCode;
-        }
-        return buildLegacyGroupCode(groupPrefix, course, groupNumber, graduationYear);
+        return groupCodeBuilder.buildGroupCode(groupPrefix, course, groupNumber, graduationYear);
     }
 
     private String buildGroupCode(String groupPrefix, String course, String groupNumber, String graduationYear, SpecialtyEntity specialty) {
-        String eduProgramCode = buildGroupCodeWithEduProgram(groupPrefix, course, groupNumber, graduationYear, specialty);
-        if (eduProgramCode != null) {
-            return eduProgramCode;
-        }
-        String specialtyCode = buildGroupCodeWithSpecialtySuffix(groupPrefix, course, groupNumber, graduationYear, specialty);
-        if (specialtyCode != null) {
-            return specialtyCode;
-        }
-        return buildLegacyGroupCode(groupPrefix, course, groupNumber, graduationYear);
+        return groupCodeBuilder.buildGroupCode(groupPrefix, course, groupNumber, graduationYear, specialty);
     }
 
     private String buildGroupCodeWithEduProgram(String groupPrefix, String course, String groupNumber, String graduationYear, SpecialtyEntity specialty) {
-        if (specialty != null && specialty.getEduProgram() != null && specialty.getEduProgram().getId() > 0) {
-            return String.format("%s-%s-%s-%s(%d)", groupPrefix, course, groupNumber, graduationYear, specialty.getEduProgram().getId());
-        }
-        return null;
+        return groupCodeBuilder.buildGroupCodeWithEduProgram(groupPrefix, course, groupNumber, graduationYear, specialty);
     }
 
     private String buildGroupCodeWithSpecialtySuffix(String groupPrefix, String course, String groupNumber, String graduationYear, SpecialtyEntity specialty) {
-        if (specialty != null && specialty.getId() != null) {
-            return String.format("%s-%s-%s-%s(%d)", groupPrefix, course, groupNumber, graduationYear, specialty.getId());
-        }
-        return null;
+        return groupCodeBuilder.buildGroupCodeWithSpecialtySuffix(groupPrefix, course, groupNumber, graduationYear, specialty);
     }
 
     private String buildLegacyGroupCode(String groupPrefix, String course, String groupNumber, String graduationYear) {
-        return String.format("%s-%s-%s-%s", groupPrefix, course, groupNumber, graduationYear);
+        return groupCodeBuilder.buildLegacyGroupCode(groupPrefix, course, groupNumber, graduationYear);
     }
 
     private void promptGroupCreation() {
@@ -1898,80 +1589,6 @@ public class CardView extends Div {
         return fallback;
     }
 
-    private Gender resolveGenderValue(Select<String> select, Gender fallback) {
-        String value = select.getValue();
-        if (value != null) {
-            value = value.trim();
-            if (!value.isEmpty()) {
-                try {
-                    return Gender.valueOf(value);
-                } catch (IllegalArgumentException ignored) {
-                }
-            }
-        }
-        return fallback;
-    }
-
-    private void setTextFieldValue(TextField field, String value) {
-        if (value != null) {
-            field.setValue(value);
-        } else {
-            field.clear();
-        }
-    }
-
-    private void setSelectValue(Select<String> select, String value) {
-        if (value != null) {
-            select.setValue(value);
-        } else {
-            select.clear();
-        }
-    }
-
-    private void setDatePickerValue(DatePicker picker, String value) {
-        if (value != null && !value.isBlank()) {
-            try {
-                picker.setValue(LocalDate.parse(value));
-            } catch (DateTimeParseException ignored) {
-                picker.clear();
-            }
-        } else {
-            picker.clear();
-        }
-    }
-
-    private void setDatePickerValue(DatePicker picker, Date value) {
-        if (value != null) {
-            picker.setValue(value.toLocalDate());
-        } else {
-            picker.clear();
-        }
-    }
-
-    private void setGenderValue(Gender gender) {
-        if (gender != null) {
-            genderSelect.setValue(gender.name());
-        } else {
-            genderSelect.clear();
-        }
-    }
-
-    private void setBenefitsValue(String benefits) {
-        if (benefits != null && !benefits.isBlank()) {
-            Set<String> values = Arrays.stream(benefits.split(","))
-                    .map(String::trim)
-                    .filter(s -> !s.isEmpty())
-                    .collect(Collectors.toCollection(LinkedHashSet::new));
-            if (values.isEmpty()) {
-                benefitsSelect.clear();
-            } else {
-                benefitsSelect.setValue(values);
-            }
-        } else {
-            benefitsSelect.clear();
-        }
-    }
-
     private String getGroupPart(String[] parts, int index) {
         if (parts.length <= index) {
             return null;
@@ -1997,135 +1614,6 @@ public class CardView extends Div {
                 .map(MainLayout.class::cast)
                 .findFirst()
                 .orElse(null);
-    }
-
-    public static void generateAndSend(String title, List<String> students) {
-        UI ui = UI.getCurrent();
-        if (ui == null) {
-            throw new IllegalStateException(
-                    "UI.getCurrent() == null. Викликати generateAndSend треба з UI-потоку Vaadin (наприклад у кнопці)."
-            );
-        }
-
-        try {
-            // 1. Почистити та відсортувати студентів
-            List<String> sortedStudents = prepareStudents(students);
-
-            // 2. Генеруємо PDF як масив байтів
-            byte[] pdfBytes = buildPdfBytes(title, sortedStudents);
-
-            // 3. Формуємо ім'я файла
-            String fileName = sanitizeFilename(title) + "-list.pdf";
-
-            // 4. Створюємо StreamResource
-            StreamResource resource = new StreamResource(
-                    fileName,
-                    (StreamResourceWriter) (outputStream, session) -> {
-                        try (InputStream in = new ByteArrayInputStream(pdfBytes)) {
-                            in.transferTo(outputStream);
-                        } catch (IOException ioException) {
-                            throw new UncheckedIOException(ioException);
-                        }
-                    }
-            );
-
-            resource.setContentType("application/pdf");
-            resource.setCacheTime(0); // щоб завжди було свіже
-
-            // 5. Реєструємо і відкриваємо у новій вкладці
-            StreamRegistration registration = ui.getSession()
-                    .getResourceRegistry()
-                    .registerResource(resource);
-
-            String resourceUrl = registration.getResourceUri().toString();
-            ui.getPage().open(resourceUrl, "_blank");
-
-        } catch (Exception e) {
-            throw new RuntimeException("Не вдалося згенерувати або відкрити PDF", e);
-        }
-    }
-
-
-    // ------------------ ВНУТРІШНІ ХЕЛПЕРИ ------------------ //
-
-    /**
-     * Чистить список від null/порожніх і сортує за українською абеткою.
-     */
-    private static List<String> prepareStudents(List<String> students) {
-        List<String> cleaned = new ArrayList<>();
-        for (String s : students) {
-            if (s != null && !s.isBlank()) {
-                cleaned.add(s.trim());
-            }
-        }
-
-        Collator uaCollator = Collator.getInstance(new Locale("uk", "UA"));
-        cleaned.sort(uaCollator);
-
-        return cleaned;
-    }
-
-    /**
-     * Створює PDF в оперативній пам'яті і повертає як масив байтів.
-     * Нічого не зберігає на диск.
-     */
-    private static byte[] buildPdfBytes(String groupName, List<String> sortedStudents) throws Exception {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PdfWriter writer = new PdfWriter(baos);
-        PdfDocument pdfDoc = new PdfDocument(writer);
-        pdfDoc.setDefaultPageSize(PageSize.A4);
-
-        Document doc = new Document(pdfDoc);
-        doc.setMargins(36, 36, 36, 36); // приблизно 1 см поля
-
-        // 1. Підвантажити шрифт з classpath, щоб кирилиця не поламалась
-        //    /fonts/DejaVuSans.ttf повинен бути у resources всередині твого jar
-        PdfFont font;
-        try (InputStream fontStream = CardView.class
-                .getResourceAsStream("/fonts/times.ttf")) {
-
-            if (fontStream == null) {
-                throw new IllegalStateException("Не знайдено /fonts/DejaVuSans.ttf у resources.");
-            }
-
-            byte[] fontBytes = fontStream.readAllBytes();
-            font = PdfFontFactory.createFont(fontBytes, PdfEncodings.IDENTITY_H);
-        }
-        doc.setFont(font);
-
-        // 2. Назва групи по центру, жирним, трішки більшим
-        Paragraph titleP = new Paragraph(groupName)
-                .setFontSize(14)
-                .setTextAlignment(TextAlignment.CENTER)
-                .setMarginBottom(4f);
-        doc.add(titleP);
-
-        // 3. Горизонтальна лінія під назвою
-        LineSeparator line = new LineSeparator(new SolidLine(1f));
-        line.setMarginBottom(16f);
-        doc.add(line);
-
-        // 4. Пронумерований список студентів
-        int idx = 1;
-        for (String student : sortedStudents) {
-            Paragraph row = new Paragraph(idx + ". " + student)
-                    .setFontSize(12)
-                    .setMarginBottom(4f);
-            doc.add(row);
-            idx++;
-        }
-
-        doc.close(); // флашить усе у baos
-        return baos.toByteArray();
-    }
-
-    /**
-     * Робимо чисте ім'я файлу. Дозволяємо кирилицю, цифри, дефіс, підкреслення і крапку.
-     */
-    private static String sanitizeFilename(String in) {
-        if (in == null || in.isBlank()) return "group";
-        return in.replaceAll("[^a-zA-Z0-9\\u0400-\\u04FF\\-_.]", "_");
     }
 
     private List<String> fetchStudentNames(String groupCode) {

--- a/src/main/java/com/esvar/dekanat/card/GroupCodeBuilder.java
+++ b/src/main/java/com/esvar/dekanat/card/GroupCodeBuilder.java
@@ -1,0 +1,59 @@
+package com.esvar.dekanat.card;
+
+import com.esvar.dekanat.entity.SpecialtyEntity;
+import com.esvar.dekanat.service.SpecialtyService;
+
+/**
+ * Responsible for constructing group codes based on specialty and educational program data.
+ */
+public class GroupCodeBuilder {
+
+    private final SpecialtyService specialtyService;
+
+    public GroupCodeBuilder(SpecialtyService specialtyService) {
+        this.specialtyService = specialtyService;
+    }
+
+    public String buildGroupCode(String groupPrefix, String course, String groupNumber, String graduationYear) {
+        SpecialtyEntity specialty = specialtyService.getSpecialtyByAbbreviation(groupPrefix);
+        String eduProgramCode = buildGroupCodeWithEduProgram(groupPrefix, course, groupNumber, graduationYear, specialty);
+        if (eduProgramCode != null) {
+            return eduProgramCode;
+        }
+        String specialtyCode = buildGroupCodeWithSpecialtySuffix(groupPrefix, course, groupNumber, graduationYear, specialty);
+        if (specialtyCode != null) {
+            return specialtyCode;
+        }
+        return buildLegacyGroupCode(groupPrefix, course, groupNumber, graduationYear);
+    }
+
+    public String buildGroupCode(String groupPrefix, String course, String groupNumber, String graduationYear, SpecialtyEntity specialty) {
+        String eduProgramCode = buildGroupCodeWithEduProgram(groupPrefix, course, groupNumber, graduationYear, specialty);
+        if (eduProgramCode != null) {
+            return eduProgramCode;
+        }
+        String specialtyCode = buildGroupCodeWithSpecialtySuffix(groupPrefix, course, groupNumber, graduationYear, specialty);
+        if (specialtyCode != null) {
+            return specialtyCode;
+        }
+        return buildLegacyGroupCode(groupPrefix, course, groupNumber, graduationYear);
+    }
+
+    public String buildGroupCodeWithEduProgram(String groupPrefix, String course, String groupNumber, String graduationYear, SpecialtyEntity specialty) {
+        if (specialty != null && specialty.getEduProgram() != null && specialty.getEduProgram().getId() > 0) {
+            return String.format("%s-%s-%s-%s(%d)", groupPrefix, course, groupNumber, graduationYear, specialty.getEduProgram().getId());
+        }
+        return null;
+    }
+
+    public String buildGroupCodeWithSpecialtySuffix(String groupPrefix, String course, String groupNumber, String graduationYear, SpecialtyEntity specialty) {
+        if (specialty != null && specialty.getId() != null) {
+            return String.format("%s-%s-%s-%s(%d)", groupPrefix, course, groupNumber, graduationYear, specialty.getId());
+        }
+        return null;
+    }
+
+    public String buildLegacyGroupCode(String groupPrefix, String course, String groupNumber, String graduationYear) {
+        return String.format("%s-%s-%s-%s", groupPrefix, course, groupNumber, graduationYear);
+    }
+}

--- a/src/main/java/com/esvar/dekanat/card/StudentListPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/card/StudentListPdfGenerator.java
@@ -1,0 +1,138 @@
+package com.esvar.dekanat.card;
+
+import com.itextpdf.io.font.PdfEncodings;
+import com.itextpdf.kernel.font.PdfFont;
+import com.itextpdf.kernel.font.PdfFontFactory;
+import com.itextpdf.kernel.geom.PageSize;
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfWriter;
+import com.itextpdf.kernel.pdf.canvas.draw.SolidLine;
+import com.itextpdf.layout.Document;
+import com.itextpdf.layout.element.LineSeparator;
+import com.itextpdf.layout.element.Paragraph;
+import com.itextpdf.layout.properties.TextAlignment;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.StreamRegistration;
+import com.vaadin.flow.server.StreamResource;
+import com.vaadin.flow.server.StreamResourceWriter;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Generates and streams a simple PDF list of students for a group.
+ */
+public final class StudentListPdfGenerator {
+
+    private StudentListPdfGenerator() {
+    }
+
+    public static void generateAndSend(String title, List<String> students) {
+        UI ui = UI.getCurrent();
+        if (ui == null) {
+            throw new IllegalStateException(
+                    "UI.getCurrent() == null. Викликати generateAndSend треба з UI-потоку Vaadin (наприклад у кнопці)."
+            );
+        }
+
+        try {
+            List<String> sortedStudents = prepareStudents(students);
+            byte[] pdfBytes = buildPdfBytes(title, sortedStudents);
+            String fileName = sanitizeFilename(title) + "-list.pdf";
+
+            StreamResource resource = new StreamResource(
+                    fileName,
+                    (StreamResourceWriter) (outputStream, session) -> {
+                        try (InputStream in = new ByteArrayInputStream(pdfBytes)) {
+                            in.transferTo(outputStream);
+                        } catch (IOException ioException) {
+                            throw new UncheckedIOException(ioException);
+                        }
+                    }
+            );
+
+            resource.setContentType("application/pdf");
+            resource.setCacheTime(0);
+
+            StreamRegistration registration = ui.getSession()
+                    .getResourceRegistry()
+                    .registerResource(resource);
+
+            String resourceUrl = registration.getResourceUri().toString();
+            ui.getPage().open(resourceUrl, "_blank");
+
+        } catch (Exception e) {
+            throw new RuntimeException("Не вдалося згенерувати або відкрити PDF", e);
+        }
+    }
+
+    private static List<String> prepareStudents(List<String> students) {
+        List<String> cleaned = new ArrayList<>();
+        for (String s : students) {
+            if (s != null && !s.isBlank()) {
+                cleaned.add(s.trim());
+            }
+        }
+
+        Collator uaCollator = Collator.getInstance(new Locale("uk", "UA"));
+        cleaned.sort(uaCollator);
+
+        return cleaned;
+    }
+
+    private static byte[] buildPdfBytes(String groupName, List<String> sortedStudents) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PdfWriter writer = new PdfWriter(baos);
+        PdfDocument pdfDoc = new PdfDocument(writer);
+        pdfDoc.setDefaultPageSize(PageSize.A4);
+
+        Document doc = new Document(pdfDoc);
+        doc.setMargins(36, 36, 36, 36);
+
+        PdfFont font;
+        try (InputStream fontStream = CardView.class.getResourceAsStream("/fonts/times.ttf")) {
+
+            if (fontStream == null) {
+                throw new IllegalStateException("Не знайдено /fonts/DejaVuSans.ttf у resources.");
+            }
+
+            byte[] fontBytes = fontStream.readAllBytes();
+            font = PdfFontFactory.createFont(fontBytes, PdfEncodings.IDENTITY_H);
+        }
+        doc.setFont(font);
+
+        Paragraph titleP = new Paragraph(groupName)
+                .setFontSize(14)
+                .setTextAlignment(TextAlignment.CENTER)
+                .setMarginBottom(4f);
+        doc.add(titleP);
+
+        LineSeparator line = new LineSeparator(new SolidLine(1f));
+        line.setMarginBottom(16f);
+        doc.add(line);
+
+        int idx = 1;
+        for (String student : sortedStudents) {
+            Paragraph row = new Paragraph(idx + ". " + student)
+                    .setFontSize(12)
+                    .setMarginBottom(4f);
+            doc.add(row);
+            idx++;
+        }
+
+        doc.close();
+        return baos.toByteArray();
+    }
+
+    private static String sanitizeFilename(String in) {
+        if (in == null || in.isBlank()) return "group";
+        return in.replaceAll("[^a-zA-Z0-9\\u0400-\\u04FF\\-_.]", "_");
+    }
+}

--- a/src/main/java/com/esvar/dekanat/dto/SpecialtyDTO.java
+++ b/src/main/java/com/esvar/dekanat/dto/SpecialtyDTO.java
@@ -1,0 +1,20 @@
+package com.esvar.dekanat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SpecialtyDTO {
+
+    private final String abbreviation;
+    private final String title;
+
+    @Override
+    public String toString() {
+        if (title != null && !title.isBlank()) {
+            return title;
+        }
+        return abbreviation;
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -3,6 +3,7 @@ package com.esvar.dekanat.mark;
 import com.esvar.dekanat.document.DocumentGenerationService;
 import com.esvar.dekanat.dto.GroupDTO;
 import com.esvar.dekanat.dto.MarkDTO;
+import com.esvar.dekanat.dto.SpecialtyDTO;
 import com.esvar.dekanat.entity.*;
 import com.esvar.dekanat.generate.*;
 
@@ -115,7 +116,7 @@ public class EnterMarksView extends Div {
 
     private Select<String> selectFaculty = new Select<>();
     private Select<String> selectDepartment = new Select<>();
-    private Select<String> selectSpecialty = new Select<>();
+    private Select<SpecialtyDTO> selectSpecialty = new Select<>();
     private Select<String> selectCourse = new Select<>();
     private final Select<GroupDTO> selectGroup = new Select<>();
     private Select<String> selectDiscipline = new Select<>();
@@ -185,6 +186,13 @@ public class EnterMarksView extends Div {
         selectSpecialty.setLabel("Спеціальність");
         selectSpecialty.setWidth("100%");
         selectSpecialty.getStyle().set("padding", "0px").set("margin", "0px").set("margin-bottom", "5px");
+        selectSpecialty.setItemLabelGenerator(option -> {
+            if (option == null) {
+                return "";
+            }
+            String title = option.getTitle();
+            return (title != null && !title.isBlank()) ? title : option.getAbbreviation();
+        });
 
         selectCourse.setLabel("Курс");
         selectCourse.setWidth("100%");
@@ -310,7 +318,8 @@ public class EnterMarksView extends Div {
 
         selectSpecialty.addValueChangeListener(event -> {
             clearGrid();
-            if (selectSpecialty.getValue() != null) {
+            SpecialtyDTO selectedSpecialty = selectSpecialty.getValue();
+            if (selectedSpecialty != null) {
                 selectCourse.setReadOnly(false);
                 selectGroup.setReadOnly(true);
                 selectDiscipline.setReadOnly(true);
@@ -323,7 +332,7 @@ public class EnterMarksView extends Div {
                 selectCourse.setItems(planService.getCourseByFacultyAndDepartmentAndSpecialty(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue()
+                        selectedSpecialty.getAbbreviation()
                 ));
             }
         });
@@ -331,7 +340,8 @@ public class EnterMarksView extends Div {
         selectCourse.addValueChangeListener(event -> {
             clearGrid();
             currentGroup = null;
-            if (selectCourse.getValue() != null) {
+            SpecialtyDTO selectedSpecialty = selectSpecialty.getValue();
+            if (selectCourse.getValue() != null && selectedSpecialty != null) {
                 selectGroup.setReadOnly(false);
                 selectDiscipline.setReadOnly(true);
                 selectControlType.setReadOnly(true);
@@ -342,7 +352,7 @@ public class EnterMarksView extends Div {
                 selectGroup.setItems(planService.getGroupsByFacultyAndDepartmentAndSpecialtyAndCourse(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
+                        selectedSpecialty.getAbbreviation(),
                         Integer.parseInt(selectCourse.getValue())
                 ));
             }
@@ -353,7 +363,8 @@ public class EnterMarksView extends Div {
             GroupDTO selectedGroup = selectGroup.getValue();
             currentGroup = selectedGroup == null ? null : groupService.getGroupByTitle(selectedGroup.getGroupCode());
             updateReportButtonState();
-            if (selectedGroup != null) {
+            SpecialtyDTO selectedSpecialty = selectSpecialty.getValue();
+            if (selectedGroup != null && selectedSpecialty != null) {
                 selectDiscipline.setReadOnly(false);
                 selectControlType.setReadOnly(true);
 
@@ -362,7 +373,7 @@ public class EnterMarksView extends Div {
                 selectDiscipline.setItems(planService.getDisciplinesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupGroupNumber(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
+                        selectedSpecialty.getAbbreviation(),
                         selectedGroup.getCourse(),
                         selectedGroup.getGroupNumber()
                 ));
@@ -372,13 +383,14 @@ public class EnterMarksView extends Div {
         selectDiscipline.addValueChangeListener(event -> {
             clearGrid();
             GroupDTO selectedGroup = selectGroup.getValue();
-            if (selectDiscipline.getValue() != null && selectedGroup != null) {
+            SpecialtyDTO selectedSpecialty = selectSpecialty.getValue();
+            if (selectDiscipline.getValue() != null && selectedGroup != null && selectedSpecialty != null) {
                 selectControlType.setReadOnly(false);
 
                 selectControlType.setItems(planService.getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
+                        selectedSpecialty.getAbbreviation(),
                         selectedGroup.getCourse(),
                         selectedGroup.getGroupNumber(),
                         selectDiscipline.getValue()
@@ -387,7 +399,7 @@ public class EnterMarksView extends Div {
                 plansEntity = planService.getPlanEntityByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
                         selectFaculty.getValue(),
                         selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
+                        selectedSpecialty.getAbbreviation(),
                         selectedGroup.getCourse(),
                         selectedGroup.getGroupNumber(),
                         selectDiscipline.getValue()

--- a/src/main/java/com/esvar/dekanat/repository/StudentRepository.java
+++ b/src/main/java/com/esvar/dekanat/repository/StudentRepository.java
@@ -4,6 +4,7 @@ import com.esvar.dekanat.entity.StudentEntity;
 import com.esvar.dekanat.entity.StudentGroupEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,7 +12,15 @@ import java.util.List;
 @Repository
 public interface StudentRepository extends JpaRepository<StudentEntity, Long> {
     @Query("SELECT DISTINCT s.group.id FROM StudentEntity s WHERE s.faculty.id = :facultyId")
-    List<Long> findDistinctGroupIdsByFacultyId(Long facultyId);
+    List<Long> findDistinctGroupIdsByFacultyId(@Param("facultyId") Long facultyId);
+
+    @Query("""
+            SELECT DISTINCT s.group.id FROM StudentEntity s
+            WHERE s.faculty.id = :facultyId
+              AND (:fullTime IS NULL OR s.fullTime = :fullTime)
+            """)
+    List<Long> findDistinctGroupIdsByFacultyIdAndStudyForm(@Param("facultyId") Long facultyId,
+                                                           @Param("fullTime") Boolean fullTime);
 
     List<StudentEntity> findByGroupId(long groupId);
 

--- a/src/main/java/com/esvar/dekanat/security/LoginView.java
+++ b/src/main/java/com/esvar/dekanat/security/LoginView.java
@@ -2,6 +2,7 @@ package com.esvar.dekanat.security;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.login.LoginForm;
 import com.vaadin.flow.component.login.LoginI18n;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
@@ -51,7 +52,33 @@ public class LoginView extends VerticalLayout implements BeforeEnterObserver {
 
 //        UI.getCurrent().access(() -> UI.getCurrent().navigate(""));
 
-        add(new H1("Dekanat CRM"), login);
+        Paragraph infoParagraph = new Paragraph(
+                "У зв’язку з проведенням технічних робіт можливі тимчасові перебої в роботі системи.\n" +
+                        "Рекомендуємо частіше зберігати внесену інформацію."
+        );
+
+        infoParagraph.getStyle()
+                .set("white-space", "pre-line")
+                // фон та кольори в стилі Lumo
+                .set("background-color", "var(--lumo-primary-color-10pct)")
+                .set("color", "var(--lumo-body-text-color)")
+                // відступи та радіус — як у стандартних компонентів
+                .set("padding", "var(--lumo-space-s) var(--lumo-space-m)")
+                .set("border-radius", "var(--lumo-border-radius-m)")
+                // легка рамка + акцентована ліва смуга
+                .set("border", "1px solid var(--lumo-contrast-10pct)")
+                .set("border-left", "4px solid var(--lumo-primary-color)")
+                // типографіка під Lumo
+                .set("font-size", "var(--lumo-font-size-s)")
+                .set("font-weight", "500")
+                .set("line-height", "1.4")
+                // щоб відокремити від решти контенту
+                .set("margin", "var(--lumo-space-m) 0")
+                .set("display", "block");
+
+
+
+        add(new H1("Dekanat CRM"),  infoParagraph, login);
     }
 
     @Override

--- a/src/main/java/com/esvar/dekanat/service/FacultyService.java
+++ b/src/main/java/com/esvar/dekanat/service/FacultyService.java
@@ -17,6 +17,11 @@ public class FacultyService {
     }
 
 
+    public List<FacultyEntity> getAllFaculties() {
+        return facultyRepository.findAll();
+    }
+
+
     public List<String> getFacultyTitles() {
         return facultyRepository.findAll().stream().map(FacultyEntity::getTitle).collect(Collectors.toList());
     }

--- a/src/main/java/com/esvar/dekanat/service/GroupService.java
+++ b/src/main/java/com/esvar/dekanat/service/GroupService.java
@@ -1,14 +1,14 @@
 package com.esvar.dekanat.service;
 
 import com.esvar.dekanat.dto.GroupDTO;
-import com.esvar.dekanat.entity.SpecialtyEntity;
 import com.esvar.dekanat.entity.StudentEntity;
 import com.esvar.dekanat.entity.StudentGroupEntity;
 import com.esvar.dekanat.repository.GroupRepository;
 import com.esvar.dekanat.security.SecurityService;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+
+import com.esvar.dekanat.user.UserModel;
 
 import java.text.Collator;
 import java.util.*;
@@ -36,27 +36,36 @@ public class GroupService {
     }
 
     public List<GroupDTO> getGroupsDTO() {
-        // 1. Завантажуємо всі групи
         List<StudentGroupEntity> groups = groupRepository.findAll();
 
-        // 2. Отримуємо ролі й roleType поточного користувача
         UserDetails user = securityService.getAuthenticatedUser();
-        boolean isAdmin   = user.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
-        boolean isDekanat = user.getAuthorities().stream()
+        boolean isDekanat = user != null && user.getAuthorities().stream()
                 .anyMatch(a -> a.getAuthority().startsWith("ROLE_DEKANAT"));
-        String roleType   = securityService.getCurrentRoleType();
 
-        // 3. Якщо користувач — методист, готуємо набір ID груп його факультету
-        Set<Long> groupIdsForFaculty = isDekanat
-                ? studentService.getGroupIdsByFaculty(Long.valueOf(roleType))
-                : Collections.emptySet();
+        RoleScope roleScope = parseRoleScope(securityService.getCurrentRoleType());
+        Boolean preferredFullTime = roleScope.fullTime();
+
+        if (preferredFullTime == null) {
+            preferredFullTime = securityService.getCurrentUserModel()
+                    .map(UserModel::getRole)
+                    .filter(role -> role != null && role.startsWith("ROLE_DEKANAT"))
+                    .map(this::parseStudyFormToken)
+                    .orElse(null);
+        }
+
+        Set<Long> groupIdsForFaculty = null;
+        if (isDekanat && roleScope.facultyId() != null) {
+            groupIdsForFaculty = studentService.getGroupIdsByFaculty(roleScope.facultyId(), preferredFullTime);
+        }
+
+        boolean applyFacultyFilter = isDekanat && groupIdsForFaculty != null;
+        boolean applyStudyFormFilter = isDekanat && preferredFullTime != null;
 
         Collator ukrainianCollator = Collator.getInstance(new Locale("uk", "UA"));
 
-        // 4. Фільтруємо та мапимо
         return groups.stream()
-                .filter(group -> !isDekanat || groupIdsForFaculty.contains(group.getId()))
+                .filter(group -> !applyFacultyFilter || groupIdsForFaculty.contains(group.getId()))
+                .filter(group -> !applyStudyFormFilter || matchesPreferredForm(preferredFullTime, group))
                 .map(group -> new GroupDTO(
                         group.getGroupCode(),
                         group.getSpecialty().getTitle(),
@@ -66,6 +75,97 @@ public class GroupService {
                 ))
                 .sorted(Comparator.comparing(GroupDTO::getGroupCode, ukrainianCollator))
                 .collect(Collectors.toList());
+    }
+
+    private boolean matchesPreferredForm(Boolean preferredFullTime, StudentGroupEntity group) {
+        if (preferredFullTime == null) {
+            return true;
+        }
+
+        return studentService.determineGroupStudyForm(group)
+                .map(preferredFullTime::equals)
+                .orElse(false);
+    }
+
+    private RoleScope parseRoleScope(String rawRoleType) {
+        if (rawRoleType == null || rawRoleType.isBlank()) {
+            return new RoleScope(null, null);
+        }
+
+        String trimmed = rawRoleType.trim();
+        String[] parts = trimmed.split(":", 2);
+
+        Long facultyId = parseFacultyId(parts[0]);
+        Boolean fullTime = null;
+        if (parts.length > 1) {
+            fullTime = parseStudyFormToken(parts[1]);
+        }
+
+        if (fullTime == null && parts.length == 1) {
+            fullTime = parseStudyFormToken(parts[0]);
+        }
+
+        return new RoleScope(facultyId, fullTime);
+    }
+
+    private Long parseFacultyId(String token) {
+        if (token == null) {
+            return null;
+        }
+
+        String candidate = token.trim();
+        if (candidate.isEmpty()) {
+            return null;
+        }
+
+        StringBuilder digits = new StringBuilder();
+        for (int i = 0; i < candidate.length(); i++) {
+            char ch = candidate.charAt(i);
+            if (Character.isDigit(ch)) {
+                digits.append(ch);
+            } else if (!Character.isWhitespace(ch)) {
+                break;
+            }
+        }
+
+        if (digits.length() == 0) {
+            return null;
+        }
+
+        try {
+            return Long.valueOf(digits.toString());
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private Boolean parseStudyFormToken(String token) {
+        if (token == null) {
+            return null;
+        }
+
+        String normalized = token.trim().toLowerCase(Locale.ROOT);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+
+        if (normalized.equals("pt") || normalized.equals("part") || normalized.contains("part_time")
+                || normalized.contains("part-time") || normalized.contains("zaoch")
+                || normalized.contains("заоч") || normalized.contains("extramur")
+                || normalized.contains("distance") || normalized.contains("вечір")) {
+            return Boolean.FALSE;
+        }
+
+        if (normalized.equals("ft") || normalized.contains("full_time") || normalized.contains("full-time")
+                || normalized.contains("fulltime") || normalized.contains("денн")
+                || normalized.contains("day") || normalized.contains("денна")) {
+            return Boolean.TRUE;
+        }
+
+        return null;
+    }
+
+    private record RoleScope(Long facultyId, Boolean fullTime) {
     }
 
 

--- a/src/main/java/com/esvar/dekanat/service/PlanService.java
+++ b/src/main/java/com/esvar/dekanat/service/PlanService.java
@@ -1,6 +1,7 @@
 package com.esvar.dekanat.service;
 
 import com.esvar.dekanat.dto.GroupDTO;
+import com.esvar.dekanat.dto.SpecialtyDTO;
 import com.esvar.dekanat.entity.*;
 import com.esvar.dekanat.repository.*;
 import org.springframework.stereotype.Service;
@@ -129,15 +130,27 @@ public class PlanService {
         return planRepository.findById(id).orElse(null);
     }
 
-    public List<String> getSpecialtiesByFacultyAndDepartment(String faculty, String department) {
-        return planRepository.findByFacultyAndDepartment
-                (
+    public List<SpecialtyDTO> getSpecialtiesByFacultyAndDepartment(String faculty, String department) {
+        Collator ukrainianCollator = Collator.getInstance(new Locale("uk", "UA"));
+
+        return planRepository.findByFacultyAndDepartment(
                         facultyRepository.findByTitle(faculty),
                         departmentRepository.findByTitle(department)
                 ).stream()
                 .map(PlansEntity::getSpecialty)
-                .map(SpecialtyEntity::getAbbreviation)
-                .distinct()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(
+                        SpecialtyEntity::getAbbreviation,
+                        specialty -> new SpecialtyDTO(
+                                specialty.getAbbreviation(),
+                                specialty.getTitle()
+                        ),
+                        (existing, duplicate) -> existing,
+                        LinkedHashMap::new
+                ))
+                .values()
+                .stream()
+                .sorted(Comparator.comparing(SpecialtyDTO::getTitle, ukrainianCollator))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/esvar/dekanat/service/PlanService.java
+++ b/src/main/java/com/esvar/dekanat/service/PlanService.java
@@ -202,25 +202,62 @@ public class PlanService {
     public List<String> getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
             String faculty, String department, String specialty, int course, int groupNumber, String discipline) {
         int semester = getNumberSemester(String.valueOf(course));
-        List<String> controlTypes = planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
-                        facultyRepository.findByTitle(faculty),
-                        departmentRepository.findByTitle(department),
-                        specialty,
-                        course,
-                        groupNumber,
-                        discipline
-                ).stream()
+        List<PlansEntity> plans = planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
+                facultyRepository.findByTitle(faculty),
+                departmentRepository.findByTitle(department),
+                specialty,
+                course,
+                groupNumber,
+                discipline
+        );
+
+        List<PlansEntity> semesterPlans = plans.stream()
                 .filter(p -> p.getSemester() == semester)
-                .flatMap(plan -> Stream.of(plan.getFirstControl().getName(), plan.getSecondControl().getName())) // Отримуємо обидва значення
-                .filter(control -> !"Відсутній".equals(control)) // Фільтруємо "Відсутній"
-                .distinct() // Унікальні значення (якщо потрібно)
+                .toList();
+
+        List<String> controlTypes = semesterPlans.stream()
+                .flatMap(plan -> Stream.of(plan.getFirstControl().getName(), plan.getSecondControl().getName()))
+                .filter(control -> !"Відсутній".equals(control))
+                .distinct()
                 .collect(Collectors.toList());
 
-        // Додаємо "Перший модульний контроль" і "Другий модульний контроль"
-        controlTypes.add("Перший модульний контроль");
-        controlTypes.add("Другий модульний контроль");
+        if (shouldIncludeModuleControls(semesterPlans, course, groupNumber)) {
+            controlTypes.add("Перший модульний контроль");
+            controlTypes.add("Другий модульний контроль");
+        }
 
         return controlTypes;
+    }
+
+    private boolean shouldIncludeModuleControls(List<PlansEntity> plans, int course, int groupNumber) {
+        if (plans == null || plans.isEmpty()) {
+            return false;
+        }
+
+        return findGroupForCourseAndNumber(plans, course, groupNumber)
+                .map(this::isFullTimeGroup)
+                .orElse(false);
+    }
+
+    private Optional<StudentGroupEntity> findGroupForCourseAndNumber(List<PlansEntity> plans, int course, int groupNumber) {
+        return plans.stream()
+                .flatMap(plan -> plan.getGroups().stream())
+                .filter(Objects::nonNull)
+                .filter(group -> group.getCourse() == course && group.getGroupNumber() == groupNumber)
+                .findFirst();
+    }
+
+    private boolean isFullTimeGroup(StudentGroupEntity group) {
+        if (group == null) {
+            return false;
+        }
+
+        List<StudentEntity> students = studentRepository.findByGroup(group);
+        if (students == null || students.isEmpty()) {
+            return false;
+        }
+
+        return students.stream().allMatch(StudentEntity::isFullTime);
     }
 
     public PlansEntity getPlanEntityByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(String faculty, String department, String specialty, int course, int groupNumber, String discipline){

--- a/src/main/java/com/esvar/dekanat/service/PlanService.java
+++ b/src/main/java/com/esvar/dekanat/service/PlanService.java
@@ -215,13 +215,17 @@ public class PlanService {
                 .filter(p -> p.getSemester() == semester)
                 .toList();
 
-        List<String> controlTypes = semesterPlans.stream()
-                .flatMap(plan -> Stream.of(plan.getFirstControl().getName(), plan.getSecondControl().getName()))
+        List<PlansEntity> relevantPlans = semesterPlans.isEmpty() ? plans : semesterPlans;
+
+        List<String> controlTypes = relevantPlans.stream()
+                .flatMap(plan -> Stream.of(plan.getFirstControl(), plan.getSecondControl()))
+                .filter(Objects::nonNull)
+                .map(ControlMethodEntity::getName)
                 .filter(control -> !"Відсутній".equals(control))
                 .distinct()
                 .collect(Collectors.toList());
 
-        if (shouldIncludeModuleControls(semesterPlans, course, groupNumber)) {
+        if (shouldIncludeModuleControls(relevantPlans, course, groupNumber)) {
             controlTypes.add("Перший модульний контроль");
             controlTypes.add("Другий модульний контроль");
         }

--- a/src/main/java/com/esvar/dekanat/service/StudentService.java
+++ b/src/main/java/com/esvar/dekanat/service/StudentService.java
@@ -92,10 +92,19 @@ public class StudentService {
     }
 
     public Set<Long> getGroupIdsByFaculty(Long facultyId) {
+        return getGroupIdsByFaculty(facultyId, null);
+    }
+
+    public Set<Long> getGroupIdsByFaculty(Long facultyId, Boolean fullTime) {
         if (facultyId == null) {
             return Collections.emptySet();
         }
-        return new HashSet<>(studentRepository.findDistinctGroupIdsByFacultyId(facultyId));
+
+        List<Long> groupIds = (fullTime == null)
+                ? studentRepository.findDistinctGroupIdsByFacultyId(facultyId)
+                : studentRepository.findDistinctGroupIdsByFacultyIdAndStudyForm(facultyId, fullTime);
+
+        return new HashSet<>(groupIds);
     }
 
     public StudentEntity findStudentById(Long id) {
@@ -137,6 +146,29 @@ public class StudentService {
         }
 
         return student;
+    }
+
+    public Optional<Boolean> determineGroupStudyForm(StudentGroupEntity group) {
+        if (group == null) {
+            return Optional.empty();
+        }
+
+        List<StudentEntity> students = studentRepository.findByGroup(group);
+        if (students == null || students.isEmpty()) {
+            return Optional.empty();
+        }
+
+        boolean allFullTime = students.stream().allMatch(StudentEntity::isFullTime);
+        if (allFullTime) {
+            return Optional.of(Boolean.TRUE);
+        }
+
+        boolean allPartTime = students.stream().noneMatch(StudentEntity::isFullTime);
+        if (allPartTime) {
+            return Optional.of(Boolean.FALSE);
+        }
+
+        return Optional.empty();
     }
 
     private static String normalizeFullName(String fullName) {

--- a/src/main/java/com/esvar/dekanat/service/UserService.java
+++ b/src/main/java/com/esvar/dekanat/service/UserService.java
@@ -6,12 +6,15 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 public class UserService {
 
     private static final String ROLE_PREFIX = "ROLE_";
+    private static final Set<String> ALLOWED_ROLES = Set.of("ADMIN", "DEKANAT", "DEPARTMENT");
     private static final String PASSWORD_CHARSET = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz0123456789";
 
     private final UserRepository userRepository;
@@ -31,21 +34,75 @@ public class UserService {
                                   String patronymic,
                                   String role,
                                   String roleType) {
-        validateEmailUniqueness(email);
+        String normalizedEmail = normalizeEmail(email);
+
+        validateRequiredFields(normalizedEmail, firstname, lastname, patronymic, role, roleType);
+        validateRole(role);
+        validateRoleType(role, roleType);
+        validateEmailUniqueness(normalizedEmail);
 
         String generatedPassword = generateTemporaryPassword();
+        String normalizedRoleType = normalizeRoleType(role, roleType);
 
         UserModel userModel = new UserModel();
-        userModel.setEmail(email);
+        userModel.setEmail(normalizedEmail);
         userModel.setFirstname(firstname);
         userModel.setLastname(lastname);
         userModel.setPatronymic(patronymic);
         userModel.setRole(ROLE_PREFIX + role);
-        userModel.setRoleType(roleType);
+        userModel.setRoleType(normalizedRoleType);
         userModel.setEnabled(true);
         userModel.setPassword(passwordEncoder.encode(generatedPassword));
 
         return new CreatedUser(userRepository.save(userModel), generatedPassword);
+    }
+
+    private String normalizeEmail(String email) {
+        if (email == null) {
+            return null;
+        }
+        return email.trim().toLowerCase();
+    }
+
+    private void validateRequiredFields(String email,
+                                        String firstname,
+                                        String lastname,
+                                        String patronymic,
+                                        String role,
+                                        String roleType) {
+        Set<String> missingFields = new HashSet<>();
+        if (isBlank(email)) missingFields.add("email");
+        if (isBlank(firstname)) missingFields.add("ім'я");
+        if (isBlank(lastname)) missingFields.add("прізвище");
+        if (isBlank(patronymic)) missingFields.add("по батькові");
+        if (isBlank(role)) missingFields.add("роль");
+        if (isBlank(roleType)) missingFields.add("тип ролі");
+
+        if (!missingFields.isEmpty()) {
+            throw new IllegalArgumentException("Заповніть обов'язкові поля: " + String.join(", ", missingFields));
+        }
+    }
+
+    private void validateRole(String role) {
+        if (!ALLOWED_ROLES.contains(role)) {
+            throw new IllegalArgumentException("Невідома роль: " + role);
+        }
+    }
+
+    private void validateRoleType(String role, String roleType) {
+        if ("ADMIN".equals(role)) {
+            return;
+        }
+        if (!roleType.matches("\\d+")) {
+            throw new IllegalArgumentException("Тип ролі має містити лише номер факультету/кафедри");
+        }
+    }
+
+    private String normalizeRoleType(String role, String roleType) {
+        if ("ADMIN".equals(role)) {
+            return "0";
+        }
+        return roleType.trim();
     }
 
     private void validateEmailUniqueness(String email) {
@@ -65,5 +122,9 @@ public class UserService {
 
     public List<UserModel> findAll() {
         return userRepository.findAll();
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
     }
 }

--- a/src/main/java/com/esvar/dekanat/service/UserService.java
+++ b/src/main/java/com/esvar/dekanat/service/UserService.java
@@ -1,0 +1,69 @@
+package com.esvar.dekanat.service;
+
+import com.esvar.dekanat.user.UserModel;
+import com.esvar.dekanat.user.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.util.List;
+
+@Service
+public class UserService {
+
+    private static final String ROLE_PREFIX = "ROLE_";
+    private static final String PASSWORD_CHARSET = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz0123456789";
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public record CreatedUser(UserModel user, String rawPassword) { }
+
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public CreatedUser createUser(String email,
+                                  String firstname,
+                                  String lastname,
+                                  String patronymic,
+                                  String role,
+                                  String roleType) {
+        validateEmailUniqueness(email);
+
+        String generatedPassword = generateTemporaryPassword();
+
+        UserModel userModel = new UserModel();
+        userModel.setEmail(email);
+        userModel.setFirstname(firstname);
+        userModel.setLastname(lastname);
+        userModel.setPatronymic(patronymic);
+        userModel.setRole(ROLE_PREFIX + role);
+        userModel.setRoleType(roleType);
+        userModel.setEnabled(true);
+        userModel.setPassword(passwordEncoder.encode(generatedPassword));
+
+        return new CreatedUser(userRepository.save(userModel), generatedPassword);
+    }
+
+    private void validateEmailUniqueness(String email) {
+        if (userRepository.findByEmail(email).isPresent()) {
+            throw new IllegalArgumentException("Користувач з такою поштою вже існує");
+        }
+    }
+
+    private String generateTemporaryPassword() {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < 10; i++) {
+            int index = secureRandom.nextInt(PASSWORD_CHARSET.length());
+            builder.append(PASSWORD_CHARSET.charAt(index));
+        }
+        return builder.toString();
+    }
+
+    public List<UserModel> findAll() {
+        return userRepository.findAll();
+    }
+}

--- a/src/main/java/com/esvar/dekanat/user/UserModel.java
+++ b/src/main/java/com/esvar/dekanat/user/UserModel.java
@@ -2,6 +2,8 @@ package com.esvar.dekanat.user;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
@@ -17,8 +19,9 @@ import lombok.Setter;
 @AllArgsConstructor
 public class UserModel {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
-    private long id;
+    private Long id;
     @Column(name = "email")
     private String email;
     @Column(name = "password")

--- a/src/main/java/com/esvar/dekanat/view/UsersView.java
+++ b/src/main/java/com/esvar/dekanat/view/UsersView.java
@@ -1,236 +1,264 @@
 package com.esvar.dekanat.view;
 
-import com.esvar.dekanat.entity.UserEntity;
-import com.vaadin.flow.component.Component;
+import com.esvar.dekanat.service.DepartmentService;
+import com.esvar.dekanat.service.FacultyService;
+import com.esvar.dekanat.service.UserService;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
-import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.combobox.ComboBox;
-import com.vaadin.flow.component.grid.ColumnTextAlign;
-import com.vaadin.flow.component.grid.Grid;
-import com.vaadin.flow.component.grid.GridVariant;
-import com.vaadin.flow.component.grid.HeaderRow;
 import com.vaadin.flow.component.html.H2;
-import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.icon.Icon;
-import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.notification.NotificationVariant;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.flow.component.textfield.TextField;
-import com.vaadin.flow.data.provider.ListDataProvider;
-import com.vaadin.flow.data.renderer.ComponentRenderer;
-import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.binder.ValidationException;
+import com.vaadin.flow.data.validator.EmailValidator;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
-import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Route(value = "users", layout = MainLayout.class)
 @PageTitle("Користувачі")
-@PermitAll
+@RolesAllowed("ROLE_ADMIN")
 public class UsersView extends VerticalLayout {
 
-    private final VerticalLayout addUserLayout = new VerticalLayout();
-    private final VerticalLayout allUserLayout = new VerticalLayout();
+    private final UserService userService;
+    private final FacultyService facultyService;
+    private final DepartmentService departmentService;
 
-    private final TextField FirstnameTF = new TextField("Ім'я");
-    private final TextField LastnameTF = new TextField("Прізвище");
-    private final TextField PatronymicTF = new TextField("По батькові");
-    private final TextField EmailTF = new TextField("Email");
-    private final ComboBox<String> RoleCB = new ComboBox<>("Роль");
-    private final ComboBox<String> RoleTypeCB = new ComboBox<>("Тип ролі");
-    private final Button addUserButton = new Button("Додати користувача");
-    private final Button saveUserButton = new Button("Зберегти");
-    private final Button cancelUserButton = new Button("Відміна");
+    private final TextField firstnameField = new TextField("Ім'я");
+    private final TextField lastnameField = new TextField("Прізвище");
+    private final TextField patronymicField = new TextField("По батькові");
+    private final EmailField emailField = new EmailField("Email");
+    private final ComboBox<String> roleField = new ComboBox<>("Роль");
+    private final ComboBox<RoleTypeOption> roleTypeField = new ComboBox<>("Тип ролі");
+    private final Button saveUserButton = new Button("Створити користувача");
+    private final Button cancelUserButton = new Button("Очистити");
 
+    private final Binder<UserFormData> binder = new Binder<>(UserFormData.class);
+    private List<RoleTypeOption> availableRoleTypeOptions = new ArrayList<>();
 
-    public UsersView() {
+    public UsersView(UserService userService, FacultyService facultyService, DepartmentService departmentService) {
+        this.userService = userService;
+        this.facultyService = facultyService;
+        this.departmentService = departmentService;
 
-
-        createUserForm();
-        createGrid();
+        configureForm();
+        configureBinder();
     }
 
-    public void createUserForm() {
-        FirstnameTF.setWidth("200px");
-        LastnameTF.setWidth("200px");
-        PatronymicTF.setWidth("200px");
-        EmailTF.setWidth("250px");
-        RoleCB.setWidth("200px");
-        RoleTypeCB.setWidth("200px");
+    private void configureForm() {
+        setSpacing(true);
+        setPadding(true);
 
-        addUserButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
-        addUserButton.setWidth("180px");
-        saveUserButton.setWidth("120px");
-        cancelUserButton.setWidth("120px");
+        firstnameField.setRequiredIndicatorVisible(true);
+        lastnameField.setRequiredIndicatorVisible(true);
+        patronymicField.setRequiredIndicatorVisible(true);
+        emailField.setRequiredIndicatorVisible(true);
+        roleField.setRequiredIndicatorVisible(true);
+        roleTypeField.setRequiredIndicatorVisible(true);
 
-        HorizontalLayout firstRow = new HorizontalLayout(FirstnameTF, LastnameTF, PatronymicTF, EmailTF);
-        HorizontalLayout secondRow = new HorizontalLayout(RoleCB, RoleTypeCB);
-        HorizontalLayout thirdRow = new HorizontalLayout(addUserButton, saveUserButton, cancelUserButton);
+        roleField.setItems("ADMIN", "DEKANAT", "DEPARTMENT");
+        roleField.addValueChangeListener(event -> updateRoleTypeOptions(event.getValue()));
 
-        firstRow.setSpacing(true);
-        secondRow.setSpacing(true);
-        thirdRow.setSpacing(true);
+        roleTypeField.setItemLabelGenerator(RoleTypeOption::label);
+        roleTypeField.setAllowCustomValue(false);
+        roleTypeField.setEnabled(false);
 
-        addUserLayout.add(
-                firstRow,
-                secondRow,
-                thirdRow
-        );
-        addUserLayout.setPadding(true);
-        add(addUserLayout);
+        firstnameField.setWidth("250px");
+        lastnameField.setWidth("250px");
+        patronymicField.setWidth("250px");
+        emailField.setWidth("300px");
+        roleField.setWidth("240px");
+        roleTypeField.setWidth("240px");
+
+        saveUserButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        saveUserButton.addClickListener(event -> saveUser());
+        cancelUserButton.addClickListener(event -> resetForm());
+
+        H2 title = new H2("Додати нового користувача (доступно лише адміністраторам)");
+
+        HorizontalLayout firstRow = new HorizontalLayout(firstnameField, lastnameField, patronymicField, emailField);
+        HorizontalLayout secondRow = new HorizontalLayout(roleField, roleTypeField);
+        HorizontalLayout actions = new HorizontalLayout(saveUserButton, cancelUserButton);
+
+        add(title, firstRow, secondRow, actions);
     }
 
-    public void createGrid() {
-        Grid<UserEntity> grid = new Grid<>(UserEntity.class, false);
-        grid.setSelectionMode(Grid.SelectionMode.MULTI);
+    private void configureBinder() {
+        binder.forField(emailField)
+                .asRequired("Email обов'язковий")
+                .withValidator(new EmailValidator("Некоректний формат email"))
+                .bind(UserFormData::getEmail, UserFormData::setEmail);
 
-        // ======== КОЛОНКИ =========
-        Grid.Column<UserEntity> idColumn = grid.addColumn(UserEntity::getId)
-                .setHeader("ID")
-                .setWidth("120px")
-                .setFlexGrow(0)
-                .setTextAlign(ColumnTextAlign.CENTER);
+        binder.forField(firstnameField)
+                .asRequired("Ім'я обов'язкове")
+                .bind(UserFormData::getFirstname, UserFormData::setFirstname);
 
-        Grid.Column<UserEntity> pibColumn = grid.addColumn(UserEntity::getPib)
-                .setHeader("Прізвище Ім'я По батькові")
-                .setWidth("200px");
+        binder.forField(lastnameField)
+                .asRequired("Прізвище обов'язкове")
+                .bind(UserFormData::getLastname, UserFormData::setLastname);
 
-        Grid.Column<UserEntity> emailColumn = grid.addColumn(UserEntity::getEmail)
-                .setHeader("Пошта")
-                .setWidth("180px");
+        binder.forField(patronymicField)
+                .asRequired("По батькові обов'язкове")
+                .bind(UserFormData::getPatronymic, UserFormData::setPatronymic);
 
-        Grid.Column<UserEntity> activeColumn = grid.addColumn(new ComponentRenderer<>(user -> {
-                    Icon icon = user.isActive() ? VaadinIcon.CHECK.create() : VaadinIcon.CLOSE.create();
-                    icon.setColor(user.isActive() ? "green" : "red");
-                    icon.setSize("18px");
-                    return icon;
-                }))
-                .setHeader("А")
-                .setWidth("120px")
-                .setFlexGrow(0)
-                .setTextAlign(ColumnTextAlign.CENTER);
+        binder.forField(roleField)
+                .asRequired("Роль обов'язкова")
+                .bind(UserFormData::getRole, UserFormData::setRole);
 
-        Grid.Column<UserEntity> roleColumn = grid.addColumn(UserEntity::getRole)
-                .setHeader("Роль")
-                .setWidth("160px");
+        binder.forField(roleTypeField)
+                .asRequired("Тип ролі обов'язковий")
+                .withConverter(RoleTypeOption::id, this::findRoleTypeOptionById, "Оберіть тип ролі")
+                .bind(UserFormData::getRoleTypeId, UserFormData::setRoleTypeId);
 
-        Grid.Column<UserEntity> roleTypeColumn = grid.addColumn(UserEntity::getRoleType)
-                .setHeader("Тип ролі")
-                .setWidth("160px");
-
-        Grid.Column<UserEntity> actionsColumn = grid.addColumn(new ComponentRenderer<>(user -> {
-                    Button edit = new Button(new Icon(VaadinIcon.EDIT));
-                    edit.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
-                    edit.getElement().getStyle().set("width", "32px").set("height", "32px");
-                    edit.addClickListener(e -> editUser(user));
-
-                    Button reset = new Button(new Icon(VaadinIcon.KEY));
-                    reset.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
-                    reset.getElement().getStyle().set("width", "32px").set("height", "32px");
-                    reset.addClickListener(e -> resetPassUser(user));
-
-                    Button delete = new Button(new Icon(VaadinIcon.TRASH));
-                    delete.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_TERTIARY_INLINE);
-                    delete.getElement().getStyle().set("width", "32px").set("height", "32px");
-                    delete.addClickListener(e -> deleteUser(user));
-
-                    HorizontalLayout layout = new HorizontalLayout(edit, reset, delete);
-                    layout.setSpacing(false);
-                    layout.getStyle().set("gap", "6px");
-                    layout.setJustifyContentMode(JustifyContentMode.CENTER);
-                    return layout;
-                }))
-                .setHeader("Дії")
-                .setWidth("140px")
-                .setFlexGrow(0)
-                .setTextAlign(ColumnTextAlign.CENTER);
-
-        grid.addThemeVariants(GridVariant.LUMO_ROW_STRIPES, GridVariant.LUMO_COLUMN_BORDERS);
-        grid.setHeight("500px");
-
-        // ======== ДАНІ =========
-        List<UserEntity> allUsers = getDemoUsers();
-        ListDataProvider<UserEntity> dataProvider = new ListDataProvider<>(allUsers);
-        grid.setDataProvider(dataProvider);
-
-        // ======== ФІЛЬТРИ =========
-        HeaderRow filterRow = grid.appendHeaderRow();
-
-        TextField idFilter = createFilterField("ID", dataProvider,
-                user -> String.valueOf(user.getId()));
-        filterRow.getCell(idColumn).setComponent(idFilter);
-
-        TextField pibFilter = createFilterField("Фільтр за ПІБ", dataProvider,
-                UserEntity::getPib);
-        filterRow.getCell(pibColumn).setComponent(pibFilter);
-
-        TextField emailFilter = createFilterField("Фільтр за поштою", dataProvider,
-                UserEntity::getEmail);
-        filterRow.getCell(emailColumn).setComponent(emailFilter);
-
-        Checkbox activeFilter = new Checkbox();
-        activeFilter.addValueChangeListener(e -> {
-            dataProvider.clearFilters();
-            dataProvider.addFilter(user -> {
-                if (activeFilter.getValue()) return user.isActive();
-                else return true;
-            });
-        });
-        filterRow.getCell(activeColumn).setComponent(activeFilter);
-
-        TextField roleFilter = createFilterField("Фільтр за роллю", dataProvider,
-                UserEntity::getRole);
-        filterRow.getCell(roleColumn).setComponent(roleFilter);
-
-        TextField roleTypeFilter = createFilterField("Фільтр за типом", dataProvider,
-                UserEntity::getRoleType);
-        filterRow.getCell(roleTypeColumn).setComponent(roleTypeFilter);
-
-        allUserLayout.setWidthFull();
-        allUserLayout.add(grid);
-        add(allUserLayout);
+        binder.setBean(new UserFormData());
     }
 
-    /**
-     * Допоміжний метод створення текстового фільтра з live-оновленням.
-     */
-    private TextField createFilterField(String placeholder,
-                                        ListDataProvider<UserEntity> dataProvider,
-                                        ValueProvider<UserEntity, String> valueProvider) {
-        TextField filter = new TextField();
-        filter.setPlaceholder(placeholder);
-        filter.setWidthFull();
-        filter.setClearButtonVisible(true);
-        filter.addValueChangeListener(event ->
-                dataProvider.setFilter(user -> {
-                    String value = valueProvider.apply(user);
-                    if (value == null) return false;
-                    return value.toLowerCase().contains(event.getValue().toLowerCase());
-                })
-        );
-        return filter;
+    private void updateRoleTypeOptions(String role) {
+        roleTypeField.clear();
+        availableRoleTypeOptions = new ArrayList<>();
+
+        if (role == null) {
+            roleTypeField.setItems(Collections.emptyList());
+            roleTypeField.setEnabled(false);
+            return;
+        }
+
+        switch (role) {
+            case "DEKANAT" -> availableRoleTypeOptions = facultyService.getAllFaculties().stream()
+                    .map(faculty -> new RoleTypeOption(String.valueOf(faculty.getId()),
+                            faculty.getId() + ": " + faculty.getTitle()))
+                    .toList();
+            case "DEPARTMENT" -> availableRoleTypeOptions = departmentService.getAllDepartments().stream()
+                    .map(department -> new RoleTypeOption(String.valueOf(department.getId()),
+                            department.getId() + ": " + department.getTitle()))
+                    .toList();
+            default -> availableRoleTypeOptions = List.of(new RoleTypeOption("0", "0: Адміністратор"));
+        }
+
+        roleTypeField.setItems(availableRoleTypeOptions);
+        roleTypeField.setEnabled(true);
     }
 
-
-    private void editUser(UserEntity user) {
-        System.out.println("Редагуємо користувача: " + user.getPib());
+    private RoleTypeOption findRoleTypeOptionById(String id) {
+        if (id == null) {
+            return null;
+        }
+        return availableRoleTypeOptions.stream()
+                .filter(option -> option.id().equals(id))
+                .findFirst()
+                .orElse(null);
     }
 
-    private void deleteUser(UserEntity user) {
-        System.out.println("Видаляємо користувача: " + user.getPib());
-    }
-    private void resetPassUser(UserEntity user) {
-        System.out.println("Скидаємо пароль користувача: " + user.getPib());
+    private void saveUser() {
+        UserFormData formData = binder.getBean();
+        if (formData == null) {
+            formData = new UserFormData();
+            binder.setBean(formData);
+        }
+
+        try {
+            binder.writeBean(formData);
+        } catch (ValidationException e) {
+            Notification.show("Перевірте правильність заповнення форми", 4000, Notification.Position.MIDDLE)
+                    .addThemeVariants(NotificationVariant.LUMO_ERROR);
+            return;
+        }
+
+        try {
+            UserService.CreatedUser createdUser = userService.createUser(
+                    formData.getEmail(),
+                    formData.getFirstname(),
+                    formData.getLastname(),
+                    formData.getPatronymic(),
+                    formData.getRole(),
+                    formData.getRoleTypeId()
+            );
+
+            Notification notification = Notification.show(
+                    "Користувача створено. Тимчасовий пароль: " + createdUser.rawPassword(),
+                    7000,
+                    Notification.Position.MIDDLE
+            );
+            notification.addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+            resetForm();
+        } catch (IllegalArgumentException ex) {
+            Notification.show(ex.getMessage(), 5000, Notification.Position.MIDDLE)
+                    .addThemeVariants(NotificationVariant.LUMO_ERROR);
+        }
     }
 
-    private List<UserEntity> getDemoUsers() {
-        List<UserEntity> list = new ArrayList<>();
-        list.add(new UserEntity(1L, "Іваненко Іван Іванович", "qwerty@gmail.com", true, "Адмін", "Системна"));
-        list.add(new UserEntity(2L, "Петренко Петро Петрович", "qwerty@gmail.com", false, "Користувач", "Локальна"));
-        list.add(new UserEntity(3L, "Сидоренко Олег Васильович", "qwerty@gmail.com", true ,"Модератор", "Проєктна"));
-        return list;
+    private void resetForm() {
+        binder.setBean(new UserFormData());
+        roleTypeField.clear();
+        roleTypeField.setItems(Collections.emptyList());
+        roleTypeField.setEnabled(false);
     }
+
+    private static class UserFormData {
+        private String firstname;
+        private String lastname;
+        private String patronymic;
+        private String email;
+        private String role;
+        private String roleTypeId;
+
+        public String getFirstname() {
+            return firstname;
+        }
+
+        public void setFirstname(String firstname) {
+            this.firstname = firstname;
+        }
+
+        public String getLastname() {
+            return lastname;
+        }
+
+        public void setLastname(String lastname) {
+            this.lastname = lastname;
+        }
+
+        public String getPatronymic() {
+            return patronymic;
+        }
+
+        public void setPatronymic(String patronymic) {
+            this.patronymic = patronymic;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public String getRole() {
+            return role;
+        }
+
+        public void setRole(String role) {
+            this.role = role;
+        }
+
+        public String getRoleTypeId() {
+            return roleTypeId;
+        }
+
+        public void setRoleTypeId(String roleTypeId) {
+            this.roleTypeId = roleTypeId;
+        }
+    }
+
+    private record RoleTypeOption(String id, String label) { }
 }

--- a/src/test/java/com/esvar/dekanat/service/PlanServiceTest.java
+++ b/src/test/java/com/esvar/dekanat/service/PlanServiceTest.java
@@ -149,6 +149,29 @@ class PlanServiceTest {
                 .doesNotContain("Перший модульний контроль", "Другий модульний контроль");
     }
 
+    @Test
+    void shouldReturnPlanControlTypesWhenSemesterDoesNotMatchSession() {
+        plan.setSemester(1); // Не відповідає семестру, обчисленому для літньої сесії
+
+        when(planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
+                any(), any(), any(), anyInt(), anyInt(), any()))
+                .thenReturn(List.of(plan));
+        when(studentRepository.findByGroup(group))
+                .thenReturn(List.of(createStudent(true)));
+
+        List<String> controlTypes = planService.getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
+                "Faculty",
+                "Department",
+                "SP",
+                1,
+                1,
+                "Math"
+        );
+
+        assertThat(controlTypes)
+                .contains("Екзамен", "Залік");
+    }
+
     private StudentEntity createStudent(boolean fullTime) {
         StudentEntity student = new StudentEntity();
         student.setId(fullTime ? 11L : 12L);

--- a/src/test/java/com/esvar/dekanat/service/PlanServiceTest.java
+++ b/src/test/java/com/esvar/dekanat/service/PlanServiceTest.java
@@ -1,0 +1,164 @@
+package com.esvar.dekanat.service;
+
+import com.esvar.dekanat.entity.*;
+import com.esvar.dekanat.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PlanServiceTest {
+
+    @Mock
+    private PlanRepository planRepository;
+    @Mock
+    private StudentPlansRepository studentPlansRepository;
+    @Mock
+    private StudentRepository studentRepository;
+    @Mock
+    private FacultyRepository facultyRepository;
+    @Mock
+    private DepartmentRepository departmentRepository;
+    @Mock
+    private SessionRepository sessionRepository;
+    @Mock
+    private MarksService marksService;
+    @Mock
+    private MarksPartsService marksPartsService;
+    @Mock
+    private MarksInitializerService marksInitializerService;
+    @Mock
+    private PlanStatementNumberService planStatementNumberService;
+
+    @InjectMocks
+    private PlanService planService;
+
+    private FacultyEntity faculty;
+    private DepartmentEntity department;
+    private DisciplineEntity discipline;
+    private ControlMethodEntity firstControl;
+    private ControlMethodEntity secondControl;
+    private StudentGroupEntity group;
+    private PlansEntity plan;
+
+    @BeforeEach
+    void setUp() {
+        faculty = new FacultyEntity();
+        faculty.setId(1L);
+        faculty.setTitle("Faculty");
+
+        department = new DepartmentEntity();
+        department.setId(2L);
+        department.setTitle("Department");
+
+        SpecialtyEntity specialty = new SpecialtyEntity();
+        specialty.setId(3L);
+        specialty.setAbbreviation("SP");
+
+        discipline = new DisciplineEntity();
+        discipline.setId(4L);
+        discipline.setTitle("Math");
+
+        firstControl = new ControlMethodEntity();
+        firstControl.setId(5L);
+        firstControl.setName("Екзамен");
+        firstControl.setType(1);
+
+        secondControl = new ControlMethodEntity();
+        secondControl.setId(6L);
+        secondControl.setName("Залік");
+        secondControl.setType(2);
+
+        group = new StudentGroupEntity();
+        group.setId(7L);
+        group.setCourse(1);
+        group.setGroupNumber(1);
+        group.setYear(2024);
+        group.setSpecialty(specialty);
+        group.setGroupCode("SP-1-1-2024");
+
+        plan = new PlansEntity();
+        plan.setId(8L);
+        plan.setDiscipline(discipline);
+        plan.setSemester(2);
+        plan.setFirstControl(firstControl);
+        plan.setSecondControl(secondControl);
+        plan.setGroups(Set.of(group));
+
+        when(facultyRepository.findByTitle("Faculty"))
+                .thenReturn(faculty);
+        when(departmentRepository.findByTitle("Department"))
+                .thenReturn(department);
+        when(sessionRepository.findById(1L))
+                .thenReturn(Optional.of(new SessionEntity(1L, false)));
+    }
+
+    @Test
+    void shouldIncludeModuleControlsForFullTimeGroup() {
+        StudentEntity fullTimeStudent = createStudent(true);
+        when(planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
+                any(), any(), any(), anyInt(), anyInt(), any()))
+                .thenReturn(List.of(plan));
+        when(studentRepository.findByGroup(group))
+                .thenReturn(List.of(fullTimeStudent));
+
+        List<String> controlTypes = planService.getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
+                "Faculty",
+                "Department",
+                "SP",
+                1,
+                1,
+                "Math"
+        );
+
+        assertThat(controlTypes)
+                .contains("Перший модульний контроль", "Другий модульний контроль");
+    }
+
+    @Test
+    void shouldSkipModuleControlsForPartTimeGroup() {
+        StudentEntity partTimeStudent = createStudent(false);
+        when(planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
+                any(), any(), any(), anyInt(), anyInt(), any()))
+                .thenReturn(List.of(plan));
+        when(studentRepository.findByGroup(group))
+                .thenReturn(List.of(partTimeStudent));
+
+        List<String> controlTypes = planService.getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
+                "Faculty",
+                "Department",
+                "SP",
+                1,
+                1,
+                "Math"
+        );
+
+        assertThat(controlTypes)
+                .doesNotContain("Перший модульний контроль", "Другий модульний контроль");
+    }
+
+    private StudentEntity createStudent(boolean fullTime) {
+        StudentEntity student = new StudentEntity();
+        student.setId(fullTime ? 11L : 12L);
+        student.setName("Ім'я");
+        student.setSurname("Прізвище");
+        student.setPatronymic("По батькові");
+        student.setFaculty(faculty);
+        student.setGroup(group);
+        student.setRecordBookNumber(fullTime ? "FT" : "PT");
+        student.setFullTime(fullTime);
+        return student;
+    }
+}


### PR DESCRIPTION
## Summary
- normalize and validate required fields when creating users
- ensure role values are limited to supported options and role types are numeric for faculties/departments
- default admin role type to 0 while keeping email uniqueness protection

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693947202ed08326b0601f8e4958ccb9)