### PR TITLE
Add semester performance summary to second module PDF

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/pdf/SecondModulePdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/SecondModulePdfGenerator.java
@@ -71,6 +71,7 @@ public class SecondModulePdfGenerator implements PdfGenerator {
 
                 addHeader(document, regular, bold, moduleData);
                 addStudentsTable(document, regular, moduleData.students());
+                addSemesterPerformanceSummary(document, regular, bold, moduleData.students());
                 addSignatureSection(document, regular, bold, moduleData);
 
                 log.info("Generated second module control PDF at {}", outputPath);
@@ -333,6 +334,31 @@ public class SecondModulePdfGenerator implements PdfGenerator {
         document.add(table);
     }
 
+    private void addSemesterPerformanceSummary(Document document, PdfFont regular, PdfFont bold,
+                                               List<StudentModelToDocumentGenerate> students) {
+        document.add(new Paragraph("Підсумки семестрової успішності")
+                .setFont(bold)
+                .setFontSize(11)
+                .setTextAlignment(TextAlignment.CENTER)
+                .setMarginTop(8)
+                .setMarginBottom(4));
+
+        Table summaryTable = new Table(UnitValue.createPercentArray(new float[]{60, 40}))
+                .useAllAvailableWidth();
+        summaryTable.addHeaderCell(createHeaderCell("Кількість студентів", regular));
+        summaryTable.addHeaderCell(createHeaderCell("Сума балів", regular));
+
+        SummaryCounts counts = calculateSummaryCounts(students);
+
+        summaryTable.addCell(createBodyCell(String.valueOf(counts.above59()), regular, TextAlignment.CENTER));
+        summaryTable.addCell(createBodyCell("60-100", regular, TextAlignment.CENTER));
+
+        summaryTable.addCell(createBodyCell(String.valueOf(counts.belowOrEqual59()), regular, TextAlignment.CENTER));
+        summaryTable.addCell(createBodyCell("0-59", regular, TextAlignment.CENTER));
+
+        document.add(summaryTable);
+    }
+
     private void addSignatureSection(Document document, PdfFont regular, PdfFont bold, DataModelForMC2 data) {
         document.add(new Paragraph("")
                 .setFont(regular)
@@ -421,6 +447,36 @@ public class SecondModulePdfGenerator implements PdfGenerator {
         return value == null || value.isBlank();
     }
 
+    private SummaryCounts calculateSummaryCounts(List<StudentModelToDocumentGenerate> students) {
+        int above59 = 0;
+        int belowOrEqual59 = 0;
+
+        for (StudentModelToDocumentGenerate student : students) {
+            Integer mark = parseMark(student.mark());
+            if (mark == null) {
+                continue;
+            }
+            if (mark > 59) {
+                above59++;
+            } else {
+                belowOrEqual59++;
+            }
+        }
+
+        return new SummaryCounts(above59, belowOrEqual59);
+    }
+
+    private Integer parseMark(String mark) {
+        if (mark == null) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(mark.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
     private Cell createHeaderCell(String text, PdfFont font) {
         return new Cell().add(new Paragraph(text)
                         .setFont(font)
@@ -465,5 +521,8 @@ public class SecondModulePdfGenerator implements PdfGenerator {
             case "Другий модульний контроль" -> "Другий модуль";
             default -> controlName == null ? "контроль" : controlName;
         };
+    }
+
+    private record SummaryCounts(int above59, int belowOrEqual59) {
     }
 }


### PR DESCRIPTION
## Summary
- add a semester performance summary table to the second module control PDF before the signature section
- calculate and display counts of marks above 59 and at or below 59

## Testing
- ./mvnw -q -DskipTests compile *(fails: Maven download blocked in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a7b6c43f0832698fca1db5a26644c)