### PR TITLE
Improve semester control detection for semester reports

### DIFF
--- a/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
+++ b/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
@@ -26,6 +26,8 @@ public class SummaryReportService {
     private static final String CONTROL_TYPE_TWO_MODULES = "Два модульних контроля";
     private static final String CONTROL_TYPE_SEMESTER = "Семестровий контроль";
     private static final List<String> SEMESTER_CONTROL_TYPES = List.of(
+            CONTROL_TYPE_SEMESTER,
+            "Семестровий",
             "Залік",
             "Екзамен",
             "Диференційний залік",
@@ -466,10 +468,17 @@ public class SummaryReportService {
     }
 
     private boolean isMatchingControl(ControlMethodEntity controlMethod, String controlType) {
-        if (controlMethod == null || controlMethod.getName() == null) {
+        if (controlMethod == null || controlMethod.getName() == null || controlType == null) {
             return false;
         }
-        return controlMethod.getName().trim().equalsIgnoreCase(controlType);
+
+        String controlName = controlMethod.getName().trim();
+        String normalizedControlName = controlName.toLowerCase(Locale.ROOT);
+        String normalizedControlType = controlType.trim().toLowerCase(Locale.ROOT);
+
+        return normalizedControlName.equals(normalizedControlType)
+                || normalizedControlName.contains(normalizedControlType)
+                || normalizedControlType.contains(normalizedControlName);
     }
 
     private String formatControlTypes(Collection<String> controlTypes) {


### PR DESCRIPTION
## Summary
- add the short "Семестровий" control name to semester report filters
- make control method comparison tolerant to partial name matches to find semester disciplines

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aae5c5b108326b5d632003c21fd05)