### PR TITLE
Restrict discipline access by department role

### DIFF
--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -169,6 +169,7 @@ public class EnterMarksView extends Div {
         boolean isDepartment   = roles.stream().anyMatch(r -> r.startsWith("ROLE_DEPARTMENT"));
         boolean isDekanatGroup = roles.stream().anyMatch(r -> r.startsWith("ROLE_DEKANAT"));
         boolean isAdmin        = roles.stream().anyMatch(r -> r.startsWith("ROLE_ADMIN"));
+        Long departmentId      = isDepartment ? Long.valueOf(role_type) : null;
 
         if (isDekanatGroup){
             selectFaculty.setValue(facultyService.getFacultyTitleById(Long.valueOf(role_type)));
@@ -351,7 +352,7 @@ public class EnterMarksView extends Div {
 
                 selectControlType.clear();
 
-                selectDiscipline.setItems(planService.getDisciplinesByGroup(currentGroup));
+                selectDiscipline.setItems(planService.getDisciplinesByGroup(currentGroup, departmentId));
             }
         });
 
@@ -361,9 +362,9 @@ public class EnterMarksView extends Div {
             if (selectDiscipline.getValue() != null && selectedGroup != null) {
                 selectControlType.setReadOnly(false);
 
-                selectControlType.setItems(planService.getControlTypesByGroupAndDiscipline(currentGroup, selectDiscipline.getValue()));
+                selectControlType.setItems(planService.getControlTypesByGroupAndDiscipline(currentGroup, selectDiscipline.getValue(), departmentId));
 
-                plansEntity = planService.getPlanEntityByGroupAndDiscipline(currentGroup, selectDiscipline.getValue());
+                plansEntity = planService.getPlanEntityByGroupAndDiscipline(currentGroup, selectDiscipline.getValue(), departmentId);
             }
         });
 

--- a/src/main/java/com/esvar/dekanat/repository/PlanRepository.java
+++ b/src/main/java/com/esvar/dekanat/repository/PlanRepository.java
@@ -24,11 +24,35 @@ public interface PlanRepository extends JpaRepository<PlansEntity, Long> {
     @Query("""
             SELECT DISTINCT p FROM PlansEntity p
             JOIN p.groups g
+            WHERE g = :group
+              AND p.semester = :semester
+              AND p.department.id = :departmentId
+            """)
+    List<PlansEntity> findByGroupAndSemesterAndDepartment(@Param("group") StudentGroupEntity group,
+                                                          @Param("semester") int semester,
+                                                          @Param("departmentId") Long departmentId);
+
+    @Query("""
+            SELECT DISTINCT p FROM PlansEntity p
+            JOIN p.groups g
             WHERE g = :group AND p.semester = :semester AND p.discipline.title = :disciplineTitle
             """)
     List<PlansEntity> findByGroupAndSemesterAndDiscipline_Title(@Param("group") StudentGroupEntity group,
                                                                 @Param("semester") int semester,
                                                                 @Param("disciplineTitle") String disciplineTitle);
+
+    @Query("""
+            SELECT DISTINCT p FROM PlansEntity p
+            JOIN p.groups g
+            WHERE g = :group
+              AND p.semester = :semester
+              AND p.discipline.title = :disciplineTitle
+              AND p.department.id = :departmentId
+            """)
+    List<PlansEntity> findByGroupAndSemesterAndDiscipline_TitleAndDepartment(@Param("group") StudentGroupEntity group,
+                                                                             @Param("semester") int semester,
+                                                                             @Param("disciplineTitle") String disciplineTitle,
+                                                                             @Param("departmentId") Long departmentId);
 
     @Query("""
             SELECT DISTINCT p FROM PlansEntity p

--- a/src/main/java/com/esvar/dekanat/service/PlanService.java
+++ b/src/main/java/com/esvar/dekanat/service/PlanService.java
@@ -184,11 +184,19 @@ public class PlanService {
     }
 
     public List<String> getDisciplinesByGroup(StudentGroupEntity group) {
+        return getDisciplinesByGroup(group, null);
+    }
+
+    public List<String> getDisciplinesByGroup(StudentGroupEntity group, Long departmentId) {
         if (group == null) {
             return Collections.emptyList();
         }
         int semester = getNumberSemester(String.valueOf(group.getCourse()));
-        return planRepository.findByGroupAndSemester(group, semester).stream()
+        List<PlansEntity> plans = departmentId == null
+                ? planRepository.findByGroupAndSemester(group, semester)
+                : planRepository.findByGroupAndSemesterAndDepartment(group, semester, departmentId);
+
+        return plans.stream()
                 .map(PlansEntity::getDiscipline)
                 .map(DisciplineEntity::getTitle)
                 .distinct()
@@ -196,12 +204,19 @@ public class PlanService {
     }
 
     public List<String> getControlTypesByGroupAndDiscipline(StudentGroupEntity group, String discipline) {
+        return getControlTypesByGroupAndDiscipline(group, discipline, null);
+    }
+
+    public List<String> getControlTypesByGroupAndDiscipline(StudentGroupEntity group, String discipline, Long departmentId) {
         if (group == null || discipline == null) {
             return Collections.emptyList();
         }
         int semester = getNumberSemester(String.valueOf(group.getCourse()));
-        List<String> controlTypes = planRepository.findByGroupAndSemesterAndDiscipline_Title(group, semester, discipline)
-                .stream()
+        List<PlansEntity> plans = departmentId == null
+                ? planRepository.findByGroupAndSemesterAndDiscipline_Title(group, semester, discipline)
+                : planRepository.findByGroupAndSemesterAndDiscipline_TitleAndDepartment(group, semester, discipline, departmentId);
+
+        List<String> controlTypes = plans.stream()
                 .flatMap(plan -> Stream.of(plan.getFirstControl().getName(), plan.getSecondControl().getName()))
                 .filter(control -> !"Відсутній".equals(control))
                 .distinct()
@@ -214,12 +229,19 @@ public class PlanService {
     }
 
     public PlansEntity getPlanEntityByGroupAndDiscipline(StudentGroupEntity group, String discipline){
+        return getPlanEntityByGroupAndDiscipline(group, discipline, null);
+    }
+
+    public PlansEntity getPlanEntityByGroupAndDiscipline(StudentGroupEntity group, String discipline, Long departmentId){
         if (group == null || discipline == null) {
             return null;
         }
         int semester = getNumberSemester(String.valueOf(group.getCourse()));
-        return planRepository.findByGroupAndSemesterAndDiscipline_Title(group, semester, discipline)
-                .stream()
+        List<PlansEntity> plans = departmentId == null
+                ? planRepository.findByGroupAndSemesterAndDiscipline_Title(group, semester, discipline)
+                : planRepository.findByGroupAndSemesterAndDiscipline_TitleAndDepartment(group, semester, discipline, departmentId);
+
+        return plans.stream()
                 .findFirst().orElse(null);
     }
 


### PR DESCRIPTION
## Summary
- add plan repository queries scoped to department
- expose PlanService helpers to filter disciplines and control types by department
- ensure mark entry view limits discipline selection to the current department

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d6d3ee76483268c179780d6fcfedc)