### PR TITLE
Add dedicated PDF generators per control type

### DIFF
--- a/src/main/java/com/esvar/dekanat/document/DocumentGenerationService.java
+++ b/src/main/java/com/esvar/dekanat/document/DocumentGenerationService.java
@@ -50,6 +50,7 @@ public class DocumentGenerationService {
         Map<String, Object> context = generator.prepareContext(data);
         log.info("Generating document {}", name);
 
-        return engine.generate(generator.getTemplatePath(), context);
+        String templatePath = generator.resolveTemplatePath(data);
+        return engine.generate(templatePath, context);
     }
 }

--- a/src/main/java/com/esvar/dekanat/document/DocumentGenerator.java
+++ b/src/main/java/com/esvar/dekanat/document/DocumentGenerator.java
@@ -18,6 +18,16 @@ public interface DocumentGenerator {
     String getTemplatePath();
 
     /**
+     * Resolve template path for the provided data. By default returns {@link #getTemplatePath()}.
+     *
+     * @param data source object with generation data
+     * @return path to template
+     */
+    default String resolveTemplatePath(Object data) {
+        return getTemplatePath();
+    }
+
+    /**
      * Prepare context variables used in template.
      *
      * @param data source object with generation data

--- a/src/main/java/com/esvar/dekanat/generate/pdf/BaseZalikStylePdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/BaseZalikStylePdfGenerator.java
@@ -1,0 +1,346 @@
+package com.esvar.dekanat.generate.pdf;
+
+import com.esvar.dekanat.document.DocumentException;
+import com.esvar.dekanat.document.PdfGenerator;
+import com.esvar.dekanat.generate.DataModelForZalik;
+import com.esvar.dekanat.generate.StudentModelToDocumentGenerate;
+import com.itextpdf.io.font.FontProgram;
+import com.itextpdf.io.font.FontProgramFactory;
+import com.itextpdf.io.font.PdfEncodings;
+import com.itextpdf.io.font.constants.StandardFonts;
+import com.itextpdf.kernel.font.PdfFont;
+import com.itextpdf.kernel.font.PdfFontFactory;
+import com.itextpdf.kernel.geom.PageSize;
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfWriter;
+import com.itextpdf.kernel.pdf.canvas.draw.SolidLine;
+import com.itextpdf.layout.Document;
+import com.itextpdf.layout.borders.Border;
+import com.itextpdf.layout.borders.SolidBorder;
+import com.itextpdf.layout.element.Cell;
+import com.itextpdf.layout.element.LineSeparator;
+import com.itextpdf.layout.element.Paragraph;
+import com.itextpdf.layout.element.Table;
+import com.itextpdf.layout.properties.TextAlignment;
+import com.itextpdf.layout.properties.UnitValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Shared layout for Zalik-like control PDFs. Subclasses override only name and output suffix.
+ */
+public abstract class BaseZalikStylePdfGenerator implements PdfGenerator {
+
+    private static final Logger log = LoggerFactory.getLogger(BaseZalikStylePdfGenerator.class);
+
+    @Override
+    public Path generatePdf(Object data) {
+        if (!(data instanceof DataModelForZalik zalikData)) {
+            throw new DocumentException("Expected DataModelForZalik");
+        }
+
+        try {
+            Path outputPath = resolveOutputPath(zalikData);
+            Files.createDirectories(outputPath.getParent());
+
+            try (PdfWriter writer = new PdfWriter(outputPath.toFile());
+                 PdfDocument pdfDocument = new PdfDocument(writer);
+                 Document document = new Document(pdfDocument, PageSize.A4)) {
+
+                PdfFont regular = loadFont("/fonts/times.ttf", StandardFonts.TIMES_ROMAN);
+                PdfFont bold = loadFont("/fonts/timesbd.ttf", StandardFonts.TIMES_BOLD);
+
+                document.setFont(regular);
+
+                addHeader(document, regular, bold, zalikData);
+                addStudentsTable(document, regular, bold, zalikData);
+                addSummarySection(document, regular, bold, zalikData);
+
+                log.info("Generated {} PDF at {}", getName(), outputPath);
+            }
+
+            return outputPath;
+        } catch (IOException e) {
+            throw new DocumentException("Failed to generate PDF", e);
+        }
+    }
+
+    protected abstract String outputSuffix(DataModelForZalik data);
+
+    private void addHeader(Document document, PdfFont regular, PdfFont bold, DataModelForZalik data) {
+        document.add(new Paragraph("НАЦІОНАЛЬНИЙ ТРАНСПОРТНИЙ УНІВЕРСИТЕТ")
+                .setFont(bold)
+                .setFontSize(11)
+                .setTextAlignment(TextAlignment.CENTER));
+
+        SolidLine solidLine = new SolidLine(1f);
+        LineSeparator line = new LineSeparator(solidLine);
+        line.setMarginTop(-6);
+        line.setMarginBottom(0);
+
+        document.add(line);
+        document.add(new Paragraph(Objects.toString(data.facultyName(), ""))
+                .setFont(regular)
+                .setFontSize(11));
+        document.add(line);
+        document.add(new Paragraph("Спеціальність: " + Objects.toString(data.specialityName(), ""))
+                .setFont(regular)
+                .setFontSize(11));
+        document.add(line);
+
+        Table groupTable = new Table(UnitValue.createPercentArray(new float[]{25, 10, 25, 40}))
+                .useAllAvailableWidth();
+
+        groupTable.addCell(buildLabelCell("Курс: ", regular));
+        groupTable.addCell(buildValueCell(Objects.toString(data.courseNumber(), ""), regular));
+        groupTable.addCell(buildLabelCell("\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0Група: ", regular));
+        groupTable.addCell(buildValueCell(Objects.toString(data.groupName(), ""), regular));
+
+        document.add(groupTable);
+
+        document.add(new Paragraph(Objects.toString(data.studyYear(), "") + " навчальний рік")
+                .setFont(regular)
+                .setFontSize(11)
+                .setTextAlignment(TextAlignment.CENTER));
+
+        document.add(new Paragraph("ВІДОМІСТЬ ОБЛІКУ УСПІШНОСТІ № " + Objects.toString(data.order(), ""))
+                .setFont(bold)
+                .setFontSize(12)
+                .setTextAlignment(TextAlignment.CENTER)
+                .setMarginTop(6));
+
+        document.add(new Paragraph(String.format("з дисципліни: %s за %s семестр",
+                        Objects.toString(data.disciplineName(), ""), Objects.toString(data.semesterNumber(), "")))
+                .setFont(regular)
+                .setFontSize(11)
+                .setTextAlignment(TextAlignment.CENTER));
+
+        document.add(new Paragraph("Форма семестрового контролю: " + Objects.toString(data.controlTypeName(), ""))
+                .setFont(regular)
+                .setFontSize(11)
+                .setTextAlignment(TextAlignment.CENTER));
+
+        document.add(new Paragraph("Загальна кількість годин: " + Objects.toString(data.hours(), ""))
+                .setFont(regular)
+                .setFontSize(11)
+                .setTextAlignment(TextAlignment.CENTER));
+
+        Table teachersTable = new Table(UnitValue.createPercentArray(new float[]{50, 50}))
+                .useAllAvailableWidth();
+        teachersTable.addCell(buildTeacherCell("Перший викладач: ", Objects.toString(data.firstTeacher(), ""), regular));
+        teachersTable.addCell(buildTeacherCell("Другий викладач: ", Objects.toString(data.secondTeacher(), ""), regular));
+
+        document.add(teachersTable);
+        document.add(new Paragraph(""));
+    }
+
+    private void addStudentsTable(Document document, PdfFont regular, PdfFont bold, DataModelForZalik data) {
+        float[] columnWidths = {4, 28, 15, 14, 10, 10, 12, 7};
+        Table table = new Table(UnitValue.createPercentArray(columnWidths))
+                .useAllAvailableWidth();
+
+        addHeaderCell(table, "№", bold);
+        addHeaderCell(table, "ПІБ", bold);
+        addHeaderCell(table, "Номер залікової книжки", bold);
+        addHeaderCell(table, "Нац. оцінка", bold);
+        addHeaderCell(table, "Бали", bold);
+        addHeaderCell(table, "ECTS", bold);
+        addHeaderCell(table, "Дата", bold);
+        addHeaderCell(table, "Підпис", bold);
+
+        String date = formatDate(data);
+        List<StudentModelToDocumentGenerate> students = data.students();
+        for (StudentModelToDocumentGenerate student : students) {
+            int numericMark = parseToInt(student.mark());
+            String nationalGrade = convertMarkToNationalGrade(numericMark);
+            String ectsGrade = convertMarkToECTSGrade(numericMark);
+
+            table.addCell(defaultCell(String.valueOf(student.index()), regular, TextAlignment.CENTER));
+            table.addCell(defaultCell(student.name(), regular, TextAlignment.LEFT));
+            table.addCell(defaultCell(student.studentNumber(), regular, TextAlignment.CENTER));
+            table.addCell(defaultCell(nationalGrade, regular, TextAlignment.CENTER));
+            table.addCell(defaultCell(student.mark(), regular, TextAlignment.CENTER));
+            table.addCell(defaultCell(ectsGrade, regular, TextAlignment.CENTER));
+            table.addCell(defaultCell(date, regular, TextAlignment.CENTER));
+            table.addCell(defaultCell("", regular, TextAlignment.CENTER));
+        }
+
+        document.add(table);
+    }
+
+    private void addSummarySection(Document document, PdfFont regular, PdfFont bold, DataModelForZalik data) {
+        document.add(new Paragraph(""));
+
+        Table gradeTable = new Table(UnitValue.createPercentArray(new float[]{10, 10, 10, 10, 10, 10, 10}))
+                .useAllAvailableWidth();
+        addHeaderCell(gradeTable, "A", bold);
+        addHeaderCell(gradeTable, "B", bold);
+        addHeaderCell(gradeTable, "C", bold);
+        addHeaderCell(gradeTable, "D", bold);
+        addHeaderCell(gradeTable, "E", bold);
+        addHeaderCell(gradeTable, "FX", bold);
+        addHeaderCell(gradeTable, "F", bold);
+
+        gradeTable.addCell(defaultCell(Objects.toString(data.a(), "0"), regular, TextAlignment.CENTER));
+        gradeTable.addCell(defaultCell(Objects.toString(data.b(), "0"), regular, TextAlignment.CENTER));
+        gradeTable.addCell(defaultCell(Objects.toString(data.c(), "0"), regular, TextAlignment.CENTER));
+        gradeTable.addCell(defaultCell(Objects.toString(data.d(), "0"), regular, TextAlignment.CENTER));
+        gradeTable.addCell(defaultCell(Objects.toString(data.e(), "0"), regular, TextAlignment.CENTER));
+        gradeTable.addCell(defaultCell(Objects.toString(data.fx(), "0"), regular, TextAlignment.CENTER));
+        gradeTable.addCell(defaultCell(Objects.toString(data.f(), "0"), regular, TextAlignment.CENTER));
+
+        document.add(gradeTable);
+
+        document.add(new Paragraph(""));
+
+        Table signTable = new Table(UnitValue.createPercentArray(new float[]{33, 34, 33}))
+                .useAllAvailableWidth();
+        signTable.addCell(signatureCell("Викладач", Objects.toString(data.gradeTeacher(), ""), regular));
+        signTable.addCell(signatureCell("Декан", Objects.toString(data.dean(), ""), regular));
+        signTable.addCell(signatureCell("Завідувач кафедри", Objects.toString(data.departmentName(), ""), regular));
+
+        document.add(signTable);
+    }
+
+    private Cell buildLabelCell(String text, PdfFont font) {
+        return new Cell().setPadding(0)
+                .add(new Paragraph(text)
+                        .setFont(font)
+                        .setFontSize(11))
+                .setBorder(Border.NO_BORDER);
+    }
+
+    private Cell buildValueCell(String text, PdfFont font) {
+        return new Cell().setPadding(0)
+                .add(new Paragraph(text)
+                        .setFont(font)
+                        .setFontSize(11)
+                        .setTextAlignment(TextAlignment.CENTER))
+                .setBorderTop(Border.NO_BORDER)
+                .setBorderLeft(Border.NO_BORDER)
+                .setBorderRight(Border.NO_BORDER)
+                .setBorderBottom(new SolidBorder(0.5f));
+    }
+
+    private Cell buildTeacherCell(String label, String value, PdfFont font) {
+        return new Cell().setPadding(4)
+                .add(new Paragraph(label + value)
+                        .setFont(font)
+                        .setFontSize(11))
+                .setBorder(Border.NO_BORDER);
+    }
+
+    private void addHeaderCell(Table table, String text, PdfFont bold) {
+        table.addHeaderCell(new Cell().add(new Paragraph(text)
+                        .setFont(bold)
+                        .setFontSize(10)
+                        .setTextAlignment(TextAlignment.CENTER))
+                .setPadding(4));
+    }
+
+    private Cell defaultCell(String text, PdfFont font, TextAlignment alignment) {
+        return new Cell().add(new Paragraph(text == null ? "" : text)
+                        .setFont(font)
+                        .setFontSize(10)
+                        .setTextAlignment(alignment))
+                .setPadding(4);
+    }
+
+    private Cell signatureCell(String label, String value, PdfFont font) {
+        Paragraph labelParagraph = new Paragraph(label)
+                .setFont(font)
+                .setFontSize(11);
+        Paragraph valueParagraph = new Paragraph(value)
+                .setFont(font)
+                .setFontSize(11)
+                .setTextAlignment(TextAlignment.CENTER)
+                .setBorderBottom(new SolidBorder(0.5f));
+
+        return new Cell().setPadding(6)
+                .add(labelParagraph)
+                .add(valueParagraph)
+                .setBorder(Border.NO_BORDER);
+    }
+
+    private PdfFont loadFont(String resourcePath, String fallbackFont) throws IOException {
+        try (InputStream fontStream = BaseZalikStylePdfGenerator.class.getResourceAsStream(resourcePath)) {
+            if (fontStream != null) {
+                FontProgram fontProgram = FontProgramFactory.createFont(fontStream.readAllBytes());
+                return PdfFontFactory.createFont(fontProgram, PdfEncodings.IDENTITY_H);
+            }
+        } catch (IOException ex) {
+            log.warn("Unable to load font {}: {}", resourcePath, ex.getMessage());
+        }
+        return PdfFontFactory.createFont(fallbackFont);
+    }
+
+    private Path resolveOutputPath(DataModelForZalik data) {
+        String fileName = Objects.toString(data.groupName(), "group") + "_"
+                + outputSuffix(data) + "_"
+                + Objects.toString(data.semesterNumber(), "0") + "_"
+                + Objects.toString(data.order(), "00") + ".pdf";
+        return Paths.get("uploads").resolve(fileName);
+    }
+
+    private int parseToInt(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private String convertMarkToNationalGrade(int mark) {
+        if (mark >= 90) {
+            return "Відмінно";
+        } else if (mark >= 82) {
+            return "Добре";
+        } else if (mark >= 74) {
+            return "Добре";
+        } else if (mark >= 64) {
+            return "Задовільно";
+        } else if (mark >= 60) {
+            return "Задовільно";
+        } else if (mark >= 35) {
+            return "Незадовільно";
+        } else {
+            return "Незадовільно";
+        }
+    }
+
+    private String convertMarkToECTSGrade(int mark) {
+        if (mark >= 90) {
+            return "A";
+        } else if (mark >= 82) {
+            return "B";
+        } else if (mark >= 74) {
+            return "C";
+        } else if (mark >= 64) {
+            return "D";
+        } else if (mark >= 60) {
+            return "E";
+        } else if (mark >= 35) {
+            return "FX";
+        } else {
+            return "F";
+        }
+    }
+
+    private String formatDate(DataModelForZalik data) {
+        String day = Objects.toString(data.day(), "").trim();
+        String month = Objects.toString(data.month(), "").trim();
+        String year = Objects.toString(data.year(), "").trim();
+        if (!day.isEmpty() && !month.isEmpty() && !year.isEmpty()) {
+            return String.format("%s.%s.%s", day, month, year);
+        }
+        return "";
+    }
+}

--- a/src/main/java/com/esvar/dekanat/generate/pdf/CalculationGraphicWorkPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/CalculationGraphicWorkPdfGenerator.java
@@ -1,16 +1,15 @@
 package com.esvar.dekanat.generate.pdf;
 
 import com.esvar.dekanat.generate.DataModelForZalik;
-import com.esvar.dekanat.generate.ZalikGenerator;
 import org.springframework.stereotype.Component;
 
 /**
- * PDF generator for "Відомість обліку успішності" (залік).
+ * PDF generator for calculation-graphic work statements.
  */
 @Component
-public class ZalikPdfGenerator extends BaseZalikStylePdfGenerator {
+public class CalculationGraphicWorkPdfGenerator extends BaseZalikStylePdfGenerator {
 
-    public static final String NAME = ZalikGenerator.NAME;
+    public static final String NAME = "calculation-graphic-work";
 
     @Override
     public String getName() {
@@ -19,6 +18,6 @@ public class ZalikPdfGenerator extends BaseZalikStylePdfGenerator {
 
     @Override
     protected String outputSuffix(DataModelForZalik data) {
-        return "zalik";
+        return "calculation-graphic-work";
     }
 }

--- a/src/main/java/com/esvar/dekanat/generate/pdf/CalculationWorkPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/CalculationWorkPdfGenerator.java
@@ -1,16 +1,15 @@
 package com.esvar.dekanat.generate.pdf;
 
 import com.esvar.dekanat.generate.DataModelForZalik;
-import com.esvar.dekanat.generate.ZalikGenerator;
 import org.springframework.stereotype.Component;
 
 /**
- * PDF generator for "Відомість обліку успішності" (залік).
+ * PDF generator for calculation work statements.
  */
 @Component
-public class ZalikPdfGenerator extends BaseZalikStylePdfGenerator {
+public class CalculationWorkPdfGenerator extends BaseZalikStylePdfGenerator {
 
-    public static final String NAME = ZalikGenerator.NAME;
+    public static final String NAME = "calculation-work";
 
     @Override
     public String getName() {
@@ -19,6 +18,6 @@ public class ZalikPdfGenerator extends BaseZalikStylePdfGenerator {
 
     @Override
     protected String outputSuffix(DataModelForZalik data) {
-        return "zalik";
+        return "calculation-work";
     }
 }

--- a/src/main/java/com/esvar/dekanat/generate/pdf/ControlWorkPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/ControlWorkPdfGenerator.java
@@ -1,16 +1,15 @@
 package com.esvar.dekanat.generate.pdf;
 
 import com.esvar.dekanat.generate.DataModelForZalik;
-import com.esvar.dekanat.generate.ZalikGenerator;
 import org.springframework.stereotype.Component;
 
 /**
- * PDF generator for "Відомість обліку успішності" (залік).
+ * PDF generator for control work statements.
  */
 @Component
-public class ZalikPdfGenerator extends BaseZalikStylePdfGenerator {
+public class ControlWorkPdfGenerator extends BaseZalikStylePdfGenerator {
 
-    public static final String NAME = ZalikGenerator.NAME;
+    public static final String NAME = "control-work";
 
     @Override
     public String getName() {
@@ -19,6 +18,6 @@ public class ZalikPdfGenerator extends BaseZalikStylePdfGenerator {
 
     @Override
     protected String outputSuffix(DataModelForZalik data) {
-        return "zalik";
+        return "control-work";
     }
 }

--- a/src/main/java/com/esvar/dekanat/generate/pdf/CourseProjectPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/CourseProjectPdfGenerator.java
@@ -1,16 +1,15 @@
 package com.esvar.dekanat.generate.pdf;
 
 import com.esvar.dekanat.generate.DataModelForZalik;
-import com.esvar.dekanat.generate.ZalikGenerator;
 import org.springframework.stereotype.Component;
 
 /**
- * PDF generator for "Відомість обліку успішності" (залік).
+ * PDF generator for course project control statements.
  */
 @Component
-public class ZalikPdfGenerator extends BaseZalikStylePdfGenerator {
+public class CourseProjectPdfGenerator extends BaseZalikStylePdfGenerator {
 
-    public static final String NAME = ZalikGenerator.NAME;
+    public static final String NAME = "course-project";
 
     @Override
     public String getName() {
@@ -19,6 +18,6 @@ public class ZalikPdfGenerator extends BaseZalikStylePdfGenerator {
 
     @Override
     protected String outputSuffix(DataModelForZalik data) {
-        return "zalik";
+        return "course-project";
     }
 }

--- a/src/main/java/com/esvar/dekanat/generate/pdf/CourseWorkPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/CourseWorkPdfGenerator.java
@@ -1,16 +1,15 @@
 package com.esvar.dekanat.generate.pdf;
 
 import com.esvar.dekanat.generate.DataModelForZalik;
-import com.esvar.dekanat.generate.ZalikGenerator;
 import org.springframework.stereotype.Component;
 
 /**
- * PDF generator for "Відомість обліку успішності" (залік).
+ * PDF generator for course work control statements.
  */
 @Component
-public class ZalikPdfGenerator extends BaseZalikStylePdfGenerator {
+public class CourseWorkPdfGenerator extends BaseZalikStylePdfGenerator {
 
-    public static final String NAME = ZalikGenerator.NAME;
+    public static final String NAME = "course-work";
 
     @Override
     public String getName() {
@@ -19,6 +18,6 @@ public class ZalikPdfGenerator extends BaseZalikStylePdfGenerator {
 
     @Override
     protected String outputSuffix(DataModelForZalik data) {
-        return "zalik";
+        return "course-work";
     }
 }

--- a/src/main/java/com/esvar/dekanat/generate/pdf/DifferentialZalikPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/DifferentialZalikPdfGenerator.java
@@ -1,16 +1,15 @@
 package com.esvar.dekanat.generate.pdf;
 
 import com.esvar.dekanat.generate.DataModelForZalik;
-import com.esvar.dekanat.generate.ZalikGenerator;
 import org.springframework.stereotype.Component;
 
 /**
- * PDF generator for "Відомість обліку успішності" (залік).
+ * PDF generator for differential credit statements.
  */
 @Component
-public class ZalikPdfGenerator extends BaseZalikStylePdfGenerator {
+public class DifferentialZalikPdfGenerator extends BaseZalikStylePdfGenerator {
 
-    public static final String NAME = ZalikGenerator.NAME;
+    public static final String NAME = "differential-zalik";
 
     @Override
     public String getName() {
@@ -19,6 +18,6 @@ public class ZalikPdfGenerator extends BaseZalikStylePdfGenerator {
 
     @Override
     protected String outputSuffix(DataModelForZalik data) {
-        return "zalik";
+        return "differential-zalik";
     }
 }

--- a/src/main/java/com/esvar/dekanat/generate/pdf/ExamPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/ExamPdfGenerator.java
@@ -1,16 +1,15 @@
 package com.esvar.dekanat.generate.pdf;
 
 import com.esvar.dekanat.generate.DataModelForZalik;
-import com.esvar.dekanat.generate.ZalikGenerator;
 import org.springframework.stereotype.Component;
 
 /**
- * PDF generator for "Відомість обліку успішності" (залік).
+ * PDF generator for exam control statements.
  */
 @Component
-public class ZalikPdfGenerator extends BaseZalikStylePdfGenerator {
+public class ExamPdfGenerator extends BaseZalikStylePdfGenerator {
 
-    public static final String NAME = ZalikGenerator.NAME;
+    public static final String NAME = "exam";
 
     @Override
     public String getName() {
@@ -19,6 +18,6 @@ public class ZalikPdfGenerator extends BaseZalikStylePdfGenerator {
 
     @Override
     protected String outputSuffix(DataModelForZalik data) {
-        return "zalik";
+        return "exam";
     }
 }

--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -5,9 +5,16 @@ import com.esvar.dekanat.dto.GroupDTO;
 import com.esvar.dekanat.dto.MarkDTO;
 import com.esvar.dekanat.entity.*;
 import com.esvar.dekanat.generate.*;
+import com.esvar.dekanat.generate.pdf.BasicControlPdfGenerator;
+import com.esvar.dekanat.generate.pdf.CalculationGraphicWorkPdfGenerator;
+import com.esvar.dekanat.generate.pdf.CalculationWorkPdfGenerator;
+import com.esvar.dekanat.generate.pdf.ControlWorkPdfGenerator;
+import com.esvar.dekanat.generate.pdf.CourseProjectPdfGenerator;
+import com.esvar.dekanat.generate.pdf.CourseWorkPdfGenerator;
+import com.esvar.dekanat.generate.pdf.DifferentialZalikPdfGenerator;
+import com.esvar.dekanat.generate.pdf.ExamPdfGenerator;
 import com.esvar.dekanat.generate.pdf.FirstModulePdfGenerator;
 import com.esvar.dekanat.generate.pdf.SecondModulePdfGenerator;
-import com.esvar.dekanat.generate.pdf.BasicControlPdfGenerator;
 import com.esvar.dekanat.generate.pdf.ZalikPdfGenerator;
 import com.esvar.dekanat.progress.SuccessView;
 import com.esvar.dekanat.security.SecurityService;
@@ -1250,27 +1257,27 @@ public class EnterMarksView extends Div {
 
     private ReportGenerationResult generateReportFile(String controlType, String secondTeacher) throws Exception {
         return switch (controlType) {
-            case CONTROL_TYPE_FIRST_MODULE -> {
-                DataModelForMC1 data = buildDataModelForMC1(secondTeacher);
-                Path path = documentGenerationService.generate(FirstModulePdfGenerator.NAME, data);
-                yield new ReportGenerationResult(path.toString(), null, null);
-            }
-            case CONTROL_TYPE_SECOND_MODULE -> {
-                DataModelForMC2 data = buildDataModelForMC2(secondTeacher);
-                Path path = documentGenerationService.generate(SecondModulePdfGenerator.NAME, data);
-                yield new ReportGenerationResult(path.toString(), null, null);
-            }
-            case "Залік", "Екзамен", "Диференційний залік", "Курсова робота", "Курсовий проєкт" -> {
-                DataModelForZalik data = buildDataModelForZalik(secondTeacher);
-                Path path = documentGenerationService.generate(ZalikPdfGenerator.NAME, data);
-                yield new ReportGenerationResult(path.toString(), null, null);
-            }
+            case CONTROL_TYPE_FIRST_MODULE -> generateReportWithModel(FirstModulePdfGenerator.NAME, buildDataModelForMC1(secondTeacher));
+            case CONTROL_TYPE_SECOND_MODULE -> generateReportWithModel(SecondModulePdfGenerator.NAME, buildDataModelForMC2(secondTeacher));
+            case "Залік" -> generateReportWithModel(ZalikPdfGenerator.NAME, buildDataModelForZalik(secondTeacher));
+            case "Екзамен" -> generateReportWithModel(ExamPdfGenerator.NAME, buildDataModelForZalik(secondTeacher));
+            case "Диференційний залік" -> generateReportWithModel(DifferentialZalikPdfGenerator.NAME, buildDataModelForZalik(secondTeacher));
+            case "Курсова робота" -> generateReportWithModel(CourseWorkPdfGenerator.NAME, buildDataModelForZalik(secondTeacher));
+            case "Курсовий проєкт" -> generateReportWithModel(CourseProjectPdfGenerator.NAME, buildDataModelForZalik(secondTeacher));
+            case "Контрольна робота" -> generateReportWithModel(ControlWorkPdfGenerator.NAME, buildDataModelForZalik(secondTeacher));
+            case "Розрахункова робота" -> generateReportWithModel(CalculationWorkPdfGenerator.NAME, buildDataModelForZalik(secondTeacher));
+            case "Розрахунково-графічна робота" -> generateReportWithModel(CalculationGraphicWorkPdfGenerator.NAME, buildDataModelForZalik(secondTeacher));
             default -> {
                 BasicControlPdfData data = new BasicControlPdfData(controlType);
                 Path path = documentGenerationService.generate(BasicControlPdfGenerator.NAME, data);
                 yield new ReportGenerationResult(path.toString(), null, null);
             }
         };
+    }
+
+    private ReportGenerationResult generateReportWithModel(String generatorName, Object dataModel) {
+        Path path = documentGenerationService.generate(generatorName, dataModel);
+        return new ReportGenerationResult(path.toString(), null, null);
     }
 
     private void configureReportControls() {
@@ -1373,22 +1380,22 @@ public class EnterMarksView extends Div {
     }
 
     private void showReport(String finalFilePath) {
-        File pdfFile = new File(finalFilePath);
-        if (!pdfFile.exists()) {
-            Notification.show("PDF файл не знайдено.");
+        File generatedFile = new File(finalFilePath);
+        if (!generatedFile.exists()) {
+            Notification.show("Файл не знайдено.");
             return;
         }
 
-        String fileName = pdfFile.getName();
+        String fileName = generatedFile.getName();
         StreamResource resource = new StreamResource(fileName, () -> {
             try {
-                return new FileInputStream(pdfFile);
+                return new FileInputStream(generatedFile);
             } catch (IOException e) {
                 Notification.show("Помилка при завантаженні файлу");
                 return null;
             }
         });
-        resource.setContentType("application/pdf");
+        resource.setContentType(resolveContentType(fileName));
         resource.setCacheTime(0);
         resource.setHeader(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + fileName + "\"");
 
@@ -1404,6 +1411,17 @@ public class EnterMarksView extends Div {
         String resourceUrl = registration.getResourceUri().toString();
 
         ui.getPage().open(resourceUrl, "_blank");
+    }
+
+    private String resolveContentType(String fileName) {
+        String lowerName = fileName.toLowerCase(Locale.ROOT);
+        if (lowerName.endsWith(".pdf")) {
+            return "application/pdf";
+        }
+        if (lowerName.endsWith(".docx")) {
+            return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+        }
+        return "application/octet-stream";
     }
 
     private void configureLoadingOverlay() {


### PR DESCRIPTION
## Summary
- remove the shared template PDF generator and introduce one class per control type, reusing a common Zalik-style base for credit-like statements
- wire mark report generation to call the specific iText generators for each control type
- keep module controls on their existing generators while providing individualized files for the remaining eight control variants

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946805d22488326a671c9c85ef28f2d)