### PR TITLE
Validate SMTP configuration before sending welcome emails

### DIFF
--- a/src/main/java/com/esvar/dekanat/mailer/EmailService.java
+++ b/src/main/java/com/esvar/dekanat/mailer/EmailService.java
@@ -2,10 +2,15 @@ package com.esvar.dekanat.mailer;
 
 import com.esvar.dekanat.user.UserModel;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.mail.MailProperties;
+import org.springframework.mail.MailException;
+import org.springframework.mail.MailPreparationException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -13,12 +18,17 @@ import java.util.stream.Collectors;
 @Service
 public class EmailService {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmailService.class);
+
     private final JavaMailSender mailSender;
+    private final MailProperties mailProperties;
     private final String defaultFrom;
 
     public EmailService(JavaMailSender mailSender,
+                        MailProperties mailProperties,
                         @Value("${mail.default-from:}") String defaultFrom) {
         this.mailSender = mailSender;
+        this.mailProperties = mailProperties;
         this.defaultFrom = defaultFrom;
     }
 
@@ -30,6 +40,13 @@ public class EmailService {
             throw new IllegalArgumentException("Потрібно вказати тему листа.");
         }
 
+        if (!StringUtils.hasText(mailProperties.getHost())) {
+            throw new MailPreparationException("Налаштуйте SMTP сервер: MAIL_HOST не задано.");
+        }
+        if (mailProperties.getPort() == null) {
+            throw new MailPreparationException("Налаштуйте SMTP сервер: MAIL_PORT не задано.");
+        }
+
         SimpleMailMessage message = new SimpleMailMessage();
         if (StringUtils.hasText(defaultFrom)) {
             message.setFrom(defaultFrom);
@@ -37,7 +54,12 @@ public class EmailService {
         message.setTo(recipient);
         message.setSubject(subject);
         message.setText(body == null ? "" : body);
-        mailSender.send(message);
+        try {
+            mailSender.send(message);
+        } catch (MailException ex) {
+            LOGGER.warn("Не вдалося надіслати email користувачу {}: {}", recipient, ex.getMessage());
+            throw ex;
+        }
     }
 
     public void sendWelcomeEmail(UserModel userModel, String rawPassword) {


### PR DESCRIPTION
## Summary
- validate SMTP configuration before attempting to send emails
- log a warning when sending fails so issues are easier to diagnose

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693979134d2883268a76339e33fdd4c8)