### PR TITLE
Add combined two-module summary report with split marks

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
@@ -39,6 +39,7 @@ public class SummaryReportPdfGenerator {
     private static final float OTHER_COLUMN_WIDTH = 35f;
     private static final float HEADER_ROW_HEIGHT = 110f;
     private static final String FIRST_MODULE_TITLE = "за перший модульний контроль";
+    private static final String TWO_MODULE_TITLE = "за два модульних контроля";
 
     // ЗАЛИШАЄМО твою існуючу сигнатуру як-є для зворотної сумісності:
     public byte[] generateSummaryReport(
@@ -60,6 +61,95 @@ public class SummaryReportPdfGenerator {
                 false,               // includeSignature
                 FIRST_MODULE_TITLE   // controlTitle
         );
+    }
+
+    public byte[] generateTwoModuleSummaryReport(
+            String groupName,
+            List<String> studentFullNames,
+            List<DisciplineColumn> disciplineColumns,
+            Map<String, List<ModuleMark>> marksByStudent,
+            boolean addAverageRow,
+            String examiner,
+            boolean numericHeader,
+            boolean includeSignature
+    ) {
+        return generateTwoModuleSummaryReport(
+                groupName,
+                studentFullNames,
+                disciplineColumns,
+                marksByStudent,
+                addAverageRow,
+                examiner,
+                numericHeader,
+                includeSignature,
+                TWO_MODULE_TITLE
+        );
+    }
+
+    public byte[] generateTwoModuleSummaryReport(
+            String groupName,
+            List<String> studentFullNames,
+            List<DisciplineColumn> disciplineColumns,
+            Map<String, List<ModuleMark>> marksByStudent,
+            boolean addAverageRow,
+            String examiner,
+            boolean numericHeader,
+            boolean includeSignature,
+            String controlTitle
+    ) {
+        System.out.println("[SummaryReportPdfGenerator] Старт генерації PDF для групи (2 модулі): " + groupName);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        try (PdfWriter writer = new PdfWriter(baos);
+             PdfDocument pdfDocument = new PdfDocument(writer);
+             Document document = new Document(pdfDocument, PageSize.A4.rotate())) {
+
+            document.setMargins(20, 20, 20, 20);
+            document.setFont(createFont());
+            System.out.println("[SummaryReportPdfGenerator] Створено документ і встановлено шрифт");
+
+            Paragraph title = new Paragraph(
+                    "Зведений звіт результатів оцінювання студентів групи " + groupName +
+                            " " + controlTitle)
+                    .setTextAlignment(TextAlignment.CENTER)
+                    .setFontSize(14)
+                    .setMarginBottom(10);
+            document.add(title);
+            System.out.println("[SummaryReportPdfGenerator] Додано заголовок (2 модулі)");
+
+            Table table = createTwoModuleTableStructure(disciplineColumns.size());
+            addTwoModuleHeaderRows(table, disciplineColumns);
+            addTwoModuleStudentRows(table, studentFullNames, disciplineColumns, marksByStudent);
+            System.out.println("[SummaryReportPdfGenerator] Додано рядки студентів (2 модулі)");
+
+            if (addAverageRow) {
+                addTwoModuleZeroSummaryRow(table, studentFullNames, disciplineColumns, marksByStudent);
+                System.out.println("[SummaryReportPdfGenerator] Додано підсумковий рядок по нулям (2 модулі)");
+            }
+
+            document.add(table);
+            System.out.println("[SummaryReportPdfGenerator] Таблицю додано до документу (2 модулі)");
+
+            if (includeSignature) {
+                Table lastRowTable = createTwoModuleTableStructure(disciplineColumns.size());
+                lastRowTable.setWidth(UnitValue.createPercentValue(100));
+                lastRowTable.setFixedLayout();
+
+                Div footer = generate(examiner, lastRowTable, numericHeader);
+                document.add(footer);
+                System.out.println("[SummaryReportPdfGenerator] Додано футер (numericHeader=" + numericHeader
+                        + ", includeSignature=true) для 2 модулів");
+            } else {
+                System.out.println("[SummaryReportPdfGenerator] Футер з підписом пропущено (2 модулі)");
+            }
+
+        } catch (IOException e) {
+            System.out.println("[SummaryReportPdfGenerator] Помилка генерації PDF (2 модулі): " + e.getMessage());
+            throw new IllegalStateException("Не вдалося згенерувати PDF звіт", e);
+        }
+
+        System.out.println("[SummaryReportPdfGenerator] Генерація PDF завершена (2 модулі)");
+        return baos.toByteArray();
     }
 
     // НОВИЙ ОВЕРЛОАД: з екзаменатором та прапорцем numericHeader
@@ -184,6 +274,24 @@ public class SummaryReportPdfGenerator {
         return table;
     }
 
+    private Table createTwoModuleTableStructure(int disciplineCount) {
+        System.out.println("[SummaryReportPdfGenerator] Створюємо структуру таблиці (2 модулі). Кількість дисциплін: "
+                + disciplineCount);
+        int totalColumns = 2 + disciplineCount * 3;
+        float[] columnWidths = new float[totalColumns];
+        columnWidths[0] = FIRST_COLUMN_WIDTH;
+        for (int i = 1; i < totalColumns - 1; i++) {
+            columnWidths[i] = OTHER_COLUMN_WIDTH;
+        }
+        columnWidths[totalColumns - 1] = OTHER_COLUMN_WIDTH;
+
+        Table table = new Table(columnWidths);
+        table.setWidth(UnitValue.createPercentValue(100));
+        table.setFixedLayout();
+        System.out.println("[SummaryReportPdfGenerator] Таблиця (2 модулі) створена з " + totalColumns + " колонками");
+        return table;
+    }
+
     private void addHeaderRows(Table table, List<DisciplineColumn> disciplineColumns) {
         System.out.println("[SummaryReportPdfGenerator] Додаємо заголовки колонок");
         int disciplineCount = disciplineColumns.size();
@@ -246,6 +354,59 @@ public class SummaryReportPdfGenerator {
         System.out.println("[SummaryReportPdfGenerator] Заголовки колонок додано");
     }
 
+    private void addTwoModuleHeaderRows(Table table, List<DisciplineColumn> disciplineColumns) {
+        System.out.println("[SummaryReportPdfGenerator] Додаємо заголовки колонок (2 модулі)");
+
+        Cell nameHeader = new Cell(2, 1)
+                .add(new Paragraph("ПІБ").setTextAlignment(TextAlignment.CENTER))
+                .setTextAlignment(TextAlignment.CENTER)
+                .setVerticalAlignment(VerticalAlignment.MIDDLE)
+                .setBorder(new SolidBorder(1));
+        table.addHeaderCell(nameHeader);
+
+        for (DisciplineColumn discipline : disciplineColumns) {
+            String headerText = discipline.title();
+            if (discipline.elective()) {
+                headerText = headerText + "\n(вибіркова)";
+                System.out.println("[SummaryReportPdfGenerator] Дисципліна вибіркова: " + discipline.title());
+            }
+
+            Paragraph disciplineTitle = new Paragraph(headerText)
+                    .setTextAlignment(TextAlignment.CENTER);
+
+            Cell disciplineHeaderCell = new Cell(1, 3)
+                    .add(disciplineTitle)
+                    .setHeight(HEADER_ROW_HEIGHT)
+                    .setTextAlignment(TextAlignment.CENTER)
+                    .setVerticalAlignment(VerticalAlignment.MIDDLE)
+                    .setBorder(new SolidBorder(1));
+            table.addHeaderCell(disciplineHeaderCell);
+        }
+
+        Cell zeroHeader = new Cell(2, 1)
+                .add(new Paragraph("К-сть 0 у студента").setTextAlignment(TextAlignment.CENTER))
+                .setTextAlignment(TextAlignment.CENTER)
+                .setVerticalAlignment(VerticalAlignment.MIDDLE)
+                .setBorder(new SolidBorder(1));
+        table.addHeaderCell(zeroHeader);
+
+        for (int i = 0; i < disciplineColumns.size(); i++) {
+            table.addHeaderCell(createSubHeaderCell("1м"));
+            table.addHeaderCell(createSubHeaderCell("2м"));
+            table.addHeaderCell(createSubHeaderCell("Сума"));
+        }
+
+        System.out.println("[SummaryReportPdfGenerator] Заголовки колонок додано (2 модулі)");
+    }
+
+    private Cell createSubHeaderCell(String text) {
+        return new Cell()
+                .add(new Paragraph(text).setTextAlignment(TextAlignment.CENTER))
+                .setTextAlignment(TextAlignment.CENTER)
+                .setVerticalAlignment(VerticalAlignment.MIDDLE)
+                .setBorder(new SolidBorder(1));
+    }
+
     private void addStudentRows(Table table,
                                 List<String> studentFullNames,
                                 List<DisciplineColumn> disciplineColumns,
@@ -273,6 +434,44 @@ public class SummaryReportPdfGenerator {
 
             table.addCell(createNumericCell(zeroCount));
             System.out.println("[SummaryReportPdfGenerator] Додано рядок студента: " + student + ", кількість нулів: " + zeroCount);
+        }
+    }
+
+    private void addTwoModuleStudentRows(Table table,
+                                         List<String> studentFullNames,
+                                         List<DisciplineColumn> disciplineColumns,
+                                         Map<String, List<ModuleMark>> marksByStudent) {
+        System.out.println("[SummaryReportPdfGenerator] Додаємо рядки студентів (2 модулі): " + studentFullNames.size());
+        for (String student : studentFullNames) {
+            Cell nameCell = new Cell()
+                    .add(new Paragraph(student))
+                    .setTextAlignment(TextAlignment.LEFT)
+                    .setVerticalAlignment(VerticalAlignment.MIDDLE)
+                    .setBorder(new SolidBorder(1));
+            table.addCell(nameCell);
+
+            List<ModuleMark> marks = marksByStudent.getOrDefault(student, Collections.emptyList());
+            int zeroCount = 0;
+
+            for (int i = 0; i < disciplineColumns.size(); i++) {
+                ModuleMark moduleMark = getModuleMark(marks, i);
+                Integer first = moduleMark == null ? null : moduleMark.firstModule();
+                Integer second = moduleMark == null ? null : moduleMark.secondModule();
+                Integer total = moduleMark == null ? null : moduleMark.totalOrNull();
+
+                table.addCell(createMarkCell(first));
+                table.addCell(createMarkCell(second));
+                table.addCell(createMarkCell(total));
+
+                if (moduleMark != null && moduleMark.hasAnyMark() && moduleMark.totalOrNull() != null
+                        && moduleMark.totalOrNull() == 0) {
+                    zeroCount++;
+                }
+            }
+
+            table.addCell(createNumericCell(zeroCount));
+            System.out.println("[SummaryReportPdfGenerator] Додано рядок студента (2 модулі): " + student
+                    + ", кількість нулів: " + zeroCount);
         }
     }
 
@@ -307,6 +506,41 @@ public class SummaryReportPdfGenerator {
         System.out.println("[SummaryReportPdfGenerator] Загальна кількість нулів: " + totalZeros);
     }
 
+    private void addTwoModuleZeroSummaryRow(Table table,
+                                            List<String> studentFullNames,
+                                            List<DisciplineColumn> disciplineColumns,
+                                            Map<String, List<ModuleMark>> marksByStudent) {
+        System.out.println("[SummaryReportPdfGenerator] Обчислюємо суму нулів по дисциплінах (2 модулі)");
+        Cell labelCell = new Cell()
+                .add(new Paragraph("Кількість 0 по дисциплінах"))
+                .setTextAlignment(TextAlignment.LEFT)
+                .setVerticalAlignment(VerticalAlignment.MIDDLE)
+                .setBorder(new SolidBorder(1));
+        table.addCell(labelCell);
+
+        int totalZeros = 0;
+        for (int i = 0; i < disciplineColumns.size(); i++) {
+            int zeroPerDiscipline = 0;
+            for (String student : studentFullNames) {
+                List<ModuleMark> marks = marksByStudent.getOrDefault(student, Collections.emptyList());
+                ModuleMark moduleMark = getModuleMark(marks, i);
+                if (moduleMark != null && moduleMark.hasAnyMark() && moduleMark.totalOrNull() != null
+                        && moduleMark.totalOrNull() == 0) {
+                    zeroPerDiscipline++;
+                }
+            }
+            totalZeros += zeroPerDiscipline;
+            table.addCell(createEmptyCell());
+            table.addCell(createEmptyCell());
+            table.addCell(createNumericCell(zeroPerDiscipline));
+            System.out.println("[SummaryReportPdfGenerator] Нулі по дисциплінах (2 модулі) #" + (i + 1)
+                    + ": " + zeroPerDiscipline);
+        }
+
+        table.addCell(createNumericCell(totalZeros));
+        System.out.println("[SummaryReportPdfGenerator] Загальна кількість нулів (2 модулі): " + totalZeros);
+    }
+
     private Cell createNumericCell(int value) {
         return new Cell()
                 .add(new Paragraph(String.valueOf(value))
@@ -336,7 +570,29 @@ public class SummaryReportPdfGenerator {
         return marks.get(index);
     }
 
+    private ModuleMark getModuleMark(List<ModuleMark> marks, int index) {
+        if (marks == null || index >= marks.size()) {
+            return null;
+        }
+        return marks.get(index);
+    }
+
     public record DisciplineColumn(String title, boolean elective) {
+    }
+
+    public record ModuleMark(Integer firstModule, Integer secondModule) {
+        public boolean hasAnyMark() {
+            return firstModule != null || secondModule != null;
+        }
+
+        public Integer totalOrNull() {
+            if (!hasAnyMark()) {
+                return null;
+            }
+            int first = firstModule == null ? 0 : firstModule;
+            int second = secondModule == null ? 0 : secondModule;
+            return first + second;
+        }
     }
 
     public static Div generate(String examiner, Table lastRowTable, boolean numericHeader) throws IOException {

--- a/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
+++ b/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
@@ -23,6 +23,7 @@ public class SummaryReportService {
 
     private static final String CONTROL_TYPE_FIRST_MODULE = "Перший модульний контроль";
     private static final String CONTROL_TYPE_SECOND_MODULE = "Другий модульний контроль";
+    private static final String CONTROL_TYPE_TWO_MODULES = "Два модульних контроля";
     private static final String CONTROL_TYPE_SEMESTER = "Семестровий контроль";
     private static final List<String> SEMESTER_CONTROL_TYPES = List.of(
             "Залік",
@@ -67,12 +68,69 @@ public class SummaryReportService {
 
     @Transactional(readOnly = true)
     public SummaryReportResult generateSecondModuleReport(GroupDTO selectedGroup) {
-        return generateReport(selectedGroup, List.of(CONTROL_TYPE_SECOND_MODULE), CONTROL_TYPE_SECOND_MODULE, true);
+        return generateTwoModuleReport(selectedGroup);
     }
 
     @Transactional(readOnly = true)
     public SummaryReportResult generateSemesterReport(GroupDTO selectedGroup) {
         return generateReport(selectedGroup, SEMESTER_CONTROL_TYPES, CONTROL_TYPE_SEMESTER, true);
+    }
+
+    private SummaryReportResult generateTwoModuleReport(GroupDTO selectedGroup) {
+        System.out.println("[SummaryReportService] Початок генерації звіту за два модулі");
+        if (selectedGroup == null) {
+            throw new SummaryReportGenerationException("Оберіть групу для формування звіту");
+        }
+
+        StudentGroupEntity group = Optional.ofNullable(groupService.getGroupByTitle(selectedGroup.getGroupCode()))
+                .orElseThrow(() -> new SummaryReportGenerationException("Групу не знайдено"));
+
+        List<StudentEntity> students = sortStudentsByFullName(studentService.getStudentByGroupId(group.getId()));
+        if (students.isEmpty()) {
+            throw new SummaryReportGenerationException("У групі немає студентів");
+        }
+
+        int semester = computeFirstModuleSemester(selectedGroup.getCourse());
+        Map<Long, TwoModulePlanAssignment> planAssignments = collectTwoModuleAssignments(group, semester, students);
+        if (planAssignments.isEmpty()) {
+            throw new SummaryReportGenerationException("Не знайдено дисциплін для обраного контролю");
+        }
+
+        List<String> studentFullNames = students.stream()
+                .map(StudentEntity::getFullName)
+                .collect(Collectors.toList());
+
+        List<TwoModuleDisciplineSummary> disciplineSummaries = buildTwoModuleDisciplineSummaries(planAssignments.values(), students);
+        if (disciplineSummaries.isEmpty()) {
+            throw new SummaryReportGenerationException("Список дисциплін порожній");
+        }
+
+        List<SummaryReportPdfGenerator.DisciplineColumn> disciplineColumns = disciplineSummaries.stream()
+                .map(summary -> new SummaryReportPdfGenerator.DisciplineColumn(summary.title(), summary.elective()))
+                .collect(Collectors.toList());
+
+        Map<String, List<SummaryReportPdfGenerator.ModuleMark>> marksByStudent =
+                buildTwoModuleMarksForSummaryReport(students, disciplineSummaries);
+
+        String examiner = resolveCurrentTeacherName();
+
+        byte[] pdfBytes = summaryReportPdfGenerator.generateTwoModuleSummaryReport(
+                group.getGroupCode(),
+                studentFullNames,
+                disciplineColumns,
+                marksByStudent,
+                true,
+                examiner,
+                false,
+                true,
+                buildReportTitle(CONTROL_TYPE_TWO_MODULES)
+        );
+
+        if (pdfBytes == null || pdfBytes.length == 0) {
+            throw new SummaryReportGenerationException("Не вдалося сформувати звіт");
+        }
+
+        return new SummaryReportResult(group.getGroupCode(), pdfBytes);
     }
 
     private SummaryReportResult generateReport(GroupDTO selectedGroup,
@@ -249,6 +307,59 @@ public class SummaryReportService {
         return assignments;
     }
 
+    private Map<Long, TwoModulePlanAssignment> collectTwoModuleAssignments(StudentGroupEntity group,
+                                                                           int semester,
+                                                                           List<StudentEntity> students) {
+        Map<Long, TwoModulePlanAssignment> assignments = new LinkedHashMap<>();
+        Map<Long, ControlMethodEntity> firstControlCache = new HashMap<>();
+        Map<Long, ControlMethodEntity> secondControlCache = new HashMap<>();
+
+        System.out.println("[SummaryReportService] Завантажуємо плани групи для двох модулів, семестр " + semester);
+        List<PlansEntity> groupPlans = planService.getAllPlansForGroupAndSemester(group, semester);
+        if (groupPlans != null) {
+            for (PlansEntity plan : groupPlans) {
+                TwoModulePlanAssignment assignment = ensureTwoModulePlanAssignment(
+                        assignments,
+                        plan,
+                        firstControlCache,
+                        secondControlCache
+                );
+                if (assignment != null) {
+                    System.out.println("[SummaryReportService] Додаємо план групи (2 модулі): " + safeDisciplineTitle(plan));
+                }
+            }
+        }
+
+        for (StudentEntity student : students) {
+            List<StudentPlansEntity> studentPlans = studentPlansService.getPlansForStudent(student);
+            if (studentPlans == null || studentPlans.isEmpty()) {
+                continue;
+            }
+
+            for (StudentPlansEntity studentPlan : studentPlans) {
+                PlansEntity plan = studentPlan.getPlan();
+                if (plan == null || plan.getSemester() != semester) {
+                    continue;
+                }
+
+                TwoModulePlanAssignment assignment = ensureTwoModulePlanAssignment(
+                        assignments,
+                        plan,
+                        firstControlCache,
+                        secondControlCache
+                );
+                if (assignment == null) {
+                    continue;
+                }
+
+                assignment.assignedStudentIds.add(student.getId());
+            }
+        }
+
+        System.out.println("[SummaryReportService] Повертаємо зібрані призначення планів (2 модулі): " + assignments.size());
+        return assignments;
+    }
+
     private PlanAssignment ensurePlanAssignment(Map<Long, PlanAssignment> assignments,
                                                 PlansEntity plan,
                                                 Map<Long, ControlMethodEntity> controlCache,
@@ -266,6 +377,31 @@ public class SummaryReportService {
         PlanAssignment assignment = assignments.get(plan.getId());
         if (assignment == null) {
             assignment = new PlanAssignment(plan, control);
+            assignments.put(plan.getId(), assignment);
+        }
+        return assignment;
+    }
+
+    private TwoModulePlanAssignment ensureTwoModulePlanAssignment(Map<Long, TwoModulePlanAssignment> assignments,
+                                                                  PlansEntity plan,
+                                                                  Map<Long, ControlMethodEntity> firstControlCache,
+                                                                  Map<Long, ControlMethodEntity> secondControlCache) {
+        if (plan == null) {
+            return null;
+        }
+
+        ControlMethodEntity firstControl = resolveControlMethod(plan, firstControlCache, List.of(CONTROL_TYPE_FIRST_MODULE));
+        ControlMethodEntity secondControl = resolveControlMethod(plan, secondControlCache, List.of(CONTROL_TYPE_SECOND_MODULE));
+
+        if (firstControl == null && secondControl == null) {
+            System.out.println("[SummaryReportService] План '" + safeDisciplineTitle(plan)
+                    + "' не має модульних контролів");
+            return null;
+        }
+
+        TwoModulePlanAssignment assignment = assignments.get(plan.getId());
+        if (assignment == null) {
+            assignment = new TwoModulePlanAssignment(plan, firstControl, secondControl);
             assignments.put(plan.getId(), assignment);
         }
         return assignment;
@@ -334,7 +470,7 @@ public class SummaryReportService {
     }
 
     private Map<String, List<Integer>> buildMarksForSummaryReport(List<StudentEntity> students,
-                                                                 List<DisciplineSummary> disciplineSummaries) {
+                                                                  List<DisciplineSummary> disciplineSummaries) {
         System.out.println("[SummaryReportService] Початок формування оцінок");
         List<String> studentNames = students.stream()
                 .map(StudentEntity::getFullName)
@@ -379,6 +515,60 @@ public class SummaryReportService {
         }
 
         System.out.println("[SummaryReportService] Формування оцінок завершено");
+        return marksByStudent;
+    }
+
+    private Map<Long, Integer> collectMarksByStudent(PlansEntity plan, ControlMethodEntity controlMethod) {
+        if (plan == null || controlMethod == null) {
+            return Map.of();
+        }
+
+        return marksService.findMarksByPlanAndControlMethod(plan, controlMethod).stream()
+                .filter(mark -> mark.getStudent() != null && mark.getStudent().getId() != null)
+                .collect(Collectors.toMap(
+                        mark -> mark.getStudent().getId(),
+                        mark -> Optional.ofNullable(mark.getFinalGrade()).orElse(0),
+                        (existing, replacement) -> existing,
+                        LinkedHashMap::new
+                ));
+    }
+
+    private Map<String, List<SummaryReportPdfGenerator.ModuleMark>> buildTwoModuleMarksForSummaryReport(
+            List<StudentEntity> students,
+            List<TwoModuleDisciplineSummary> disciplineSummaries) {
+        Map<String, List<SummaryReportPdfGenerator.ModuleMark>> marksByStudent = new LinkedHashMap<>();
+        List<String> studentNames = students.stream()
+                .map(StudentEntity::getFullName)
+                .collect(Collectors.toList());
+
+        for (String name : studentNames) {
+            marksByStudent.put(name, new ArrayList<>());
+        }
+
+        for (TwoModuleDisciplineSummary disciplineSummary : disciplineSummaries) {
+            Map<Long, Integer> firstModuleMarks = collectMarksByStudent(disciplineSummary.plan(), disciplineSummary.firstControlMethod());
+            Map<Long, Integer> secondModuleMarks = collectMarksByStudent(disciplineSummary.plan(), disciplineSummary.secondControlMethod());
+
+            for (int i = 0; i < students.size(); i++) {
+                StudentEntity student = students.get(i);
+                String studentName = studentNames.get(i);
+
+                if (!disciplineSummary.assignedStudentIds().contains(student.getId())) {
+                    marksByStudent.get(studentName).add(null);
+                    continue;
+                }
+
+                Integer firstMark = disciplineSummary.firstControlMethod() == null
+                        ? null
+                        : firstModuleMarks.getOrDefault(student.getId(), 0);
+                Integer secondMark = disciplineSummary.secondControlMethod() == null
+                        ? null
+                        : secondModuleMarks.getOrDefault(student.getId(), 0);
+
+                marksByStudent.get(studentName).add(new SummaryReportPdfGenerator.ModuleMark(firstMark, secondMark));
+            }
+        }
+
         return marksByStudent;
     }
 
@@ -448,6 +638,59 @@ public class SummaryReportService {
         return sorted;
     }
 
+    private List<TwoModuleDisciplineSummary> buildTwoModuleDisciplineSummaries(Collection<TwoModulePlanAssignment> assignments,
+                                                                               List<StudentEntity> students) {
+        if (assignments == null || assignments.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> groupStudentIds = students.stream()
+                .map(StudentEntity::getId)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        List<TwoModuleDisciplineSummary> summaries = new ArrayList<>();
+        for (TwoModulePlanAssignment assignment : assignments) {
+            PlansEntity plan = assignment.plan;
+            DisciplineEntity discipline = plan.getDiscipline();
+            if (discipline == null || discipline.getTitle() == null) {
+                continue;
+            }
+
+            String title = discipline.getTitle().trim();
+            if (title.isBlank()) {
+                continue;
+            }
+
+            Set<Long> assignedStudentIds = new LinkedHashSet<>(assignment.assignedStudentIds);
+            if (assignedStudentIds.isEmpty() && !plan.isElective()) {
+                assignedStudentIds.addAll(groupStudentIds);
+            } else if (!assignedStudentIds.isEmpty()) {
+                assignedStudentIds.retainAll(groupStudentIds);
+            }
+
+            if (assignedStudentIds.isEmpty()) {
+                continue;
+            }
+
+            boolean matchesGroup = assignedStudentIds.containsAll(groupStudentIds)
+                    && groupStudentIds.containsAll(assignedStudentIds);
+            boolean elective = plan.isElective() || !matchesGroup;
+
+            summaries.add(new TwoModuleDisciplineSummary(
+                    plan,
+                    assignment.firstControlMethod,
+                    assignment.secondControlMethod,
+                    title,
+                    elective,
+                    assignedStudentIds
+            ));
+        }
+
+        return summaries.stream()
+                .sorted(Comparator.comparing(TwoModuleDisciplineSummary::title, ukrainianCollator))
+                .collect(Collectors.toList());
+    }
+
     private String safeDisciplineTitle(PlansEntity plan) {
         DisciplineEntity discipline = plan.getDiscipline();
         if (discipline == null || discipline.getTitle() == null) {
@@ -466,6 +709,14 @@ public class SummaryReportService {
                                      Set<Long> assignedStudentIds) {
     }
 
+    private record TwoModuleDisciplineSummary(PlansEntity plan,
+                                              ControlMethodEntity firstControlMethod,
+                                              ControlMethodEntity secondControlMethod,
+                                              String title,
+                                              boolean elective,
+                                              Set<Long> assignedStudentIds) {
+    }
+
     private static class PlanAssignment {
         private final PlansEntity plan;
         private final ControlMethodEntity controlMethod;
@@ -474,6 +725,21 @@ public class SummaryReportService {
         private PlanAssignment(PlansEntity plan, ControlMethodEntity controlMethod) {
             this.plan = plan;
             this.controlMethod = controlMethod;
+        }
+    }
+
+    private static class TwoModulePlanAssignment {
+        private final PlansEntity plan;
+        private final ControlMethodEntity firstControlMethod;
+        private final ControlMethodEntity secondControlMethod;
+        private final Set<Long> assignedStudentIds = new LinkedHashSet<>();
+
+        private TwoModulePlanAssignment(PlansEntity plan,
+                                        ControlMethodEntity firstControlMethod,
+                                        ControlMethodEntity secondControlMethod) {
+            this.plan = plan;
+            this.firstControlMethod = firstControlMethod;
+            this.secondControlMethod = secondControlMethod;
         }
     }
 


### PR DESCRIPTION
## Summary
- add PDF generator path for two-module summaries with per-module mark columns and totals
- build two-module report data using marks from both module controls and updated control title
- preserve zero-count footer generation and signature handling for the new layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a752214048326aed266bf47e50059)