### PR TITLE
Fix group filtering on marks entry page

### DIFF
--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -649,7 +649,12 @@ public class EnterMarksView extends Div {
             return;
         }
 
-        List<MarksEntity> marksEntityList = marksService.findMarksByPlanAndTypeControl(plansEntity, selectControlType.getValue());
+        StudentGroupEntity targetGroup = getPlanContextGroup();
+
+        List<MarksEntity> marksEntityList = marksService.findMarksByPlanAndTypeControl(plansEntity, selectControlType.getValue())
+                .stream()
+                .filter(mark -> targetGroup == null || targetGroup.equals(mark.getStudent().getGroup()))
+                .toList();
         List<MarkDTO> markDTOList = new ArrayList<>();
         configureGrid(selectControlType.getValue(), plansEntity.getParts());
 


### PR DESCRIPTION
## Summary
- filter marks loaded into the marks entry grid by the currently selected group to avoid mixing students

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d3de681cc8326b7ce0d38bae7f75c)