### PR TITLE
Ensure plan groups are initialized before syncing students

### DIFF
--- a/src/main/java/com/esvar/dekanat/plan/PlanView.java
+++ b/src/main/java/com/esvar/dekanat/plan/PlanView.java
@@ -292,10 +292,13 @@ public class PlanView extends Div {
                     .collect(Collectors.toList());
             targetStudents = studentPlansService.synchronizePlanAssignments(updatedPlan, mapped);
         } else {
-            StudentGroupEntity selectedGroup = getSelectedGroup();
-            List<StudentEntity> groupStudents = selectedGroup == null
-                    ? Collections.emptyList()
-                    : studentService.getStudentByGroupId(selectedGroup.getId());
+            List<StudentEntity> groupStudents = getStudentsForPlanGroups(updatedPlan);
+            if (groupStudents.isEmpty()) {
+                StudentGroupEntity selectedGroup = getSelectedGroup();
+                groupStudents = selectedGroup == null
+                        ? Collections.emptyList()
+                        : studentService.getStudentByGroupId(selectedGroup.getId());
+            }
             targetStudents = studentPlansService.synchronizePlanAssignments(updatedPlan, groupStudents);
         }
 
@@ -390,6 +393,24 @@ public class PlanView extends Div {
             return null;
         }
         return groupService.getGroupByTitle(selectedGroup);
+    }
+
+    private List<StudentEntity> getStudentsForPlanGroups(PlansEntity plan) {
+        if (plan == null || plan.getGroups() == null || plan.getGroups().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        PlansEntity planWithGroups = planService.getPlanWithGroups(plan.getId());
+        if (planWithGroups == null || planWithGroups.getGroups() == null || planWithGroups.getGroups().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return planWithGroups.getGroups().stream()
+                .filter(Objects::nonNull)
+                .flatMap(group -> studentService.getStudentByGroupId(group.getId()).stream())
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
     }
 
     private StudentEntity findStudentByFullName(String fullName) {

--- a/src/main/java/com/esvar/dekanat/service/PlanService.java
+++ b/src/main/java/com/esvar/dekanat/service/PlanService.java
@@ -129,6 +129,18 @@ public class PlanService {
         return planRepository.findById(id).orElse(null);
     }
 
+    @Transactional(readOnly = true)
+    public PlansEntity getPlanWithGroups(Long id) {
+        if (id == null) {
+            return null;
+        }
+        PlansEntity plan = planRepository.findById(id).orElse(null);
+        if (plan != null && plan.getGroups() != null) {
+            plan.getGroups().size();
+        }
+        return plan;
+    }
+
     public List<String> getSpecialtiesByFacultyAndDepartment(String faculty, String department) {
         return planRepository.findByFacultyAndDepartment
                 (
@@ -261,7 +273,12 @@ public class PlanService {
         if (plan.isElective()) {
             return;
         }
-        Set<StudentGroupEntity> planGroups = plan.getGroups();
+        PlansEntity managedPlan = planRepository.findById(plan.getId()).orElse(null);
+        if (managedPlan == null) {
+            return;
+        }
+
+        Set<StudentGroupEntity> planGroups = managedPlan.getGroups();
         if (planGroups == null || planGroups.isEmpty()) {
             return;
         }


### PR DESCRIPTION
## Summary
- add a PlanService helper that loads plan groups within a read-only transaction
- use the managed plan when collecting students for mandatory plans to avoid lazy loading errors

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694122e7f0848326a3e3fdef173b235b)