### PR TITLE
Customize welcome emails for different user roles

### DIFF
--- a/src/main/java/com/esvar/dekanat/mailer/EmailService.java
+++ b/src/main/java/com/esvar/dekanat/mailer/EmailService.java
@@ -61,8 +61,20 @@ public class EmailService {
     }
 
     public void sendWelcomeEmail(UserModel userModel, String rawPassword) {
+        String subject = "Доступ до системи Деканат";
+        String role = userModel.getRole();
+        String body = switch (role == null ? "" : role) {
+            case "ROLE_DEPARTMENT" -> buildTeacherEmailBody(userModel, rawPassword);
+            case "ROLE_ADMIN" -> buildAdminEmailBody(userModel, rawPassword);
+            default -> buildDekanatEmailBody(userModel, rawPassword);
+        };
+
+        sendEmail(userModel.getEmail(), subject, body);
+    }
+
+    private String buildDekanatEmailBody(UserModel userModel, String rawPassword) {
         String fullName = composeFullName(userModel);
-        String body = """
+        return """
         Шановний(-а) %s!
 
         Вас підключено до інформаційної системи АСУ «Деканат».
@@ -80,10 +92,83 @@ public class EmailService {
         З повагою,
         Команда АСУ «Деканат»
         dekanat.support@ntu.edu.ua
-        """.stripIndent().formatted(fullName, userModel.getEmail(), rawPassword);
+        """.stripIndent().formatted(resolveDisplayName(fullName, userModel), userModel.getEmail(), rawPassword);
+    }
 
+    private String buildTeacherEmailBody(UserModel userModel, String rawPassword) {
+        String fullName = composeFullName(userModel);
+        return """
+        Шановний(а) %s!
 
-        sendEmail(userModel.getEmail(), "Доступ до системи Деканат", body);
+        Вам надано доступ до АСУ «Деканат» у ролі викладача для внесення результатів оцінювання.
+
+        Дані для входу:
+
+            Адреса системи: https://dekanat.ntu.edu.ua/
+
+            Логін: %s
+
+            Пароль: %s
+
+        Порядок роботи з системою
+
+            Увійдіть до системи, використовуючи надані облікові дані.
+
+            Оберіть спеціальність, курс та групу, у якій Ви викладаєте.
+
+            Оберіть дисципліну та тип контролю.
+
+            Після завантаження відомості внесіть оцінки у колонку «Оцінка»:
+
+                0–30 балів — для першого та другого модульного контролю,
+
+                60–100 балів — для заліку, екзамену та інших підсумкових форм контролю.
+
+            Після внесення оцінок натисніть «Зберегти».
+
+        Увага!
+
+        Для генерування PDF-файлу відомості з метою її подальшого друку необхідно затвердити оцінки, натиснувши кнопку «Затвердити».
+
+        Після затвердження оцінок стане доступною можливість сформувати відомість у форматі PDF — активується кнопка «Друк відомості».
+
+        При натисканні кнопки «Друк відомості» з’явиться вікно для внесення даних про викладача, який здійснював поточне оцінювання (другого викладача, що вів лабораторні, практичні, семінарські заняття тощо).
+
+        Звертаємо увагу, що першим (ГОЛОВНИМ) викладачем у відомості буде той, хто безпосередньо генерує документ.
+
+        Наполегливо рекомендуємо не передавати лаври першості своїм менш іменитим колегам 😉
+
+        Внесення змін до вже затверджених оцінок неможливе. Якщо вам необхідно внести коригування після затвердження, зверніться до методиста факультету/інституту, до якого належить група — вони мають можливість розблокувати оцінки.
+
+        Звертаємо вашу увагу!
+        З міркувань інформаційної безпеки категорично заборонено передавати свої облікові дані стороннім особам або надавати доступ до системи під власним акаунтом.
+
+        У разі виявлення таких випадків доступ до облікового запису буде негайно заблоковано до моменту з’ясування всіх обставин.
+        Повторні порушення можуть призвести до повного анулювання доступу до системи та подальшої службової перевірки.
+
+        Просимо поставитися до цього з максимальною відповідальністю. Система фіксує всі дії користувачів і уникнути ідентифікації порушника неможливо.
+
+        У разі виникнення запитань чи технічних складнощів звертайтесь на адресу підтримки:
+        dekanat.support@ntu.edu.ua
+        З повагою,
+        Команда системи «Деканат»
+        """.stripIndent().formatted(resolveDisplayName(fullName, userModel), userModel.getEmail(), rawPassword);
+    }
+
+    private String buildAdminEmailBody(UserModel userModel, String rawPassword) {
+        String fullName = composeFullName(userModel);
+        return """
+        Шановний(а) %s!
+
+        Для вас створено адміністраторський обліковий запис у системі «Деканат».
+
+        Дані для входу:
+        Адреса системи: https://dekanat.ntu.edu.ua/
+        Логін: %s
+        Пароль: %s
+
+        З міркувань безпеки не передавайте ваші облікові дані третім особам.
+        """.stripIndent().formatted(resolveDisplayName(fullName, userModel), userModel.getEmail(), rawPassword);
     }
 
     private String resolveFromAddress() {
@@ -103,5 +188,9 @@ public class EmailService {
                 .map(String::trim)
                 .filter(value -> !value.isEmpty())
                 .collect(Collectors.joining(" "));
+    }
+
+    private String resolveDisplayName(String fullName, UserModel userModel) {
+        return StringUtils.hasText(fullName) ? fullName : userModel.getEmail();
     }
 }


### PR DESCRIPTION
## Summary
- send distinct welcome emails depending on user role (dekanat, teacher, admin)
- add detailed instructions for teachers and concise admin account notice while preserving the dekanat message
- fall back to email when a full name is unavailable to personalize greetings

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69398266c870832685e50385f3defee6)