### PR TITLE
Fix lazy initialization when syncing mandatory plan groups

### DIFF
--- a/src/main/java/com/esvar/dekanat/plan/PlanView.java
+++ b/src/main/java/com/esvar/dekanat/plan/PlanView.java
@@ -292,10 +292,13 @@ public class PlanView extends Div {
                     .collect(Collectors.toList());
             targetStudents = studentPlansService.synchronizePlanAssignments(updatedPlan, mapped);
         } else {
-            StudentGroupEntity selectedGroup = getSelectedGroup();
-            List<StudentEntity> groupStudents = selectedGroup == null
-                    ? Collections.emptyList()
-                    : studentService.getStudentByGroupId(selectedGroup.getId());
+            List<StudentEntity> groupStudents = getStudentsForPlanGroups(updatedPlan);
+            if (groupStudents.isEmpty()) {
+                StudentGroupEntity selectedGroup = getSelectedGroup();
+                groupStudents = selectedGroup == null
+                        ? Collections.emptyList()
+                        : studentService.getStudentByGroupId(selectedGroup.getId());
+            }
             targetStudents = studentPlansService.synchronizePlanAssignments(updatedPlan, groupStudents);
         }
 
@@ -390,6 +393,19 @@ public class PlanView extends Div {
             return null;
         }
         return groupService.getGroupByTitle(selectedGroup);
+    }
+
+    private List<StudentEntity> getStudentsForPlanGroups(PlansEntity plan) {
+        if (plan == null || plan.getGroups() == null || plan.getGroups().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return plan.getGroups().stream()
+                .filter(Objects::nonNull)
+                .flatMap(group -> studentService.getStudentByGroupId(group.getId()).stream())
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
     }
 
     private StudentEntity findStudentByFullName(String fullName) {

--- a/src/main/java/com/esvar/dekanat/service/PlanService.java
+++ b/src/main/java/com/esvar/dekanat/service/PlanService.java
@@ -261,7 +261,12 @@ public class PlanService {
         if (plan.isElective()) {
             return;
         }
-        Set<StudentGroupEntity> planGroups = plan.getGroups();
+        PlansEntity managedPlan = planRepository.findById(plan.getId()).orElse(null);
+        if (managedPlan == null) {
+            return;
+        }
+
+        Set<StudentGroupEntity> planGroups = managedPlan.getGroups();
         if (planGroups == null || planGroups.isEmpty()) {
             return;
         }


### PR DESCRIPTION
## Summary
- load a managed plan entity before synchronizing group assignments to avoid lazy loading failures
- continue skipping elective plans but ensure group mappings for mandatory plans are created reliably

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694122e7f0848326a3e3fdef173b235b)