### PR TITLE
Fix PDF report opening using registered stream resources

### DIFF
--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -1347,7 +1347,12 @@ public class EnterMarksView extends Div {
         resource.setCacheTime(0);
         resource.setHeader(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + fileName + "\"");
 
-        ui.getPage().open(resource, "_blank", false);
+        StreamRegistration registration = VaadinSession.getCurrent()
+                .getResourceRegistry()
+                .registerResource(resource);
+        String resourceUrl = registration.getResourceUri().toString();
+
+        ui.getPage().open(resourceUrl, "_blank");
     }
 
     private void notifyFeatureInDevelopment() {
@@ -1385,7 +1390,12 @@ public class EnterMarksView extends Div {
             return;
         }
 
-        ui.getPage().open(resource, "_blank", false);
+        StreamRegistration registration = VaadinSession.getCurrent()
+                .getResourceRegistry()
+                .registerResource(resource);
+        String resourceUrl = registration.getResourceUri().toString();
+
+        ui.getPage().open(resourceUrl, "_blank");
     }
 
     private void configureLoadingOverlay() {


### PR DESCRIPTION
## Summary
- register generated PDF StreamResources in the Vaadin resource registry before opening
- ensure PDF report and saved file previews open in a new tab using the generated resource URL

## Testing
- ./mvnw -q -DskipTests compile *(fails: unable to download Maven binaries in this environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69416eefcf588326b92d2cdcc85a5a49)