### PR TITLE
Fix department head surname formatting in reports

### DIFF
--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -1495,7 +1495,7 @@ public class EnterMarksView extends Div {
         String gradeTeacher = getCurrentUserFullName();
         FacultyEntity faculty = plansEntity.getFaculty();
         String dean = faculty.getDeanLanding();
-        String departmentName = capitalize(faculty.getDeanI()) + " " + faculty.getDeanP().toUpperCase();
+        String departmentName = formatDepartmentHeadName(faculty);
 
         Map<String, Long> gradeMap = marksService
                 .findMarksByPlanAndTypeControl(plansEntity, controlTypeName)
@@ -1528,6 +1528,14 @@ public class EnterMarksView extends Div {
                 order, day, month, year, disciplineName, semesterNumber, controlTypeName,
                 hours, firstTeacher, secondTeacher, dean, departmentName,
                 a, b, c, d, e, fx, f, gradeTeacher, students);
+    }
+
+    private String formatDepartmentHeadName(FacultyEntity faculty) {
+        String firstName = capitalize(faculty.getDeanI());
+        String surname = Optional.ofNullable(faculty.getDeanB())
+                .map(String::toUpperCase)
+                .orElse("");
+        return (firstName + " " + surname).trim();
     }
 
     private void showAdditionalReportDialog() {


### PR DESCRIPTION
## Summary
- format the head of department name using the stored surname to prevent patronymic from appearing in statements
- keep generated mark sheets showing the expected first-name plus uppercase-surname format

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942ebf133dc83268471ad8f9823fc00)