### PR TITLE
summary-report: rotate two-module discipline headers

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
@@ -372,7 +372,9 @@ public class SummaryReportPdfGenerator {
             }
 
             Paragraph disciplineTitle = new Paragraph(headerText)
-                    .setTextAlignment(TextAlignment.CENTER);
+                    .setRotationAngle(Math.toRadians(90))
+                    .setTextAlignment(TextAlignment.CENTER)
+                    .setFontSize(10f);
 
             Cell disciplineHeaderCell = new Cell(1, 3)
                     .add(disciplineTitle)


### PR DESCRIPTION
## Summary
- rotate discipline titles in the two-module summary PDF so they render vertically like the first module report

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a7ad507f88326a5c5db8cd21964fc)