### PR TITLE
Fix discipline filtering when entering marks

### DIFF
--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -351,13 +351,7 @@ public class EnterMarksView extends Div {
 
                 selectControlType.clear();
 
-                selectDiscipline.setItems(planService.getDisciplinesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupGroupNumber(
-                        selectFaculty.getValue(),
-                        selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
-                        selectedGroup.getCourse(),
-                        selectedGroup.getGroupNumber()
-                ));
+                selectDiscipline.setItems(planService.getDisciplinesByGroup(currentGroup));
             }
         });
 
@@ -367,23 +361,9 @@ public class EnterMarksView extends Div {
             if (selectDiscipline.getValue() != null && selectedGroup != null) {
                 selectControlType.setReadOnly(false);
 
-                selectControlType.setItems(planService.getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
-                        selectFaculty.getValue(),
-                        selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
-                        selectedGroup.getCourse(),
-                        selectedGroup.getGroupNumber(),
-                        selectDiscipline.getValue()
-                ));
+                selectControlType.setItems(planService.getControlTypesByGroupAndDiscipline(currentGroup, selectDiscipline.getValue()));
 
-                plansEntity = planService.getPlanEntityByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
-                        selectFaculty.getValue(),
-                        selectDepartment.getValue(),
-                        selectSpecialty.getValue(),
-                        selectedGroup.getCourse(),
-                        selectedGroup.getGroupNumber(),
-                        selectDiscipline.getValue()
-                );
+                plansEntity = planService.getPlanEntityByGroupAndDiscipline(currentGroup, selectDiscipline.getValue());
             }
         });
 

--- a/src/main/java/com/esvar/dekanat/repository/PlanRepository.java
+++ b/src/main/java/com/esvar/dekanat/repository/PlanRepository.java
@@ -24,6 +24,15 @@ public interface PlanRepository extends JpaRepository<PlansEntity, Long> {
     @Query("""
             SELECT DISTINCT p FROM PlansEntity p
             JOIN p.groups g
+            WHERE g = :group AND p.semester = :semester AND p.discipline.title = :disciplineTitle
+            """)
+    List<PlansEntity> findByGroupAndSemesterAndDiscipline_Title(@Param("group") StudentGroupEntity group,
+                                                                @Param("semester") int semester,
+                                                                @Param("disciplineTitle") String disciplineTitle);
+
+    @Query("""
+            SELECT DISTINCT p FROM PlansEntity p
+            JOIN p.groups g
             WHERE p.faculty = :faculty
               AND p.department = :department
               AND p.specialty = :specialty

--- a/src/main/java/com/esvar/dekanat/service/PlanService.java
+++ b/src/main/java/com/esvar/dekanat/service/PlanService.java
@@ -183,57 +183,43 @@ public class PlanService {
                 .collect(Collectors.toList());
     }
 
-    public List<String> getDisciplinesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupGroupNumber(String faculty, String department, String specialty, int course, int groupNumber) {
-        int semester = getNumberSemester(String.valueOf(course));
-        return planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumber(
-                        facultyRepository.findByTitle(faculty),
-                        departmentRepository.findByTitle(department),
-                        specialty,
-                        course,
-                        groupNumber
-                ).stream()
-                .filter(p -> p.getSemester() == semester)
+    public List<String> getDisciplinesByGroup(StudentGroupEntity group) {
+        if (group == null) {
+            return Collections.emptyList();
+        }
+        int semester = getNumberSemester(String.valueOf(group.getCourse()));
+        return planRepository.findByGroupAndSemester(group, semester).stream()
                 .map(PlansEntity::getDiscipline)
                 .map(DisciplineEntity::getTitle)
                 .distinct()
                 .collect(Collectors.toList());
     }
 
-    public List<String> getControlTypesByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(
-            String faculty, String department, String specialty, int course, int groupNumber, String discipline) {
-        int semester = getNumberSemester(String.valueOf(course));
-        List<String> controlTypes = planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
-                        facultyRepository.findByTitle(faculty),
-                        departmentRepository.findByTitle(department),
-                        specialty,
-                        course,
-                        groupNumber,
-                        discipline
-                ).stream()
-                .filter(p -> p.getSemester() == semester)
-                .flatMap(plan -> Stream.of(plan.getFirstControl().getName(), plan.getSecondControl().getName())) // Отримуємо обидва значення
-                .filter(control -> !"Відсутній".equals(control)) // Фільтруємо "Відсутній"
-                .distinct() // Унікальні значення (якщо потрібно)
+    public List<String> getControlTypesByGroupAndDiscipline(StudentGroupEntity group, String discipline) {
+        if (group == null || discipline == null) {
+            return Collections.emptyList();
+        }
+        int semester = getNumberSemester(String.valueOf(group.getCourse()));
+        List<String> controlTypes = planRepository.findByGroupAndSemesterAndDiscipline_Title(group, semester, discipline)
+                .stream()
+                .flatMap(plan -> Stream.of(plan.getFirstControl().getName(), plan.getSecondControl().getName()))
+                .filter(control -> !"Відсутній".equals(control))
+                .distinct()
                 .collect(Collectors.toList());
 
-        // Додаємо "Перший модульний контроль" і "Другий модульний контроль"
         controlTypes.add("Перший модульний контроль");
         controlTypes.add("Другий модульний контроль");
 
         return controlTypes;
     }
 
-    public PlansEntity getPlanEntityByFacultyAndDepartmentAndSpecialtyAndGroupCourseAndGroupNumberAndDiscipline(String faculty, String department, String specialty, int course, int groupNumber, String discipline){
-        int semester = getNumberSemester(String.valueOf(course));
-        return planRepository.findByFacultyAndDepartmentAndSpecialty_AbbreviationAndGroup_CourseAndGroup_GroupNumberAndDiscipline_Title(
-                        facultyRepository.findByTitle(faculty),
-                        departmentRepository.findByTitle(department),
-                        specialty,
-                        course,
-                        groupNumber,
-                        discipline
-                ).stream()
-                .filter(p -> p.getSemester() == semester)
+    public PlansEntity getPlanEntityByGroupAndDiscipline(StudentGroupEntity group, String discipline){
+        if (group == null || discipline == null) {
+            return null;
+        }
+        int semester = getNumberSemester(String.valueOf(group.getCourse()));
+        return planRepository.findByGroupAndSemesterAndDiscipline_Title(group, semester, discipline)
+                .stream()
                 .findFirst().orElse(null);
     }
 


### PR DESCRIPTION
## Summary
- use group-specific plan queries when populating disciplines and control types in the marks view
- add repository query to fetch plans by group, semester, and discipline title

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d609e6fcc83269693c5cd1a512c24)