### PR TITLE
Add second module summary report generation

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
@@ -38,6 +38,7 @@ public class SummaryReportPdfGenerator {
     private static final float FIRST_COLUMN_WIDTH = 150f;
     private static final float OTHER_COLUMN_WIDTH = 35f;
     private static final float HEADER_ROW_HEIGHT = 110f;
+    private static final String FIRST_MODULE_TITLE = "за перший модульний контроль";
 
     // ЗАЛИШАЄМО твою існуючу сигнатуру як-є для зворотної сумісності:
     public byte[] generateSummaryReport(
@@ -54,9 +55,10 @@ public class SummaryReportPdfGenerator {
                 disciplineColumns,
                 marksByStudent,
                 addAverageRow,
-                null,        // examiner
-                false,       // numericHeader
-                false        // includeSignature
+                null,                // examiner
+                false,               // numericHeader
+                false,               // includeSignature
+                FIRST_MODULE_TITLE   // controlTitle
         );
     }
 
@@ -79,7 +81,8 @@ public class SummaryReportPdfGenerator {
                 addAverageRow,
                 examiner,
                 numericHeader,
-                includeSignature
+                includeSignature,
+                FIRST_MODULE_TITLE
         );
     }
 
@@ -91,7 +94,8 @@ public class SummaryReportPdfGenerator {
             boolean addAverageRow,
             String examiner,
             boolean numericHeader,
-            boolean includeSignature
+            boolean includeSignature,
+            String controlTitle
     ) {
         System.out.println("[SummaryReportPdfGenerator] Старт генерації PDF для групи: " + groupName);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -106,7 +110,7 @@ public class SummaryReportPdfGenerator {
 
             Paragraph title = new Paragraph(
                     "Зведений звіт результатів оцінювання студентів групи " + groupName +
-                            " за перший модульний контроль")
+                            " " + controlTitle)
                     .setTextAlignment(TextAlignment.CENTER)
                     .setFontSize(14)
                     .setMarginBottom(10);

--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -1258,7 +1258,7 @@ public class EnterMarksView extends Div {
         secondModuleButton.setWidthFull();
         secondModuleButton.addClickListener(event -> {
             reportDialog.close();
-            notifyFeatureInDevelopment();
+            generateSecondModuleSummaryReport();
         });
 
         Button semesterButton = new Button("Семестровий");
@@ -1282,6 +1282,22 @@ public class EnterMarksView extends Div {
         try {
             SummaryReportResult result = summaryReportService.generateFirstModuleReport(selectGroup.getValue());
             String fileName = String.format("summary-first-module-%s.pdf", result.groupCode());
+            openPdfReport(fileName, result.pdfBytes());
+
+            Notification notification = Notification.show("Звіт сформовано");
+            notification.setDuration(3000);
+        } catch (SummaryReportGenerationException ex) {
+            Notification.show(ex.getMessage());
+        } catch (RuntimeException ex) {
+            log.error("Не вдалося згенерувати зведений звіт", ex);
+            Notification.show("Не вдалося згенерувати звіт");
+        }
+    }
+
+    private void generateSecondModuleSummaryReport() {
+        try {
+            SummaryReportResult result = summaryReportService.generateSecondModuleReport(selectGroup.getValue());
+            String fileName = String.format("summary-second-module-%s.pdf", result.groupCode());
             openPdfReport(fileName, result.pdfBytes());
 
             Notification notification = Notification.show("Звіт сформовано");

--- a/src/main/java/com/esvar/dekanat/plan/PlanView.java
+++ b/src/main/java/com/esvar/dekanat/plan/PlanView.java
@@ -412,20 +412,18 @@ public class PlanView extends Div {
 
     private void configureReportButtons() {
         List<Button> reportButtons = List.of(firstModuleButton, secondModuleButton, semesterControlButton);
-        reportButtons.forEach(button -> {
-            button.addThemeVariants(ButtonVariant.LUMO_CONTRAST);
-            button.setTooltipText("Функціонал генерації у розробці");
-        });
+        reportButtons.forEach(button -> button.addThemeVariants(ButtonVariant.LUMO_CONTRAST));
+
+        firstModuleButton.setTooltipText("Зведений звіт за перший модульний контроль");
+        secondModuleButton.setTooltipText("Зведений звіт за другий модульний контроль");
+        semesterControlButton.setTooltipText("Генерація семестрових відомостей у розробці");
 
         firstModuleButton.addClickListener(buttonClickEvent -> {
             generateFirstModuleSummaryReport();
             Notification.show("Генерація першого модулю");
         });
         secondModuleButton.addClickListener(buttonClickEvent -> {
-            Notification.show("Генерація відомостей буде доступна найближчим часом.");
-        });
-        secondModuleButton.addClickListener(buttonClickEvent -> {
-            Notification.show("Генерація відомостей буде доступна найближчим часом.");
+            generateSecondModuleSummaryReport();
         });
 
         firstModuleButton.setIcon(VaadinIcon.FILE_TEXT.create());
@@ -438,6 +436,22 @@ public class PlanView extends Div {
         try {
             SummaryReportService.SummaryReportResult result = summaryReportService.generateFirstModuleReport(selectGroup.getValue());
             String fileName = String.format("summary-first-module-%s.pdf", result.groupCode());
+            openPdfReport(fileName, result.pdfBytes());
+
+            Notification notification = Notification.show("Звіт сформовано");
+            notification.setDuration(3000);
+        } catch (SummaryReportService.SummaryReportGenerationException ex) {
+            Notification.show(ex.getMessage());
+        } catch (RuntimeException ex) {
+            log.error("Не вдалося згенерувати зведений звіт", ex);
+            Notification.show("Не вдалося згенерувати звіт");
+        }
+    }
+
+    private void generateSecondModuleSummaryReport() {
+        try {
+            SummaryReportService.SummaryReportResult result = summaryReportService.generateSecondModuleReport(selectGroup.getValue());
+            String fileName = String.format("summary-second-module-%s.pdf", result.groupCode());
             openPdfReport(fileName, result.pdfBytes());
 
             Notification notification = Notification.show("Звіт сформовано");

--- a/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
+++ b/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 public class SummaryReportService {
 
     private static final String CONTROL_TYPE_FIRST_MODULE = "Перший модульний контроль";
+    private static final String CONTROL_TYPE_SECOND_MODULE = "Другий модульний контроль";
 
     private final GroupService groupService;
     private final StudentService studentService;
@@ -50,7 +51,16 @@ public class SummaryReportService {
 
     @Transactional(readOnly = true)
     public SummaryReportResult generateFirstModuleReport(GroupDTO selectedGroup) {
-        System.out.println("[SummaryReportService] Початок генерації звіту для першого модулю");
+        return generateModuleReport(selectedGroup, CONTROL_TYPE_FIRST_MODULE, false);
+    }
+
+    @Transactional(readOnly = true)
+    public SummaryReportResult generateSecondModuleReport(GroupDTO selectedGroup) {
+        return generateModuleReport(selectedGroup, CONTROL_TYPE_SECOND_MODULE, true);
+    }
+
+    private SummaryReportResult generateModuleReport(GroupDTO selectedGroup, String controlType, boolean includeSignature) {
+        System.out.println("[SummaryReportService] Початок генерації звіту для контролю: " + controlType);
         if (selectedGroup == null) {
             System.out.println("[SummaryReportService] Не обрано групу для звіту");
             throw new SummaryReportGenerationException("Оберіть групу для формування звіту");
@@ -70,11 +80,11 @@ public class SummaryReportService {
         System.out.println("[SummaryReportService] Знайдено студентів: " + students.size());
 
         int semester = computeFirstModuleSemester(selectedGroup.getCourse());
-        System.out.println("[SummaryReportService] Обчислено семестр першого модулю: " + semester);
-        Map<Long, PlanAssignment> planAssignments = collectPlanAssignments(group, semester, students);
+        System.out.println("[SummaryReportService] Обчислено семестр для контролю: " + semester);
+        Map<Long, PlanAssignment> planAssignments = collectPlanAssignments(group, semester, students, controlType);
         if (planAssignments.isEmpty()) {
-            System.out.println("[SummaryReportService] Не знайдено планів для першого модулю");
-            throw new SummaryReportGenerationException("Не знайдено дисциплін для першого модульного контролю");
+            System.out.println("[SummaryReportService] Не знайдено планів для контролю: " + controlType);
+            throw new SummaryReportGenerationException("Не знайдено дисциплін для обраного модульного контролю");
         }
 
         System.out.println("[SummaryReportService] Зібрано планів: " + planAssignments.size());
@@ -108,7 +118,8 @@ public class SummaryReportService {
                 true,
                 examiner,
                 false,
-                false
+                includeSignature,
+                buildReportTitle(controlType)
         );
 
         System.out.println("[SummaryReportService] Генерація PDF завершена, розмір: " + (pdfBytes == null ? 0 : pdfBytes.length));
@@ -163,18 +174,26 @@ public class SummaryReportService {
         return course * 2 - 1;
     }
 
+    private String buildReportTitle(String controlType) {
+        if (controlType == null || controlType.isBlank()) {
+            return "";
+        }
+        return "за " + controlType.toLowerCase(Locale.ROOT);
+    }
+
     private Map<Long, PlanAssignment> collectPlanAssignments(StudentGroupEntity group,
                                                              int semester,
-                                                             List<StudentEntity> students) {
+                                                             List<StudentEntity> students,
+                                                             String controlType) {
         Map<Long, PlanAssignment> assignments = new LinkedHashMap<>();
-        Map<Long, ControlMethodEntity> firstModuleControlCache = new HashMap<>();
+        Map<Long, ControlMethodEntity> moduleControlCache = new HashMap<>();
 
         System.out.println("[SummaryReportService] Завантажуємо плани групи для семестру " + semester);
         List<PlansEntity> groupPlans = planService.getAllPlansForGroupAndSemester(group, semester);
         if (groupPlans != null) {
             System.out.println("[SummaryReportService] Отримано планів групи: " + groupPlans.size());
             for (PlansEntity plan : groupPlans) {
-                PlanAssignment assignment = ensurePlanAssignment(assignments, plan, firstModuleControlCache);
+                PlanAssignment assignment = ensurePlanAssignment(assignments, plan, moduleControlCache, controlType);
                 if (assignment != null) {
                     System.out.println("[SummaryReportService] Додаємо план групи: " + safeDisciplineTitle(plan));
                 }
@@ -192,13 +211,13 @@ public class SummaryReportService {
             for (StudentPlansEntity studentPlan : studentPlans) {
                 PlansEntity plan = studentPlan.getPlan();
                 if (plan == null || plan.getSemester() != semester) {
-                    System.out.println("[SummaryReportService] Пропускаємо план (не підходить для 1 модулю)");
+                    System.out.println("[SummaryReportService] Пропускаємо план (не підходить для модульного контролю)");
                     continue;
                 }
 
-                PlanAssignment assignment = ensurePlanAssignment(assignments, plan, firstModuleControlCache);
+                PlanAssignment assignment = ensurePlanAssignment(assignments, plan, moduleControlCache, controlType);
                 if (assignment == null) {
-                    System.out.println("[SummaryReportService] Пропускаємо план (не підходить для 1 модулю)");
+                    System.out.println("[SummaryReportService] Пропускаємо план (не підходить для модульного контролю)");
                     continue;
                 }
 
@@ -213,14 +232,15 @@ public class SummaryReportService {
 
     private PlanAssignment ensurePlanAssignment(Map<Long, PlanAssignment> assignments,
                                                 PlansEntity plan,
-                                                Map<Long, ControlMethodEntity> controlCache) {
+                                                Map<Long, ControlMethodEntity> controlCache,
+                                                String controlType) {
         if (plan == null) {
             return null;
         }
 
-        ControlMethodEntity control = resolveFirstModuleControl(plan, controlCache);
+        ControlMethodEntity control = resolveModuleControl(plan, controlCache, controlType);
         if (control == null) {
-            System.out.println("[SummaryReportService] План '" + safeDisciplineTitle(plan) + "' не має контролю '" + CONTROL_TYPE_FIRST_MODULE + "'");
+            System.out.println("[SummaryReportService] План '" + safeDisciplineTitle(plan) + "' не має контролю '" + controlType + "'");
             return null;
         }
 
@@ -232,8 +252,9 @@ public class SummaryReportService {
         return assignment;
     }
 
-    private ControlMethodEntity resolveFirstModuleControl(PlansEntity plan,
-                                                          Map<Long, ControlMethodEntity> controlCache) {
+    private ControlMethodEntity resolveModuleControl(PlansEntity plan,
+                                                     Map<Long, ControlMethodEntity> controlCache,
+                                                     String controlType) {
         if (plan == null || plan.getId() == null) {
             return null;
         }
@@ -243,12 +264,12 @@ public class SummaryReportService {
         }
 
         ControlMethodEntity control = null;
-        if (isFirstModuleControl(plan.getFirstControl())) {
+        if (isMatchingControl(plan.getFirstControl(), controlType)) {
             control = plan.getFirstControl();
-        } else if (isFirstModuleControl(plan.getSecondControl())) {
+        } else if (isMatchingControl(plan.getSecondControl(), controlType)) {
             control = plan.getSecondControl();
         } else {
-            List<MarksEntity> marks = marksService.findMarksByPlanAndTypeControl(plan, CONTROL_TYPE_FIRST_MODULE);
+            List<MarksEntity> marks = marksService.findMarksByPlanAndTypeControl(plan, controlType);
             if (marks != null && !marks.isEmpty()) {
                 control = marks.get(0).getControlMethod();
             }
@@ -256,15 +277,15 @@ public class SummaryReportService {
 
         controlCache.put(plan.getId(), control);
         System.out.println("[SummaryReportService] План '" + safeDisciplineTitle(plan) + "' "
-                + (control != null ? "має" : "не має") + " контроль '" + CONTROL_TYPE_FIRST_MODULE + "'");
+                + (control != null ? "має" : "не має") + " контроль '" + controlType + "'");
         return control;
     }
 
-    private boolean isFirstModuleControl(ControlMethodEntity controlMethod) {
+    private boolean isMatchingControl(ControlMethodEntity controlMethod, String controlType) {
         if (controlMethod == null || controlMethod.getName() == null) {
             return false;
         }
-        return controlMethod.getName().trim().equalsIgnoreCase(CONTROL_TYPE_FIRST_MODULE);
+        return controlMethod.getName().trim().equalsIgnoreCase(controlType);
     }
 
     private Map<String, List<Integer>> buildMarksForSummaryReport(List<StudentEntity> students,
@@ -331,9 +352,9 @@ public class SummaryReportService {
         List<DisciplineSummary> summaries = new ArrayList<>();
         for (PlanAssignment assignment : assignments) {
             PlansEntity plan = assignment.plan;
-            ControlMethodEntity controlMethod = assignment.firstModuleControl;
+            ControlMethodEntity controlMethod = assignment.moduleControl;
             if (controlMethod == null) {
-                System.out.println("[SummaryReportService] Пропущено план без контролю першого модулю");
+                System.out.println("[SummaryReportService] Пропущено план без контрольної події");
                 continue;
             }
             DisciplineEntity discipline = plan.getDiscipline();
@@ -402,12 +423,12 @@ public class SummaryReportService {
 
     private static class PlanAssignment {
         private final PlansEntity plan;
-        private final ControlMethodEntity firstModuleControl;
+        private final ControlMethodEntity moduleControl;
         private final Set<Long> assignedStudentIds = new LinkedHashSet<>();
 
-        private PlanAssignment(PlansEntity plan, ControlMethodEntity firstModuleControl) {
+        private PlanAssignment(PlansEntity plan, ControlMethodEntity moduleControl) {
             this.plan = plan;
-            this.firstModuleControl = firstModuleControl;
+            this.moduleControl = moduleControl;
         }
     }
 


### PR DESCRIPTION
## Summary
- enable generation of a second-module summary report with signature on plan and marks pages
- generalize summary report service and PDF generator to handle module-specific control types and titles
- reuse existing layouts while pulling marks specifically for the second module

## Testing
- mvnw -q -DskipTests package *(fails: Maven download blocked in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a1a77af448326a903d615f1a802ca)