### PR TITLE
mark: generate statements by selected control type

### DIFF
--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -1242,14 +1242,19 @@ public class EnterMarksView extends Div {
         }
 
         return switch (controlType) {
-            case "Перший модульний контроль" -> {
+            case CONTROL_TYPE_FIRST_MODULE -> {
                 DataModelForMC1 data = buildDataModelForMC1(secondTeacher);
                 Path path = documentGenerationService.generate(FirstModulePdfGenerator.NAME, data);
                 yield new ReportGenerationResult(path.toString(), null, null);
             }
-            case "Другий модульний контроль" -> {
+            case CONTROL_TYPE_SECOND_MODULE -> {
                 DataModelForMC2 data = buildDataModelForMC2(secondTeacher);
                 Path path = documentGenerationService.generate(SecondModulePdfGenerator.NAME, data);
+                yield new ReportGenerationResult(path.toString(), null, null);
+            }
+            case "Залік", "Екзамен", "Диференційний залік", "Курсова робота", "Курсовий проєкт" -> {
+                DataModelForZalik data = buildDataModelForZalik(secondTeacher);
+                Path path = documentGenerationService.generate(ZalikPdfGenerator.NAME, data);
                 yield new ReportGenerationResult(path.toString(), null, null);
             }
             default -> {


### PR DESCRIPTION
## Summary
- route grade entry PDF generation by the selected control type instead of defaulting to the first module
- reuse the zalik template for exams and course work statements and fall back to a placeholder PDF for other control types

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69413e1014bc832686f586c42986d8f0)