### PR TITLE
Remove rotation from single-module summary headers

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/summary/SummaryReportPdfGenerator.java
@@ -329,14 +329,13 @@ public class SummaryReportPdfGenerator {
                 System.out.println("[SummaryReportPdfGenerator] Дисципліна вибіркова: " + discipline.title());
             }
 
-            Paragraph rotated = new Paragraph(headerText)
-                    .setRotationAngle(Math.toRadians(90))
+            Paragraph disciplineTitle = new Paragraph(headerText)
                     .setTextAlignment(TextAlignment.CENTER)
-                    .setFontSize(10f);
+                    .setFontSize(9f);
 
             Cell disciplineHeaderCell = new Cell()
-                    .add(rotated)
-                    .setHeight(HEADER_ROW_HEIGHT)
+                    .add(disciplineTitle)
+                    .setMinHeight(HEADER_ROW_HEIGHT)
                     .setTextAlignment(TextAlignment.CENTER)
                     .setVerticalAlignment(VerticalAlignment.MIDDLE)
                     .setBorder(new SolidBorder(1));
@@ -344,13 +343,12 @@ public class SummaryReportPdfGenerator {
         }
 
         Paragraph zeroColumnText = new Paragraph("К-сть 0 у студента")
-                .setRotationAngle(Math.toRadians(90))
                 .setTextAlignment(TextAlignment.CENTER)
-                .setFontSize(10f);
+                .setFontSize(9f);
 
         Cell zeroHeaderCell = new Cell()
                 .add(zeroColumnText)
-                .setHeight(HEADER_ROW_HEIGHT)
+                .setMinHeight(HEADER_ROW_HEIGHT)
                 .setTextAlignment(TextAlignment.CENTER)
                 .setVerticalAlignment(VerticalAlignment.MIDDLE)
                 .setBorder(new SolidBorder(1));
@@ -381,7 +379,7 @@ public class SummaryReportPdfGenerator {
 
             Cell disciplineHeaderCell = new Cell(1, 3)
                     .add(disciplineTitle)
-                    .setHeight(TWO_MODULE_HEADER_ROW_HEIGHT)
+                    .setMinHeight(TWO_MODULE_HEADER_ROW_HEIGHT)
                     .setTextAlignment(TextAlignment.CENTER)
                     .setVerticalAlignment(VerticalAlignment.MIDDLE)
                     .setBorder(new SolidBorder(1));


### PR DESCRIPTION
## Summary
- align single-module summary header styling with the two-module report by removing the 90-degree rotation
- center and size discipline and zero-count header text for readability without rotating cells

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a82d1669c832692c4dd66c4f843df)