### PR TITLE
Add exam grade sheet PDF generator

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/DataModelForExam.java
+++ b/src/main/java/com/esvar/dekanat/generate/DataModelForExam.java
@@ -1,0 +1,30 @@
+package com.esvar.dekanat.generate;
+
+import java.util.List;
+
+/**
+ * Data model for generating exam documents.
+ */
+public record DataModelForExam(
+        String facultyName,
+        String specialityName,
+        String knowledgeArea,
+        String courseNumber,
+        String groupName,
+        String studyYear,
+        String order,
+        String day,
+        String month,
+        String year,
+        String disciplineName,
+        String semesterNumber,
+        String controlTypeName,
+        String hours,
+        String firstTeacher,
+        String secondTeacher,
+        String dean,
+        String departmentHead,
+        String gradeTeacher,
+        ExamSummary summary,
+        List<ExamStudentRow> students
+) {}

--- a/src/main/java/com/esvar/dekanat/generate/ExamStudentRow.java
+++ b/src/main/java/com/esvar/dekanat/generate/ExamStudentRow.java
@@ -1,0 +1,20 @@
+package com.esvar.dekanat.generate;
+
+/**
+ * Student row for exam document generation.
+ */
+public record ExamStudentRow(
+        int index,
+        String surname,
+        String name,
+        String patronymic,
+        String recordBookNumber,
+        String knowledgeArea,
+        String speciality,
+        String firstModuleMark,
+        String secondModuleMark,
+        String finalControlMark,
+        String totalPoints,
+        String ectsGrade,
+        String nationalGrade
+) {}

--- a/src/main/java/com/esvar/dekanat/generate/ExamSummary.java
+++ b/src/main/java/com/esvar/dekanat/generate/ExamSummary.java
@@ -1,0 +1,18 @@
+package com.esvar.dekanat.generate;
+
+/**
+ * Summary information for exam document generation.
+ */
+public record ExamSummary(
+        String countA,
+        String countB,
+        String countC,
+        String countD,
+        String countE,
+        String countFx,
+        String countF,
+        String averagePoints,
+        String averageNationalScore,
+        String averageEctsScore,
+        String totalStudents
+) {}

--- a/src/main/java/com/esvar/dekanat/generate/pdf/ExamPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/ExamPdfGenerator.java
@@ -1,0 +1,317 @@
+package com.esvar.dekanat.generate.pdf;
+
+import com.esvar.dekanat.document.DocumentException;
+import com.esvar.dekanat.document.PdfGenerator;
+import com.esvar.dekanat.generate.DataModelForExam;
+import com.esvar.dekanat.generate.ExamStudentRow;
+import com.esvar.dekanat.generate.ExamSummary;
+import com.itextpdf.io.font.FontProgram;
+import com.itextpdf.io.font.FontProgramFactory;
+import com.itextpdf.io.font.PdfEncodings;
+import com.itextpdf.io.font.constants.StandardFonts;
+import com.itextpdf.kernel.font.PdfFont;
+import com.itextpdf.kernel.font.PdfFontFactory;
+import com.itextpdf.kernel.geom.PageSize;
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfWriter;
+import com.itextpdf.kernel.pdf.canvas.draw.SolidLine;
+import com.itextpdf.layout.Document;
+import com.itextpdf.layout.borders.Border;
+import com.itextpdf.layout.borders.SolidBorder;
+import com.itextpdf.layout.element.Cell;
+import com.itextpdf.layout.element.LineSeparator;
+import com.itextpdf.layout.element.Paragraph;
+import com.itextpdf.layout.element.Table;
+import com.itextpdf.layout.properties.TextAlignment;
+import com.itextpdf.layout.properties.UnitValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+/**
+ * PDF generator for exam grade sheets.
+ */
+@Component
+public class ExamPdfGenerator implements PdfGenerator {
+
+    public static final String NAME = "exam";
+
+    private static final Logger log = LoggerFactory.getLogger(ExamPdfGenerator.class);
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Path generatePdf(Object data) {
+        if (!(data instanceof DataModelForExam examData)) {
+            throw new DocumentException("Expected DataModelForExam");
+        }
+
+        try {
+            Path outputPath = resolveOutputPath(examData);
+            Files.createDirectories(outputPath.getParent());
+
+            try (PdfWriter writer = new PdfWriter(outputPath.toFile());
+                 PdfDocument pdfDocument = new PdfDocument(writer);
+                 Document document = new Document(pdfDocument, PageSize.A4)) {
+
+                PdfFont regular = loadFont("/fonts/times.ttf", StandardFonts.TIMES_ROMAN);
+                PdfFont bold = loadFont("/fonts/timesbd.ttf", StandardFonts.TIMES_BOLD);
+
+                document.setFont(regular);
+
+                addHeader(document, regular, bold, examData);
+                addStudentsTable(document, regular, bold, examData);
+                addSummarySection(document, regular, bold, examData.summary());
+                addFooter(document, regular, bold, examData);
+
+                log.info("Generated exam PDF at {}", outputPath);
+            }
+
+            return outputPath;
+        } catch (IOException e) {
+            throw new DocumentException("Failed to generate exam PDF", e);
+        }
+    }
+
+    private void addHeader(Document document, PdfFont regular, PdfFont bold, DataModelForExam data) {
+        document.add(new Paragraph("НАЦІОНАЛЬНИЙ ТРАНСПОРТНИЙ УНІВЕРСИТЕТ")
+                .setFont(bold)
+                .setFontSize(11)
+                .setTextAlignment(TextAlignment.CENTER));
+
+        SolidLine solidLine = new SolidLine(1f);
+        LineSeparator line = new LineSeparator(solidLine);
+        line.setMarginTop(-6);
+        line.setMarginBottom(0);
+
+        document.add(line);
+        document.add(new Paragraph(Objects.toString(data.facultyName(), ""))
+                .setFont(regular)
+                .setFontSize(11));
+        document.add(line);
+        document.add(new Paragraph("Спеціальність: " + Objects.toString(data.specialityName(), ""))
+                .setFont(regular)
+                .setFontSize(11));
+        document.add(line);
+
+        Table infoTable = new Table(UnitValue.createPercentArray(new float[]{20, 10, 20, 10, 20, 20}))
+                .useAllAvailableWidth();
+        infoTable.addCell(buildLabelCell("Курс: ", regular));
+        infoTable.addCell(buildValueCell(Objects.toString(data.courseNumber(), ""), regular));
+        infoTable.addCell(buildLabelCell("\u00A0\u00A0\u00A0\u00A0Група: ", regular));
+        infoTable.addCell(buildValueCell(Objects.toString(data.groupName(), ""), regular));
+        infoTable.addCell(buildLabelCell("\u00A0\u00A0\u00A0\u00A0Навчальний рік: ", regular));
+        infoTable.addCell(buildValueCell(Objects.toString(data.studyYear(), ""), regular));
+        document.add(infoTable);
+
+        document.add(new Paragraph("ВІДОМІСТЬ ОБЛІКУ УСПІШНОСТІ № " + Objects.toString(data.order(), ""))
+                .setFont(bold)
+                .setFontSize(12)
+                .setTextAlignment(TextAlignment.CENTER)
+                .setMarginTop(6));
+
+        document.add(new Paragraph(String.format("з дисципліни: %s за %s семестр",
+                        Objects.toString(data.disciplineName(), ""), Objects.toString(data.semesterNumber(), "")))
+                .setFont(regular)
+                .setFontSize(11)
+                .setTextAlignment(TextAlignment.CENTER));
+
+        document.add(new Paragraph("Форма семестрового контролю: "
+                        + Objects.toString(data.controlTypeName(), "")
+                        + " \u200B" + Objects.toString(data.hours(), "") + " навчальних годин")
+                .setFont(regular)
+                .setFontSize(11)
+                .setTextAlignment(TextAlignment.CENTER));
+
+        document.add(new Paragraph("Проведення підсумкового контролю ________________________________")
+                .setFont(regular)
+                .setFontSize(11)
+                .setTextAlignment(TextAlignment.CENTER));
+
+        document.add(new Paragraph("Викладач: " + Objects.toString(data.firstTeacher(), ""))
+                .setFont(regular)
+                .setFontSize(11));
+        document.add(new Paragraph("Другий викладач: " + Objects.toString(data.secondTeacher(), ""))
+                .setFont(regular)
+                .setFontSize(11));
+        document.add(new Paragraph(""));
+    }
+
+    private void addStudentsTable(Document document, PdfFont regular, PdfFont bold, DataModelForExam data) {
+        float[] widths = {4, 12, 12, 12, 12, 12, 10, 8, 8, 8, 8, 6, 10};
+        Table table = new Table(UnitValue.createPercentArray(widths)).useAllAvailableWidth();
+
+        table.addHeaderCell(createHeaderCell("№", bold, 2, 1));
+        table.addHeaderCell(createHeaderCell("Прізвище", bold, 2, 1));
+        table.addHeaderCell(createHeaderCell("Ім'я", bold, 2, 1));
+        table.addHeaderCell(createHeaderCell("По батькові", bold, 2, 1));
+        table.addHeaderCell(createHeaderCell("Номер залікової книжки", bold, 2, 1));
+        table.addHeaderCell(createHeaderCell("Галузь знань", bold, 2, 1));
+        table.addHeaderCell(createHeaderCell("Спеціальність", bold, 2, 1));
+        table.addHeaderCell(createHeaderCell("Поточний контроль", bold, 1, 2));
+        table.addHeaderCell(createHeaderCell("Підсумковий контроль", bold, 2, 1));
+        table.addHeaderCell(createHeaderCell("Сума балів", bold, 2, 1));
+        table.addHeaderCell(createHeaderCell("ОЦІНКА ECTS", bold, 2, 1));
+        table.addHeaderCell(createHeaderCell("ОЦІНКА ЗА НАЦІОНАЛЬНОЮ ШКАЛОЮ", bold, 2, 1));
+
+        table.addHeaderCell(createHeaderCell("МК1", bold, 1, 1));
+        table.addHeaderCell(createHeaderCell("МК2", bold, 1, 1));
+
+        for (ExamStudentRow student : data.students()) {
+            table.addCell(defaultCell(String.valueOf(student.index()), regular, TextAlignment.CENTER));
+            table.addCell(defaultCell(student.surname(), regular, TextAlignment.LEFT));
+            table.addCell(defaultCell(student.name(), regular, TextAlignment.LEFT));
+            table.addCell(defaultCell(student.patronymic(), regular, TextAlignment.LEFT));
+            table.addCell(defaultCell(student.recordBookNumber(), regular, TextAlignment.CENTER));
+            table.addCell(defaultCell(student.knowledgeArea(), regular, TextAlignment.CENTER));
+            table.addCell(defaultCell(student.speciality(), regular, TextAlignment.CENTER));
+            table.addCell(defaultCell(student.firstModuleMark(), regular, TextAlignment.CENTER));
+            table.addCell(defaultCell(student.secondModuleMark(), regular, TextAlignment.CENTER));
+            table.addCell(defaultCell(student.finalControlMark(), regular, TextAlignment.CENTER));
+            table.addCell(defaultCell(student.totalPoints(), regular, TextAlignment.CENTER));
+            table.addCell(defaultCell(student.ectsGrade(), regular, TextAlignment.CENTER));
+            table.addCell(defaultCell(student.nationalGrade(), regular, TextAlignment.CENTER));
+        }
+
+        document.add(table);
+    }
+
+    private void addSummarySection(Document document, PdfFont regular, PdfFont bold, ExamSummary summary) {
+        document.add(new Paragraph(""));
+
+        float[] widths = {10, 10, 10, 10, 10, 10, 10};
+        Table summaryTable = new Table(UnitValue.createPercentArray(widths)).useAllAvailableWidth();
+        summaryTable.addHeaderCell(createHeaderCell("90-100", bold, 1, 1));
+        summaryTable.addHeaderCell(createHeaderCell("82-89", bold, 1, 1));
+        summaryTable.addHeaderCell(createHeaderCell("74-81", bold, 1, 1));
+        summaryTable.addHeaderCell(createHeaderCell("64-73", bold, 1, 1));
+        summaryTable.addHeaderCell(createHeaderCell("60-63", bold, 1, 1));
+        summaryTable.addHeaderCell(createHeaderCell("35-59", bold, 1, 1));
+        summaryTable.addHeaderCell(createHeaderCell("1-34", bold, 1, 1));
+
+        summaryTable.addCell(defaultCell(summary.countA(), regular, TextAlignment.CENTER));
+        summaryTable.addCell(defaultCell(summary.countB(), regular, TextAlignment.CENTER));
+        summaryTable.addCell(defaultCell(summary.countC(), regular, TextAlignment.CENTER));
+        summaryTable.addCell(defaultCell(summary.countD(), regular, TextAlignment.CENTER));
+        summaryTable.addCell(defaultCell(summary.countE(), regular, TextAlignment.CENTER));
+        summaryTable.addCell(defaultCell(summary.countFx(), regular, TextAlignment.CENTER));
+        summaryTable.addCell(defaultCell(summary.countF(), regular, TextAlignment.CENTER));
+
+        document.add(summaryTable);
+
+        document.add(new Paragraph("Середній бал за національною шкалою: " + summary.averageNationalScore())
+                .setFont(regular)
+                .setFontSize(11));
+        document.add(new Paragraph("Середній бал ECTS: " + summary.averageEctsScore())
+                .setFont(regular)
+                .setFontSize(11));
+        document.add(new Paragraph("Середня сума балів: " + summary.averagePoints())
+                .setFont(regular)
+                .setFontSize(11));
+        document.add(new Paragraph("Кількість студентів: " + summary.totalStudents())
+                .setFont(regular)
+                .setFontSize(11));
+    }
+
+    private void addFooter(Document document, PdfFont regular, PdfFont bold, DataModelForExam data) {
+        document.add(new Paragraph("Дата проведення підсумкового екзамену (заліку) "
+                        + Objects.toString(data.day(), "") + "."
+                        + Objects.toString(data.month(), "") + "."
+                        + Objects.toString(data.year(), ""))
+                .setFont(regular)
+                .setFontSize(11));
+
+        document.add(new Paragraph(""));
+
+        Table signTable = new Table(UnitValue.createPercentArray(new float[]{33, 34, 33}))
+                .useAllAvailableWidth();
+        signTable.addCell(signatureCell("Екзаменатор (викладач)", Objects.toString(data.gradeTeacher(), ""), regular));
+        signTable.addCell(signatureCell("Завідувач кафедри", Objects.toString(data.departmentHead(), ""), regular));
+        signTable.addCell(signatureCell("Декан факультету", Objects.toString(data.dean(), ""), regular));
+
+        document.add(signTable);
+    }
+
+    private Cell createHeaderCell(String text, PdfFont font, int rowSpan, int colSpan) {
+        Cell cell = new Cell(rowSpan, colSpan)
+                .add(new Paragraph(text)
+                        .setFont(font)
+                        .setFontSize(9)
+                        .setTextAlignment(TextAlignment.CENTER))
+                .setPadding(4);
+        return cell;
+    }
+
+    private Cell defaultCell(String text, PdfFont font, TextAlignment alignment) {
+        return new Cell().add(new Paragraph(text == null ? "" : text)
+                        .setFont(font)
+                        .setFontSize(9)
+                        .setTextAlignment(alignment))
+                .setPadding(4);
+    }
+
+    private Cell signatureCell(String label, String value, PdfFont font) {
+        Paragraph labelParagraph = new Paragraph(label)
+                .setFont(font)
+                .setFontSize(11);
+        Paragraph valueParagraph = new Paragraph(value)
+                .setFont(font)
+                .setFontSize(11)
+                .setTextAlignment(TextAlignment.CENTER)
+                .setBorderBottom(new SolidBorder(0.5f));
+
+        return new Cell().setPadding(6)
+                .add(labelParagraph)
+                .add(valueParagraph)
+                .setBorder(Border.NO_BORDER);
+    }
+
+    private Cell buildLabelCell(String text, PdfFont font) {
+        return new Cell().setPadding(0)
+                .add(new Paragraph(text)
+                        .setFont(font)
+                        .setFontSize(11))
+                .setBorder(Border.NO_BORDER);
+    }
+
+    private Cell buildValueCell(String text, PdfFont font) {
+        return new Cell().setPadding(0)
+                .add(new Paragraph(text)
+                        .setFont(font)
+                        .setFontSize(11)
+                        .setTextAlignment(TextAlignment.CENTER))
+                .setBorderTop(Border.NO_BORDER)
+                .setBorderLeft(Border.NO_BORDER)
+                .setBorderRight(Border.NO_BORDER)
+                .setBorderBottom(new SolidBorder(0.5f));
+    }
+
+    private PdfFont loadFont(String resourcePath, String fallbackFont) throws IOException {
+        try (InputStream fontStream = ExamPdfGenerator.class.getResourceAsStream(resourcePath)) {
+            if (fontStream != null) {
+                FontProgram fontProgram = FontProgramFactory.createFont(fontStream.readAllBytes());
+                return PdfFontFactory.createFont(fontProgram, PdfEncodings.IDENTITY_H);
+            }
+        } catch (IOException ex) {
+            log.warn("Unable to load font {}: {}", resourcePath, ex.getMessage());
+        }
+        return PdfFontFactory.createFont(fallbackFont);
+    }
+
+    private Path resolveOutputPath(DataModelForExam data) {
+        String fileName = Objects.toString(data.groupName(), "group") + "_exam_"
+                + Objects.toString(data.semesterNumber(), "0") + "_"
+                + Objects.toString(data.order(), "00") + ".pdf";
+        return Paths.get("uploads").resolve(fileName);
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -5,6 +5,7 @@ import com.esvar.dekanat.dto.GroupDTO;
 import com.esvar.dekanat.dto.MarkDTO;
 import com.esvar.dekanat.entity.*;
 import com.esvar.dekanat.generate.*;
+import com.esvar.dekanat.generate.pdf.ExamPdfGenerator;
 import com.esvar.dekanat.generate.pdf.FirstModulePdfGenerator;
 import com.esvar.dekanat.generate.pdf.SecondModulePdfGenerator;
 import com.esvar.dekanat.generate.pdf.ZalikPdfGenerator;
@@ -59,6 +60,7 @@ import java.io.*;
 import java.nio.file.Path;
 import java.sql.Timestamp;
 import java.text.Collator;
+import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -1255,6 +1257,11 @@ public class EnterMarksView extends Div {
                 Path path = documentGenerationService.generate(ZalikPdfGenerator.NAME, data);
                 return new ReportGenerationResult(path.toString(), null);
             }
+            case "Екзамен" -> {
+                DataModelForExam data = buildDataModelForExam(secondTeacher);
+                Path path = documentGenerationService.generate(ExamPdfGenerator.NAME, data);
+                return new ReportGenerationResult(path.toString(), null);
+            }
         }
 
         throw new IllegalStateException(
@@ -1512,6 +1519,133 @@ public class EnterMarksView extends Div {
                 order, day, month, year, disciplineName, semesterNumber, controlTypeName,
                 hours, firstTeacher, secondTeacher, dean, departmentName,
                 a, b, c, d, e, fx, f, gradeTeacher, students);
+    }
+
+    private DataModelForExam buildDataModelForExam(String secondTeacher) {
+        String facultyName = plansEntity.getFaculty().getTitle();
+        SpecialtyEntity specialty = plansEntity.getSpecialty();
+        String specialityName = specialty.getTitle();
+        String knowledgeArea = Optional.ofNullable(specialty.getEduProgram())
+                .map(EduProgramEntity::getTitle)
+                .orElse(specialityName);
+        StudentGroupEntity group = requireCurrentGroup();
+        String courseNumber = String.valueOf(group.getCourse());
+        String groupName = group.getGroupCode();
+        String studyYear = String.valueOf(group.getYear());
+        String order = plansEntity.getStatementNumber();
+        LocalDate today = LocalDate.now();
+        String day = today.format(DateTimeFormatter.ofPattern("dd"));
+        String month = today.format(DateTimeFormatter.ofPattern("MM"));
+        String year = today.format(DateTimeFormatter.ofPattern("yyyy"));
+        String disciplineName = plansEntity.getDiscipline().getTitle();
+        String semesterNumber = String.valueOf(plansEntity.getSemester());
+        String controlTypeName = selectControlType.getValue();
+        String hours = String.valueOf(plansEntity.getHours());
+        String firstTeacher = getCurrentUserFullNameSurnameFirst();
+        String gradeTeacher = getCurrentUserFullName();
+        FacultyEntity faculty = plansEntity.getFaculty();
+        String dean = faculty.getDeanLanding();
+        String departmentHead = plansEntity.getDepartment().getTitle();
+
+        List<ExamStudentRow> students = new ArrayList<>();
+        List<StudentEntity> studentEntities = sortStudentsByFullName(studentService.getStudentByGroupId(group.getId()));
+        int index = 1;
+        for (StudentEntity student : studentEntities) {
+            String firstModule = marksService.getMarkForFirstModalControl(student, plansEntity, CONTROL_TYPE_FIRST_MODULE);
+            String secondModule = marksService.getMarkForFirstModalControl(student, plansEntity, CONTROL_TYPE_SECOND_MODULE);
+            String examMark = marksService.getMarkForFirstModalControl(student, plansEntity, controlTypeName);
+
+            int total = parseMark(firstModule) + parseMark(secondModule) + parseMark(examMark);
+            String ectsGrade = convertMarkToECTSGrade(total);
+            String nationalGrade = convertMarkToNationalGrade(total);
+
+            students.add(new ExamStudentRow(
+                    index++,
+                    student.getSurname(),
+                    student.getName(),
+                    Optional.ofNullable(student.getPatronymic()).orElse(""),
+                    student.getRecordBookNumber() != null ? student.getRecordBookNumber() : "",
+                    knowledgeArea,
+                    specialityName,
+                    firstModule,
+                    secondModule,
+                    examMark,
+                    String.valueOf(total),
+                    ectsGrade,
+                    nationalGrade
+            ));
+        }
+
+        ExamSummary summary = buildExamSummary(students);
+
+        return new DataModelForExam(facultyName, specialityName, knowledgeArea, courseNumber, groupName,
+                studyYear, order, day, month, year, disciplineName, semesterNumber, controlTypeName, hours,
+                firstTeacher, secondTeacher, dean, departmentHead, gradeTeacher, summary, students);
+    }
+
+    private ExamSummary buildExamSummary(List<ExamStudentRow> students) {
+        Map<String, Long> gradeCounts = students.stream()
+                .collect(Collectors.groupingBy(ExamStudentRow::ectsGrade, Collectors.counting()));
+
+        double totalPoints = students.stream()
+                .mapToInt(s -> parseMark(s.totalPoints()))
+                .sum();
+        double averagePoints = students.isEmpty() ? 0 : totalPoints / students.size();
+
+        double totalNationalScore = students.stream()
+                .mapToDouble(s -> convertNationalToScore(s.nationalGrade()))
+                .sum();
+        double averageNationalScore = students.isEmpty() ? 0 : totalNationalScore / students.size();
+
+        double totalEctsScore = students.stream()
+                .mapToDouble(s -> convertEctsToScore(s.ectsGrade()))
+                .sum();
+        double averageEctsScore = students.isEmpty() ? 0 : totalEctsScore / students.size();
+
+        DecimalFormat format = new DecimalFormat("0.0");
+
+        return new ExamSummary(
+                String.valueOf(gradeCounts.getOrDefault("A", 0L)),
+                String.valueOf(gradeCounts.getOrDefault("B", 0L)),
+                String.valueOf(gradeCounts.getOrDefault("C", 0L)),
+                String.valueOf(gradeCounts.getOrDefault("D", 0L)),
+                String.valueOf(gradeCounts.getOrDefault("E", 0L)),
+                String.valueOf(gradeCounts.getOrDefault("FX", 0L)),
+                String.valueOf(gradeCounts.getOrDefault("F", 0L)),
+                format.format(averagePoints),
+                format.format(averageNationalScore),
+                format.format(averageEctsScore),
+                String.valueOf(students.size())
+        );
+    }
+
+    private int parseMark(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException ex) {
+            return 0;
+        }
+    }
+
+    private double convertNationalToScore(String nationalGrade) {
+        return switch (nationalGrade) {
+            case "Відмінно" -> 5;
+            case "Добре" -> 4;
+            case "Задовільно" -> 3;
+            case "Незадовільно" -> 2;
+            default -> 0;
+        };
+    }
+
+    private double convertEctsToScore(String ectsGrade) {
+        return switch (ectsGrade) {
+            case "A" -> 5;
+            case "B" -> 4;
+            case "C" -> 3;
+            case "D" -> 2;
+            case "E" -> 1;
+            default -> 0;
+        };
     }
 
     private void showAdditionalReportDialog() {


### PR DESCRIPTION
## Summary
- add data models and PDF generator for the exam grade sheet
- extend mark entry view to assemble exam data, student totals, and summary metrics
- enable PDF export for the "Екзамен" control type alongside existing reports

## Testing
- ./mvnw -q -DskipTests package *(fails: unable to download Maven binary in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b05918e34832689ba6be6f56b4d36)