### PR TITLE
Sort department selections alphabetically

### DIFF
--- a/src/main/java/com/esvar/dekanat/service/DepartmentService.java
+++ b/src/main/java/com/esvar/dekanat/service/DepartmentService.java
@@ -2,6 +2,7 @@ package com.esvar.dekanat.service;
 
 import com.esvar.dekanat.entity.DepartmentEntity;
 import com.esvar.dekanat.repository.DepartmentRepository;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
@@ -16,11 +17,11 @@ public class DepartmentService {
     }
 
     public DepartmentEntity getFirstDep() {
-        return departmentRepository.findAll().get(0);
+        return departmentRepository.findAll(Sort.by(Sort.Direction.ASC, "title")).get(0);
     }
 
     public List<DepartmentEntity> getAllDepartments() {
-        return departmentRepository.findAll();
+        return departmentRepository.findAll(Sort.by(Sort.Direction.ASC, "title"));
     }
 
     public DepartmentEntity getDepartmentByAbbreviation(String abbreviation) {
@@ -32,7 +33,9 @@ public class DepartmentService {
     }
 
     public List<String> getAllDepartment() {
-        return departmentRepository.findAll().stream().map(DepartmentEntity::getTitle).toList();
+        return getAllDepartments().stream()
+                .map(DepartmentEntity::getTitle)
+                .toList();
     }
 
     public String getDepartmentById(Long id) {


### PR DESCRIPTION
## Summary
- fetch departments ordered by title to present alphabetical options
- reuse the sorted department list when returning department names

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aac02c2ec832693d6019665acef46)