### PR TITLE
Handle patronymic-optional student lookup

### DIFF
--- a/src/main/java/com/esvar/dekanat/plan/PlanView.java
+++ b/src/main/java/com/esvar/dekanat/plan/PlanView.java
@@ -10,7 +10,6 @@ import com.esvar.dekanat.dto.GroupDTO;
 import com.esvar.dekanat.entity.*;
 import com.esvar.dekanat.mark.EnterMarksView;
 import com.esvar.dekanat.plan.dialog.PlanDialog;
-import com.esvar.dekanat.repository.StudentRepository;
 import com.esvar.dekanat.service.*;
 import com.esvar.dekanat.view.MainLayout;
 import com.vaadin.flow.component.UI;
@@ -64,7 +63,6 @@ public class PlanView extends Div {
     private final ControlPartsService controlPartsService;
     private final StudentService studentService;
     private final MarksInitializerService marksInitializerService;
-    private final StudentRepository studentRepository;
     private final SummaryReportService summaryReportService;
     private static final Logger log = LoggerFactory.getLogger(EnterMarksView.class);
 
@@ -83,7 +81,7 @@ public class PlanView extends Div {
                     ControlMethodService controlMethodService,
                     GroupService groupService, PlanService planService,
                     MarksPartsService marksPartsService, StudentPlansService studentPlansService,
-                    MarksService marksService, ControlPartsService controlPartsService, StudentService studentService, MarksInitializerService marksInitializerService, StudentRepository studentRepository, SummaryReportService summaryReportService) {
+                    MarksService marksService, ControlPartsService controlPartsService, StudentService studentService, MarksInitializerService marksInitializerService, SummaryReportService summaryReportService) {
         // Ініціалізація сервісів
         this.disciplineService = disciplineService;
         this.departmentService = departmentService;
@@ -96,7 +94,6 @@ public class PlanView extends Div {
         this.controlPartsService = controlPartsService;
         this.studentService = studentService;
         this.marksInitializerService = marksInitializerService;
-        this.studentRepository = studentRepository;
         this.summaryReportService = summaryReportService;
 
         // Ініціалізація діалогового вікна
@@ -411,24 +408,6 @@ public class PlanView extends Div {
                 .filter(Objects::nonNull)
                 .distinct()
                 .toList();
-    }
-
-    private StudentEntity findStudentByFullName(String fullName) {
-        if (fullName == null || fullName.isBlank()) {
-            throw new IllegalArgumentException("ПІБ студента не може бути порожнім.");
-        }
-
-        String[] parts = fullName.trim().split("\\s+");
-        if (parts.length < 3) {
-            throw new IllegalArgumentException("Невірний формат ПІБ студента: '" + fullName + "'.");
-        }
-
-        String surname = parts[0];
-        String name = parts[1];
-        String patronymic = String.join(" ", Arrays.copyOfRange(parts, 2, parts.length));
-
-        return Optional.ofNullable(studentRepository.findFirstBySurnameAndNameAndPatronymicOrderByIdAsc(surname, name, patronymic))
-                .orElseThrow(() -> new IllegalArgumentException("Студент '" + fullName + "' не знайдений."));
     }
 
     private void configureReportButtons() {

--- a/src/main/java/com/esvar/dekanat/repository/StudentRepository.java
+++ b/src/main/java/com/esvar/dekanat/repository/StudentRepository.java
@@ -25,8 +25,13 @@ public interface StudentRepository extends JpaRepository<StudentEntity, Long> {
 
     StudentEntity findFirstBySurnameAndNameAndPatronymicOrderByIdAsc(String studentSurname, String studentName, String studentPatronymic);
 
+    List<StudentEntity> findBySurnameIgnoreCaseAndNameIgnoreCaseOrderByIdAsc(String studentSurname, String studentName);
+
     StudentEntity findFirstBySurnameAndNameAndPatronymicAndGroupIdOrderByIdAsc(String studentSurname, String studentName, String studentPatronymic, long groupId);
 
     List<StudentEntity> findByGroup(StudentGroupEntity group);
 
-    StudentEntity findFirstBySurnameAndNameAndPatronymicAndGroup_GroupCodeOrderByIdAsc(String studentSurname, String studentName, String studentPatronymic, String groupCode);}
+    List<StudentEntity> findBySurnameIgnoreCaseAndNameIgnoreCaseAndGroup_GroupCodeOrderByIdAsc(String studentSurname, String studentName, String groupCode);
+
+    StudentEntity findFirstBySurnameAndNameAndPatronymicAndGroup_GroupCodeOrderByIdAsc(String studentSurname, String studentName, String studentPatronymic, String groupCode);
+}

--- a/src/main/java/com/esvar/dekanat/service/StudentPlansService.java
+++ b/src/main/java/com/esvar/dekanat/service/StudentPlansService.java
@@ -5,26 +5,23 @@ import com.esvar.dekanat.entity.StudentEntity;
 import com.esvar.dekanat.entity.StudentPlansEntity;
 import com.esvar.dekanat.entity.StudentPlansPK;
 import com.esvar.dekanat.repository.StudentPlansRepository;
-import com.esvar.dekanat.repository.StudentRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 public class StudentPlansService{
 
     private final StudentPlansRepository studentPlansRepository;
-    private final StudentRepository studentRepository;
+    private final StudentService studentService;
 
 
-    public StudentPlansService(StudentPlansRepository studentPlansRepository, StudentRepository studentRepository) {
+    public StudentPlansService(StudentPlansRepository studentPlansRepository, StudentService studentService) {
         this.studentPlansRepository = studentPlansRepository;
-        this.studentRepository = studentRepository;
+        this.studentService = studentService;
     }
 
     /**
@@ -71,7 +68,7 @@ public class StudentPlansService{
         List<StudentEntity> mappedStudents = new ArrayList<>();
         if (students != null) {
             for (String studentName : students) {
-                mappedStudents.add(findStudentByFullName(studentName));
+                mappedStudents.add(studentService.getStudentByFullName(studentName));
             }
         }
 
@@ -150,105 +147,6 @@ public class StudentPlansService{
         }
 
         return targetStudents;
-    }
-
-    private StudentEntity findStudentByFullName(String fullName) {
-        if (fullName == null || fullName.isBlank()) {
-            throw new IllegalArgumentException("ПІБ студента не може бути порожнім.");
-        }
-
-        String normalizedFullName = normalizeFullName(fullName);
-        if (normalizedFullName.isBlank()) {
-            throw new IllegalArgumentException("ПІБ студента не може бути порожнім.");
-        }
-
-        String[] parts = normalizedFullName.split(" ");
-        if (parts.length < 2) {
-            throw new IllegalArgumentException("Невірний формат ПІБ студента: '" + fullName + "'.");
-        }
-
-        String surname = parts[0];
-        String name = parts[1];
-        String patronymic = parts.length > 2
-                ? String.join(" ", Arrays.copyOfRange(parts, 2, parts.length))
-                : null;
-
-        StudentEntity directMatch = studentRepository.findFirstBySurnameAndNameAndPatronymicOrderByIdAsc(surname, name, patronymic);
-        if (directMatch != null) {
-            return directMatch;
-        }
-
-        String normalizedWithoutPatronymic = patronymic == null ? surname + " " + name : null;
-
-        return studentRepository.findAll().stream()
-                .filter(existing -> matchesFullName(existing, normalizedFullName, normalizedWithoutPatronymic))
-                .sorted((a, b) -> compareByPatronymicPresence(a, b, normalizedWithoutPatronymic != null))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Студент '" + fullName + "' не знайдений."));
-    }
-
-    private static boolean matchesFullName(StudentEntity student,
-                                           String normalizedFullName,
-                                           String normalizedWithoutPatronymic) {
-        String existingNormalized = normalizeFullName(student.getFullName());
-        if (existingNormalized.equalsIgnoreCase(normalizedFullName)) {
-            return true;
-        }
-
-        if (normalizedWithoutPatronymic == null || existingNormalized.isBlank()) {
-            return false;
-        }
-
-        if (existingNormalized.equalsIgnoreCase(normalizedWithoutPatronymic)) {
-            return true;
-        }
-
-        String[] parts = existingNormalized.split(" ");
-        if (parts.length < 2) {
-            return false;
-        }
-
-        String candidateWithoutPatronymic = parts[0] + " " + parts[1];
-        return candidateWithoutPatronymic.equalsIgnoreCase(normalizedWithoutPatronymic);
-    }
-
-    private static int compareByPatronymicPresence(StudentEntity first,
-                                                   StudentEntity second,
-                                                   boolean preferMissingPatronymic) {
-        if (!preferMissingPatronymic) {
-            return 0;
-        }
-
-        boolean firstHasPatronymic = hasText(first.getPatronymic());
-        boolean secondHasPatronymic = hasText(second.getPatronymic());
-
-        if (firstHasPatronymic == secondHasPatronymic) {
-            return 0;
-        }
-        return firstHasPatronymic ? 1 : -1;
-    }
-
-    private static boolean hasText(String value) {
-        return value != null && !value.isBlank();
-    }
-
-    private static String normalizeFullName(String fullName) {
-        if (fullName == null) {
-            return "";
-        }
-        return Arrays.stream(fullName.trim().split("\\s+"))
-                .map(StudentPlansService::sanitizeNamePart)
-                .map(String::trim)
-                .filter(part -> !part.isBlank())
-                .filter(part -> !part.equalsIgnoreCase("null"))
-                .collect(Collectors.joining(" "));
-    }
-
-    private static String sanitizeNamePart(String part) {
-        if (part == null) {
-            return "";
-        }
-        return part.replaceAll("^[^\\p{L}0-9]+|[^\\p{L}0-9]+$", "");
     }
 
 }

--- a/src/main/java/com/esvar/dekanat/service/StudentService.java
+++ b/src/main/java/com/esvar/dekanat/service/StudentService.java
@@ -29,7 +29,15 @@ public class StudentService {
     }
 
     public StudentEntity getStudentByFullName(String studentSurname, String studentName, String studentPatronymic) {
-        return studentRepository.findFirstBySurnameAndNameAndPatronymicOrderByIdAsc(studentSurname, studentName, studentPatronymic);
+        NameParts parts = buildNameParts(studentSurname, studentName, studentPatronymic);
+        if (!hasText(parts.surname()) || !hasText(parts.name())) {
+            return null;
+        }
+
+        List<StudentEntity> candidates = studentRepository
+                .findBySurnameIgnoreCaseAndNameIgnoreCaseOrderByIdAsc(parts.surname(), parts.name());
+
+        return selectBestMatch(candidates, parts).orElse(null);
     }
 
 
@@ -54,40 +62,24 @@ public class StudentService {
     }
 
     public StudentEntity getStudentByStudentPIB_AndGroup(String studentPIB, StudentGroupEntity group) {
-        if (studentPIB == null) {
-            throw new IllegalArgumentException("ПІБ студента не може бути порожнім.");
-        }
+        NameParts parts = parseFullName(studentPIB);
         if (group == null) {
             throw new IllegalArgumentException("Група студента не може бути порожньою.");
         }
 
-        String normalizedFullName = normalizeFullName(studentPIB);
-        if (normalizedFullName.isBlank()) {
-            throw new IllegalArgumentException("ПІБ студента не може бути порожнім.");
+        List<StudentEntity> candidates = studentRepository
+                .findBySurnameIgnoreCaseAndNameIgnoreCaseAndGroup_GroupCodeOrderByIdAsc(parts.surname(), parts.name(), group.getGroupCode());
+
+        if (candidates.isEmpty()) {
+            candidates = studentRepository.findByGroup(group).stream()
+                    .sorted(Comparator.comparing(StudentEntity::getId))
+                    .filter(existing -> normalizeFullNameFromEntity(existing).equalsIgnoreCase(parts.normalizedFullName()))
+                    .toList();
         }
 
-        String[] parts = normalizedFullName.split(" ");
-        if (parts.length >= 3) {
-            String surname = parts[0];
-            String name = parts[1];
-            String patronymic = String.join(" ", Arrays.copyOfRange(parts, 2, parts.length));
-            StudentEntity student = studentRepository.findFirstBySurnameAndNameAndPatronymicAndGroup_GroupCodeOrderByIdAsc(
-                    surname,
-                    name,
-                    patronymic,
-                    group.getGroupCode()
-            );
-            if (student != null) {
-                return student;
-            }
-        }
-
-        String normalizedTarget = normalizedFullName.toLowerCase();
-        return studentRepository.findByGroup(group).stream()
-                .filter(existing -> normalizeFullName(existing.getFullName()).equalsIgnoreCase(normalizedTarget))
-                .findFirst()
+        return selectBestMatch(candidates, parts)
                 .orElseThrow(() -> new IllegalArgumentException(
-                        "Студента '" + normalizedFullName + "' у групі '" + group.getGroupCode() + "' не знайдено."
+                        "Студента '" + parts.normalizedFullName() + "' у групі '" + group.getGroupCode() + "' не знайдено."
                 ));
     }
 
@@ -107,6 +99,83 @@ public class StudentService {
     }
 
     public StudentEntity getStudentByFullName(String fullName) {
+        NameParts parts = parseFullName(fullName);
+        StudentEntity student = findStudentByParts(parts);
+
+        if (student == null) {
+            throw new IllegalArgumentException("Студента '" + parts.normalizedFullName() + "' не знайдено.");
+        }
+
+        return student;
+    }
+
+    private StudentEntity findStudentByParts(NameParts parts) {
+        List<StudentEntity> candidates = collectCandidates(parts);
+        return selectBestMatch(candidates, parts).orElse(null);
+    }
+
+    private List<StudentEntity> collectCandidates(NameParts parts) {
+        List<StudentEntity> candidates = studentRepository
+                .findBySurnameIgnoreCaseAndNameIgnoreCaseOrderByIdAsc(parts.surname(), parts.name());
+
+        if (!candidates.isEmpty()) {
+            return candidates;
+        }
+
+        String normalizedTarget = parts.normalizedFullName();
+        return studentRepository.findAll().stream()
+                .sorted(Comparator.comparing(StudentEntity::getId))
+                .filter(existing -> normalizeFullNameFromEntity(existing).equalsIgnoreCase(normalizedTarget))
+                .toList();
+    }
+
+    private static Optional<StudentEntity> selectBestMatch(List<StudentEntity> candidates, NameParts target) {
+        if (candidates == null || candidates.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String targetPatronymic = normalizeNamePart(target.patronymic());
+        boolean targetHasPatronymic = hasText(targetPatronymic);
+        Comparator<StudentEntity> byId = Comparator.comparing(StudentEntity::getId);
+
+        if (targetHasPatronymic) {
+            Optional<StudentEntity> patronymicMatch = candidates.stream()
+                    .filter(student -> hasText(student.getPatronymic()))
+                    .filter(student -> normalizeNamePart(student.getPatronymic()).equalsIgnoreCase(targetPatronymic))
+                    .min(byId);
+
+            if (patronymicMatch.isPresent()) {
+                return patronymicMatch;
+            }
+        }
+
+        Optional<StudentEntity> withoutPatronymic = candidates.stream()
+                .filter(student -> !hasText(student.getPatronymic()))
+                .min(byId);
+
+        if (withoutPatronymic.isPresent()) {
+            return withoutPatronymic;
+        }
+
+        if (!targetHasPatronymic) {
+            return candidates.stream().min(byId);
+        }
+
+        return candidates.stream()
+                .filter(student -> hasText(student.getPatronymic()))
+                .min(byId);
+    }
+
+    private static NameParts buildNameParts(String surname, String name, String patronymic) {
+        String normalizedSurname = normalizeNamePart(surname);
+        String normalizedName = normalizeNamePart(name);
+        String normalizedPatronymic = normalizeNamePart(patronymic);
+        String normalizedFullName = normalizeFullName(String.join(" ",
+                Arrays.asList(normalizedSurname, normalizedName, normalizedPatronymic)));
+        return new NameParts(normalizedSurname, normalizedName, normalizedPatronymic, normalizedFullName);
+    }
+
+    private static NameParts parseFullName(String fullName) {
         if (fullName == null) {
             throw new IllegalArgumentException("ПІБ студента не може бути порожнім.");
         }
@@ -117,33 +186,35 @@ public class StudentService {
         }
 
         String[] parts = normalizedFullName.split(" ");
-        if (parts.length < 3) {
+        if (parts.length < 2) {
             throw new IllegalArgumentException("Невірний формат ПІБ студента: '" + normalizedFullName + "'.");
         }
 
         String surname = parts[0];
         String name = parts[1];
-        String patronymic = parts[2];
+        String patronymic = parts.length > 2
+                ? String.join(" ", Arrays.copyOfRange(parts, 2, parts.length))
+                : "";
 
-        StudentEntity student = Optional.ofNullable(getStudentByFullName(surname, name, patronymic))
-                .orElseGet(() -> studentRepository.findAll()
-                        .stream()
-                        .filter(existing -> normalizeFullName(existing.getFullName()).equalsIgnoreCase(normalizedFullName))
-                        .findFirst()
-                        .orElse(null));
-
-        if (student == null) {
-            throw new IllegalArgumentException("Студента '" + normalizedFullName + "' не знайдено.");
-        }
-
-        return student;
+        return new NameParts(surname, name, patronymic, normalizedFullName);
     }
 
     private static String normalizeFullName(String fullName) {
+        if (fullName == null) {
+            return "";
+        }
         return Arrays.stream(fullName.trim().split("\\s+"))
-                .map(StudentService::sanitizeNamePart)
-                .filter(part -> !part.isBlank())
+                .map(StudentService::normalizeNamePart)
+                .filter(StudentService::hasText)
+                .filter(part -> !part.equalsIgnoreCase("null"))
                 .collect(Collectors.joining(" "));
+    }
+
+    private static String normalizeNamePart(String part) {
+        if (part == null) {
+            return "";
+        }
+        return sanitizeNamePart(part).trim();
     }
 
     private static String sanitizeNamePart(String part) {
@@ -151,5 +222,20 @@ public class StudentService {
             return "";
         }
         return part.replaceAll("^[^\\p{L}0-9]+|[^\\p{L}0-9]+$", "");
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private static String normalizeFullNameFromEntity(StudentEntity student) {
+        return normalizeFullName(String.join(" ", Arrays.asList(
+                normalizeNamePart(student.getSurname()),
+                normalizeNamePart(student.getName()),
+                normalizeNamePart(student.getPatronymic())
+        )));
+    }
+
+    private record NameParts(String surname, String name, String patronymic, String normalizedFullName) {
     }
 }


### PR DESCRIPTION
## Summary
- add case-insensitive surname and name queries to support patronymic-optional lookups
- centralize student search logic to normalize names and prefer the best match when patronymic data is missing
- update plan services and views to reuse the flexible lookup instead of direct strict repository calls

## Testing
- ./mvnw -q -DskipTests compile *(fails: unable to download Maven distribution in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942da7d275c83268e5332c79fd2a2f4)