### PR TITLE
Open generated reports directly via session resources

### DIFF
--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.grid.Grid;
-import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.Icon;
@@ -1185,6 +1184,11 @@ public class EnterMarksView extends Div {
     }
 
     private void generateReportWithLoading(String secondTeacher) {
+        String controlType = selectControlType.getValue();
+        if (controlType == null) {
+            Notification.show("Спочатку оберіть тип контролю!");
+            return;
+        }
         loadingOverlay.setVisible(true);
         UI ui = UI.getCurrent();
         SecurityContext securityContext = SecurityContextHolder.getContext();
@@ -1192,7 +1196,7 @@ public class EnterMarksView extends Div {
         CompletableFuture.supplyAsync(() -> {
             SecurityContextHolder.setContext(securityContext);
             try {
-                return generateReportFile(secondTeacher);
+                return generateReportFile(controlType, secondTeacher);
             } catch (Exception e) {
                 throw new CompletionException(e);
             } finally {
@@ -1235,21 +1239,21 @@ public class EnterMarksView extends Div {
         });
     }
 
-    private ReportGenerationResult generateReportFile(String secondTeacher) throws Exception {
-        String controlType = selectControlType.getValue();
-        if (controlType == null) {
-            throw new IllegalStateException("Спочатку оберіть тип контролю!");
-        }
-
+    private ReportGenerationResult generateReportFile(String controlType, String secondTeacher) throws Exception {
         return switch (controlType) {
-            case "Перший модульний контроль" -> {
+            case CONTROL_TYPE_FIRST_MODULE -> {
                 DataModelForMC1 data = buildDataModelForMC1(secondTeacher);
                 Path path = documentGenerationService.generate(FirstModulePdfGenerator.NAME, data);
                 yield new ReportGenerationResult(path.toString(), null, null);
             }
-            case "Другий модульний контроль" -> {
+            case CONTROL_TYPE_SECOND_MODULE -> {
                 DataModelForMC2 data = buildDataModelForMC2(secondTeacher);
                 Path path = documentGenerationService.generate(SecondModulePdfGenerator.NAME, data);
+                yield new ReportGenerationResult(path.toString(), null, null);
+            }
+            case "Залік", "Екзамен", "Диференційний залік", "Курсова робота", "Курсовий проєкт" -> {
+                DataModelForZalik data = buildDataModelForZalik(secondTeacher);
+                Path path = documentGenerationService.generate(ZalikPdfGenerator.NAME, data);
                 yield new ReportGenerationResult(path.toString(), null, null);
             }
             default -> {
@@ -1370,12 +1374,19 @@ public class EnterMarksView extends Div {
                     return null;
                 }
             });
-            Anchor downloadLink = new Anchor(resource, "");
-            downloadLink.getElement().setAttribute("download", true);
-            downloadLink.getElement().setAttribute("target", "_blank");
-            add(downloadLink);
-            UI.getCurrent().getPage()
-                    .executeJs("document.querySelector('a[download]').click();");
+            resource.setContentType("application/pdf");
+            resource.setCacheTime(0);
+
+            UI ui = UI.getCurrent();
+            if (ui == null) {
+                Notification.show("Не вдалося отримати UI для завантаження файлу");
+                return;
+            }
+
+            StreamRegistration registration = ui.getSession()
+                    .getResourceRegistry()
+                    .registerResource(resource);
+            ui.getPage().open(registration.getResourceUri().toString(), "_blank");
         } else {
             Notification.show("PDF файл не знайдено.");
         }


### PR DESCRIPTION
## Summary
- open generated PDF statements using session-registered stream resources instead of temporary anchors
- add explicit content type and caching directives for downloaded report files

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69413e1014bc832686f586c42986d8f0)