### PR TITLE
Add mail chat messenger module

### DIFF
--- a/MAIL_SETUP.md
+++ b/MAIL_SETUP.md
@@ -1,0 +1,26 @@
+## Налаштування поштового модуля (.env)
+
+Додайте/уточніть наступні змінні в `.env` (використовується SMTP для відправки та IMAP для читання):
+
+```
+# SMTP (вже використовувалося раніше)
+MAIL_HOST=smtp.gmail.com
+MAIL_PORT=587
+MAIL_USERNAME=dekanat.support@ntu.edu.ua
+MAIL_PASSWORD=<app_password>
+MAIL_DEFAULT_FROM=dekanat.support@ntu.edu.ua
+
+# IMAP (нове)
+MAIL_IMAP_HOST=imap.gmail.com
+MAIL_IMAP_PORT=993
+MAIL_IMAP_USERNAME=dekanat.support@ntu.edu.ua
+MAIL_IMAP_PASSWORD=<app_password>
+MAIL_IMAP_INBOX=INBOX
+MAIL_IMAP_SENT=[Gmail]/Sent Mail
+MAIL_IMAP_SSL=true
+
+# Інтервал опитування (мс)
+MAIL_SYNC_INTERVAL_MS=60000
+```
+
+> Використовуйте пароль додатка Gmail, а не основний пароль. Якщо папка вихідних листів має іншу назву, змініть `MAIL_IMAP_SENT`.

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,13 @@
             <version>4.0.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.17.2</version>
+        </dependency>
+
+
         <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/frontend/styles/mail-view.css
+++ b/src/main/frontend/styles/mail-view.css
@@ -1,0 +1,13 @@
+.incoming {
+    background-color: var(--lumo-contrast-5pct);
+    padding: var(--lumo-space-m);
+    border-radius: var(--lumo-border-radius-l);
+    margin-bottom: var(--lumo-space-m);
+}
+
+.outgoing {
+    background-color: var(--lumo-primary-color-10pct);
+    padding: var(--lumo-space-m);
+    border-radius: var(--lumo-border-radius-l);
+    margin-bottom: var(--lumo-space-m);
+}

--- a/src/main/java/com/esvar/dekanat/mail/ChatEntity.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatEntity.java
@@ -1,0 +1,48 @@
+package com.esvar.dekanat.mail;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "mail_chat", indexes = {
+        @Index(name = "idx_mail_chat_peer_email", columnList = "peer_email", unique = true),
+        @Index(name = "idx_mail_chat_last_message_at", columnList = "last_message_at")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "peer_email", nullable = false, unique = true, length = 320)
+    private String peerEmail;
+
+    @Column(name = "display_name", length = 255)
+    private String displayName;
+
+    @Column(name = "org_unit", length = 255)
+    private String orgUnit;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    @ColumnDefault("'NEW'")
+    private ChatStatus status = ChatStatus.NEW;
+
+    @Column(name = "has_unprocessed", nullable = false)
+    private boolean hasUnprocessed = false;
+
+    @Column(name = "last_message_at")
+    private Instant lastMessageAt;
+}

--- a/src/main/java/com/esvar/dekanat/mail/ChatProfileResolver.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatProfileResolver.java
@@ -1,0 +1,90 @@
+package com.esvar.dekanat.mail;
+
+import com.esvar.dekanat.service.DepartmentService;
+import com.esvar.dekanat.service.FacultyService;
+import com.esvar.dekanat.user.UserModel;
+import com.esvar.dekanat.user.UserRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.Optional;
+
+@Component
+public class ChatProfileResolver {
+
+    private final UserRepository userRepository;
+    private final FacultyService facultyService;
+    private final DepartmentService departmentService;
+
+    public ChatProfileResolver(UserRepository userRepository,
+                               FacultyService facultyService,
+                               DepartmentService departmentService) {
+        this.userRepository = userRepository;
+        this.facultyService = facultyService;
+        this.departmentService = departmentService;
+    }
+
+    public ResolvedProfile resolve(String peerEmail) {
+        Optional<UserModel> user = userRepository.findByEmail(peerEmail);
+        if (user.isEmpty()) {
+            return ResolvedProfile.unknown(peerEmail);
+        }
+        UserModel userModel = user.get();
+        String displayName = composeFullName(userModel);
+        String orgUnit = resolveOrgUnit(userModel);
+        return new ResolvedProfile(displayName, orgUnit);
+    }
+
+    private String composeFullName(UserModel user) {
+        StringBuilder builder = new StringBuilder();
+        if (StringUtils.hasText(user.getLastname())) {
+            builder.append(user.getLastname());
+        }
+        if (StringUtils.hasText(user.getFirstname())) {
+            if (builder.length() > 0) {
+                builder.append(" ");
+            }
+            builder.append(user.getFirstname());
+        }
+        if (StringUtils.hasText(user.getPatronymic())) {
+            if (builder.length() > 0) {
+                builder.append(" ");
+            }
+            builder.append(user.getPatronymic());
+        }
+        return builder.length() == 0 ? peerEmailFallback(user) : builder.toString();
+    }
+
+    private String peerEmailFallback(UserModel userModel) {
+        return StringUtils.hasText(userModel.getEmail()) ? userModel.getEmail() : "Невідомий";
+    }
+
+    private String resolveOrgUnit(UserModel userModel) {
+        String role = userModel.getRole();
+        String roleType = userModel.getRoleType();
+        if (!StringUtils.hasText(role) || !StringUtils.hasText(roleType)) {
+            return null;
+        }
+        if (role.startsWith("ROLE_DEKANAT")) {
+            return facultyService.getFacultyTitleById(parseLongSafe(roleType));
+        }
+        if (role.startsWith("ROLE_DEPARTMENT")) {
+            return departmentService.getDepartmentById(parseLongSafe(roleType));
+        }
+        return null;
+    }
+
+    private Long parseLongSafe(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    public record ResolvedProfile(String displayName, String orgUnit) {
+        static ResolvedProfile unknown(String email) {
+            return new ResolvedProfile("Невідомий", null);
+        }
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mail/ChatRepository.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatRepository.java
@@ -1,0 +1,20 @@
+package com.esvar.dekanat.mail;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ChatRepository extends JpaRepository<ChatEntity, Long> {
+
+    Optional<ChatEntity> findByPeerEmail(String peerEmail);
+
+    Page<ChatEntity> findByPeerEmailContainingIgnoreCaseAndDisplayNameContainingIgnoreCaseAndStatusIn(
+            String peerEmail, String displayName, Iterable<ChatStatus> statuses, Pageable pageable);
+
+    Page<ChatEntity> findByPeerEmailContainingIgnoreCaseAndDisplayNameContainingIgnoreCase(
+            String peerEmail, String displayName, Pageable pageable);
+}

--- a/src/main/java/com/esvar/dekanat/mail/ChatService.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatService.java
@@ -1,0 +1,179 @@
+package com.esvar.dekanat.mail;
+
+import com.esvar.dekanat.mail.dto.AttachmentDto;
+import com.esvar.dekanat.mail.dto.ChatListItemDto;
+import com.esvar.dekanat.mail.dto.ChatMessageDto;
+import com.esvar.dekanat.mail.dto.ChatFilter;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.mail.MailProperties;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class ChatService {
+
+    private final ChatRepository chatRepository;
+    private final MailMessageRepository mailMessageRepository;
+    private final MailAttachmentMetaRepository attachmentRepository;
+    private final MailImapClient mailImapClient;
+    private final JavaMailSender mailSender;
+    private final MailSyncProperties properties;
+    private final MailProperties mailProperties;
+    private final String defaultFrom;
+
+    public ChatService(ChatRepository chatRepository,
+                       MailMessageRepository mailMessageRepository,
+                       MailAttachmentMetaRepository attachmentRepository,
+                       MailImapClient mailImapClient,
+                       JavaMailSender mailSender,
+                       MailSyncProperties properties,
+                       MailProperties mailProperties,
+                       @Value("${mail.default-from:}") String defaultFrom) {
+        this.chatRepository = chatRepository;
+        this.mailMessageRepository = mailMessageRepository;
+        this.attachmentRepository = attachmentRepository;
+        this.mailImapClient = mailImapClient;
+        this.mailSender = mailSender;
+        this.properties = properties;
+        this.mailProperties = mailProperties;
+        this.defaultFrom = defaultFrom;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ChatListItemDto> findChats(ChatFilter filter, Pageable pageable) {
+        String query = filter != null && StringUtils.hasText(filter.getQuery()) ? filter.getQuery() : "";
+        Sort sort = pageable.getSort().isUnsorted() ? Sort.by(Sort.Direction.DESC, "lastMessageAt") : pageable.getSort();
+        Pageable effectivePageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+        Page<ChatEntity> page;
+        if (filter != null && filter.getStatuses() != null && !filter.getStatuses().isEmpty()) {
+            page = chatRepository.findByPeerEmailContainingIgnoreCaseAndDisplayNameContainingIgnoreCaseAndStatusIn(
+                    query, query, filter.getStatuses(), effectivePageable);
+        } else {
+            page = chatRepository.findByPeerEmailContainingIgnoreCaseAndDisplayNameContainingIgnoreCase(
+                    query, query, effectivePageable);
+        }
+        return page.map(this::toDto);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ChatMessageDto> findMessages(Long chatId, Pageable pageable) {
+        Page<MailMessageEntity> page = mailMessageRepository.findByChatId(chatId, pageable);
+        return page.map(this::toMessageDto);
+    }
+
+    public void updateStatus(Long chatId, ChatStatus status) {
+        ChatEntity chat = chatRepository.findById(chatId).orElseThrow();
+        chat.setStatus(status);
+        chatRepository.save(chat);
+    }
+
+    public void markProcessed(Long chatId) {
+        chatRepository.findById(chatId).ifPresent(chat -> {
+            chat.setHasUnprocessed(false);
+            chatRepository.save(chat);
+        });
+    }
+
+    @Transactional(readOnly = true)
+    public InputStream loadAttachment(String messageId, String attachmentId) {
+        MailAttachmentMetaEntity meta = attachmentRepository.findByMessage_MessageIdAndPartId(messageId, attachmentId);
+        if (meta == null) {
+            throw new IllegalArgumentException("Attachment not found");
+        }
+        MailMessageEntity message = meta.getMessage();
+        Message mimeMessage = mailImapClient.getMessage(message.getFolder(), message.getUid());
+        return MailpartExtractor.extractAttachmentStream(mimeMessage, attachmentId);
+    }
+
+    public void replyToChat(Long chatId, String body, String subjectOverride) {
+        ChatEntity chat = chatRepository.findById(chatId).orElseThrow();
+        String to = chat.getPeerEmail();
+        Optional<MailMessageEntity> lastMessage = mailMessageRepository.findTop1ByChatIdOrderBySentAtDesc(chatId);
+
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            helper.setTo(to);
+            helper.setFrom(resolveFromAddress());
+            if (lastMessage.isPresent() && StringUtils.hasText(lastMessage.get().getSubject())) {
+                helper.setSubject(subjectOverride != null ? subjectOverride : "Re: " + lastMessage.get().getSubject());
+            } else {
+                helper.setSubject(subjectOverride != null ? subjectOverride : "Re:");
+            }
+            helper.setText(body, false);
+            lastMessage.map(MailMessageEntity::getMessageId).ifPresent(id -> mimeMessage.setHeader("In-Reply-To", id));
+            lastMessage.map(MailMessageEntity::getMessageId).ifPresent(id -> mimeMessage.setHeader("References", id));
+            mailSender.send(mimeMessage);
+        } catch (MessagingException e) {
+            throw new IllegalStateException("Failed to send reply: " + e.getMessage(), e);
+        }
+    }
+
+    private String resolveFromAddress() {
+        if (StringUtils.hasText(defaultFrom)) {
+            return defaultFrom;
+        }
+        if (StringUtils.hasText(mailProperties.getUsername())) {
+            return mailProperties.getUsername();
+        }
+        return properties.getImap().getUsername();
+    }
+
+    private ChatListItemDto toDto(ChatEntity chat) {
+        return ChatListItemDto.builder()
+                .id(chat.getId())
+                .displayName(StringUtils.hasText(chat.getDisplayName()) ? chat.getDisplayName() : "Невідомий")
+                .peerEmail(chat.getPeerEmail())
+                .orgUnit(chat.getOrgUnit())
+                .status(chat.getStatus())
+                .hasUnprocessed(chat.isHasUnprocessed())
+                .lastMessageAt(chat.getLastMessageAt())
+                .build();
+    }
+
+    private ChatMessageDto toMessageDto(MailMessageEntity entity) {
+        String bodyText = fetchPlainBody(entity);
+        return ChatMessageDto.builder()
+                .id(entity.getId())
+                .messageId(entity.getMessageId())
+                .from(entity.getFromEmail())
+                .to(entity.getToEmail())
+                .subject(entity.getSubject())
+                .bodyText(bodyText)
+                .sentAt(entity.getSentAt())
+                .direction(entity.getDirection())
+                .hasAttachments(entity.isHasAttachments())
+                .attachments(entity.getAttachments().stream().map(this::toAttachmentDto).collect(Collectors.toList()))
+                .build();
+    }
+
+    private String fetchPlainBody(MailMessageEntity entity) {
+        Message message = mailImapClient.getMessage(entity.getFolder(), entity.getUid());
+        return MailpartExtractor.extractPlainText(message);
+    }
+
+    private AttachmentDto toAttachmentDto(MailAttachmentMetaEntity attachment) {
+        return AttachmentDto.builder()
+                .id(attachment.getId())
+                .attachmentId(attachment.getPartId())
+                .filename(attachment.getFilename())
+                .sizeBytes(attachment.getSizeBytes())
+                .build();
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mail/ChatStatus.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatStatus.java
@@ -1,0 +1,8 @@
+package com.esvar.dekanat.mail;
+
+public enum ChatStatus {
+    NEW,
+    IN_PROGRESS,
+    NEEDS_INFO,
+    CLOSED
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailAttachmentMetaEntity.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailAttachmentMetaEntity.java
@@ -1,0 +1,38 @@
+package com.esvar.dekanat.mail;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "mail_attachment_meta")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MailAttachmentMetaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id", nullable = false)
+    private MailMessageEntity message;
+
+    @Column(name = "part_id", nullable = false, length = 128)
+    private String partId;
+
+    @Column(name = "filename", length = 500)
+    private String filename;
+
+    @Column(name = "content_type", length = 255)
+    private String contentType;
+
+    @Column(name = "size_bytes")
+    private Long sizeBytes;
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailAttachmentMetaRepository.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailAttachmentMetaRepository.java
@@ -1,0 +1,14 @@
+package com.esvar.dekanat.mail;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MailAttachmentMetaRepository extends JpaRepository<MailAttachmentMetaEntity, Long> {
+
+    List<MailAttachmentMetaEntity> findByMessageId(Long messageId);
+
+    MailAttachmentMetaEntity findByMessage_MessageIdAndPartId(String messageId, String partId);
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailConfiguration.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailConfiguration.java
@@ -1,0 +1,11 @@
+package com.esvar.dekanat.mail;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@EnableConfigurationProperties(MailSyncProperties.class)
+public class MailConfiguration {
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailController.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailController.java
@@ -1,0 +1,73 @@
+package com.esvar.dekanat.mail;
+
+import com.esvar.dekanat.mail.dto.ChatFilter;
+import com.esvar.dekanat.mail.dto.ChatListItemDto;
+import com.esvar.dekanat.mail.dto.ChatMessageDto;
+import com.esvar.dekanat.mail.dto.ReplyRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import jakarta.annotation.security.RolesAllowed;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.InputStream;
+
+@RestController
+@RequestMapping("/mail")
+@RolesAllowed({"ROLE_ADMIN", "ROLE_DEKANAT"})
+public class MailController {
+
+    private final ChatService chatService;
+
+    public MailController(ChatService chatService) {
+        this.chatService = chatService;
+    }
+
+    @GetMapping("/chats")
+    public Page<ChatListItemDto> getChats(@RequestParam(name = "q", required = false) String query,
+                                          @RequestParam(name = "page", defaultValue = "0") int page,
+                                          @RequestParam(name = "size", defaultValue = "20") int size) {
+        ChatFilter filter = new ChatFilter();
+        filter.setQuery(query);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "lastMessageAt"));
+        return chatService.findChats(filter, pageable);
+    }
+
+    @GetMapping("/chats/{chatId}/messages")
+    public Page<ChatMessageDto> getMessages(@PathVariable Long chatId,
+                                            @RequestParam(name = "page", defaultValue = "0") int page,
+                                            @RequestParam(name = "size", defaultValue = "50") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "sentAt"));
+        return chatService.findMessages(chatId, pageable);
+    }
+
+    @PostMapping("/chats/{chatId}/status")
+    public void updateStatus(@PathVariable Long chatId, @RequestParam ChatStatus status) {
+        chatService.updateStatus(chatId, status);
+    }
+
+    @PostMapping("/chats/{chatId}/processed")
+    public void markProcessed(@PathVariable Long chatId) {
+        chatService.markProcessed(chatId);
+    }
+
+    @PostMapping("/chats/{chatId}/reply")
+    public void reply(@PathVariable Long chatId, @RequestBody ReplyRequest request) {
+        chatService.replyToChat(chatId, request.getBody(), request.getSubject());
+    }
+
+    @GetMapping("/messages/{messageId}/attachments/{attachmentId}")
+    public ResponseEntity<InputStreamResource> downloadAttachment(@PathVariable String messageId,
+                                                                  @PathVariable String attachmentId) {
+        InputStream stream = chatService.loadAttachment(messageId, attachmentId);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment")
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(new InputStreamResource(stream));
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailImapClient.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailImapClient.java
@@ -1,0 +1,70 @@
+package com.esvar.dekanat.mail;
+
+import com.sun.mail.imap.IMAPFolder;
+import com.sun.mail.imap.IMAPStore;
+import jakarta.mail.Folder;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Properties;
+import java.util.function.Function;
+
+@Component
+public class MailImapClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MailImapClient.class);
+
+    private final MailSyncProperties properties;
+
+    public MailImapClient(MailSyncProperties properties) {
+        this.properties = properties;
+    }
+
+    public <T> T withFolder(String folderName, Function<IMAPFolder, T> consumer) {
+        Properties props = new Properties();
+        props.put("mail.store.protocol", properties.getImap().isUseSsl() ? "imaps" : "imap");
+        props.put("mail.imap.ssl.enable", String.valueOf(properties.getImap().isUseSsl()));
+        Session session = Session.getInstance(props);
+        IMAPStore store = null;
+        IMAPFolder folder = null;
+        try {
+            store = (IMAPStore) session.getStore(properties.getImap().isUseSsl() ? "imaps" : "imap");
+            store.connect(properties.getImap().getHost(),
+                    properties.getImap().getPort(),
+                    properties.getImap().getUsername(),
+                    properties.getImap().getPassword());
+            folder = (IMAPFolder) store.getFolder(folderName);
+            folder.open(Folder.READ_ONLY);
+            return consumer.apply(folder);
+        } catch (Exception ex) {
+            LOGGER.error("IMAP folder interaction failed for {}: {}", folderName, ex.getMessage());
+            throw new IllegalStateException("IMAP interaction failed: " + ex.getMessage(), ex);
+        } finally {
+            if (folder != null && folder.isOpen()) {
+                try {
+                    folder.close(false);
+                } catch (MessagingException ignored) {
+                }
+            }
+            if (store != null && store.isConnected()) {
+                try {
+                    store.close();
+                } catch (MessagingException ignored) {
+                }
+            }
+        }
+    }
+
+    public Message getMessage(String folderName, long uid) {
+        return withFolder(folderName, folder -> {
+            try {
+                return folder.getMessageByUID(uid);
+            } catch (MessagingException e) {
+                throw new IllegalStateException("Failed to load message by UID " + uid + " from folder " + folderName, e);
+            }
+        });
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailInboxView.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailInboxView.java
@@ -1,0 +1,297 @@
+package com.esvar.dekanat.mail;
+
+import com.esvar.dekanat.mail.dto.ChatListItemDto;
+import com.esvar.dekanat.mail.dto.ChatMessageDto;
+import com.esvar.dekanat.view.MainLayout;
+import com.vaadin.flow.component.Unit;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.dependency.CssImport;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H3;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.SplitLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.provider.CallbackDataProvider;
+import com.vaadin.flow.data.provider.Query;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import jakarta.annotation.security.RolesAllowed;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+
+@Route(value = "mail", layout = MainLayout.class)
+@PageTitle("Пошта як месенджер")
+@RolesAllowed({"ROLE_ADMIN", "ROLE_DEKANAT"})
+@CssImport(value = "./styles/mail-view.css", themeFor = "vaadin-grid")
+public class MailInboxView extends VerticalLayout {
+
+    private final ChatService chatService;
+    private final Grid<ChatListItemDto> chatGrid = new Grid<>(ChatListItemDto.class, false);
+    private final VerticalLayout messagePanel = new VerticalLayout();
+    private final Button loadMoreButton = new Button("Завантажити ще");
+    private final TextArea replyArea = new TextArea("Відповідь");
+    private final ComboBox<ChatStatus> statusComboBox = new ComboBox<>("Статус");
+    private final Button markProcessedButton = new Button("Позначити опрацьованим");
+    private final ComboBox<ChatStatus> statusFilter = new ComboBox<>();
+
+    private ChatListItemDto selectedChat;
+    private final TextField searchField = new TextField();
+    private int messagePage = 0;
+
+    private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm")
+            .withZone(ZoneId.systemDefault());
+
+    public MailInboxView(ChatService chatService) {
+        this.chatService = chatService;
+        setSizeFull();
+        setPadding(true);
+        setSpacing(true);
+
+        add(buildToolbar(), buildContent());
+    }
+
+    private HorizontalLayout buildToolbar() {
+        searchField.setPlaceholder("Email або ПІБ");
+        searchField.setClearButtonVisible(true);
+        searchField.addValueChangeListener(e -> chatGrid.getDataProvider().refreshAll());
+
+        statusFilter.setPlaceholder("Статус");
+        statusFilter.setItems(ChatStatus.values());
+        statusFilter.setClearButtonVisible(true);
+        statusFilter.addValueChangeListener(e -> chatGrid.getDataProvider().refreshAll());
+
+        Button refreshButton = new Button("Оновити", e -> chatGrid.getDataProvider().refreshAll());
+        HorizontalLayout toolbar = new HorizontalLayout(searchField, statusFilter, refreshButton);
+        toolbar.setWidthFull();
+        toolbar.setDefaultVerticalComponentAlignment(FlexComponent.Alignment.END);
+        return toolbar;
+    }
+
+    private SplitLayout buildContent() {
+        SplitLayout splitLayout = new SplitLayout();
+        splitLayout.setSizeFull();
+        splitLayout.setSplitterPosition(32);
+
+        configureChatGrid();
+        splitLayout.addToPrimary(chatGrid);
+
+        VerticalLayout right = new VerticalLayout();
+        right.setSizeFull();
+        right.setPadding(false);
+        right.setSpacing(false);
+
+        HorizontalLayout header = buildChatHeader();
+        right.add(header);
+
+        messagePanel.setSizeFull();
+        messagePanel.setPadding(true);
+        messagePanel.setSpacing(true);
+        right.add(messagePanel);
+        right.setFlexGrow(1, messagePanel);
+
+        loadMoreButton.setWidthFull();
+        loadMoreButton.addClickListener(e -> loadMessagesPage(messagePage + 1, true));
+        loadMoreButton.setVisible(false);
+        right.add(loadMoreButton);
+
+        VerticalLayout replyWrapper = buildReplyArea();
+        right.add(replyWrapper);
+        splitLayout.addToSecondary(right);
+        return splitLayout;
+    }
+
+    private void configureChatGrid() {
+        CallbackDataProvider<ChatListItemDto, Void> dataProvider = new CallbackDataProvider<>(
+                this::fetchChats, this::countChats);
+        chatGrid.setDataProvider(dataProvider);
+        chatGrid.addThemeVariants(GridVariant.LUMO_ROW_STRIPES);
+        chatGrid.setHeightFull();
+
+        chatGrid.addColumn(ChatListItemDto::getDisplayName).setHeader("ПІБ").setFlexGrow(1);
+        chatGrid.addColumn(ChatListItemDto::getPeerEmail).setHeader("Email").setFlexGrow(1);
+        chatGrid.addColumn(ChatListItemDto::getOrgUnit).setHeader("Факультет/Кафедра").setFlexGrow(1);
+        chatGrid.addColumn(item -> item.getStatus().name()).setHeader("Статус").setWidth("140px");
+        chatGrid.addColumn(item -> item.isHasUnprocessed() ? "1" : "0").setHeader("Неопрацьовано").setWidth("140px");
+        chatGrid.addColumn(item -> item.getLastMessageAt() != null ? dateTimeFormatter.format(item.getLastMessageAt()) : "")
+                .setHeader("Останнє").setWidth("180px");
+
+        chatGrid.asSingleSelect().addValueChangeListener(event -> {
+            selectedChat = event.getValue();
+            loadMessages();
+            updateHeader();
+        });
+    }
+
+    private HorizontalLayout buildChatHeader() {
+        H3 title = new H3("Діалог");
+        title.getStyle().set("margin", "0");
+
+        statusComboBox.setItems(ChatStatus.values());
+        statusComboBox.addValueChangeListener(e -> {
+            if (selectedChat != null && e.getValue() != null) {
+                chatService.updateStatus(selectedChat.getId(), e.getValue());
+                selectedChat = ChatListItemDto.builder()
+                        .id(selectedChat.getId())
+                        .displayName(selectedChat.getDisplayName())
+                        .peerEmail(selectedChat.getPeerEmail())
+                        .orgUnit(selectedChat.getOrgUnit())
+                        .status(e.getValue())
+                        .hasUnprocessed(selectedChat.isHasUnprocessed())
+                        .lastMessageAt(selectedChat.getLastMessageAt())
+                        .build();
+                chatGrid.getDataProvider().refreshAll();
+            }
+        });
+
+        markProcessedButton.addClickListener(e -> {
+            if (selectedChat != null) {
+                chatService.markProcessed(selectedChat.getId());
+                selectedChat = ChatListItemDto.builder()
+                        .id(selectedChat.getId())
+                        .displayName(selectedChat.getDisplayName())
+                        .peerEmail(selectedChat.getPeerEmail())
+                        .orgUnit(selectedChat.getOrgUnit())
+                        .status(selectedChat.getStatus())
+                        .hasUnprocessed(false)
+                        .lastMessageAt(selectedChat.getLastMessageAt())
+                        .build();
+                chatGrid.getDataProvider().refreshAll();
+                updateHeader();
+            }
+        });
+        markProcessedButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+
+        HorizontalLayout header = new HorizontalLayout(title, statusComboBox, markProcessedButton);
+        header.setDefaultVerticalComponentAlignment(FlexComponent.Alignment.CENTER);
+        header.setWidthFull();
+        return header;
+    }
+
+    private VerticalLayout buildReplyArea() {
+        replyArea.setWidthFull();
+        replyArea.setHeight(180, Unit.PIXELS);
+        Button sendButton = new Button("Відправити", e -> sendReply());
+        sendButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        VerticalLayout wrapper = new VerticalLayout(replyArea, sendButton);
+        wrapper.setWidthFull();
+        wrapper.setPadding(true);
+        wrapper.setSpacing(true);
+        return wrapper;
+    }
+
+    private void sendReply() {
+        if (selectedChat == null) {
+            return;
+        }
+        String text = replyArea.getValue();
+        if (text == null || text.isBlank()) {
+            return;
+        }
+        chatService.replyToChat(selectedChat.getId(), text, null);
+        replyArea.clear();
+    }
+
+    private void loadMessages() {
+        messagePanel.removeAll();
+        if (selectedChat == null) {
+            messagePanel.add(new Span("Оберіть чат"));
+            loadMoreButton.setVisible(false);
+            return;
+        }
+        messagePage = 0;
+        loadMessagesPage(messagePage, false);
+    }
+
+    private void loadMessagesPage(int page, boolean append) {
+        if (selectedChat == null) {
+            return;
+        }
+        Pageable pageable = PageRequest.of(page, 50, Sort.by(Sort.Direction.ASC, "sentAt"));
+        Page<ChatMessageDto> messages = chatService.findMessages(selectedChat.getId(), pageable);
+        if (!append) {
+            messagePanel.removeAll();
+        }
+        messages.forEach(this::appendMessage);
+        messagePage = page;
+        loadMoreButton.setVisible(messages.hasNext());
+    }
+
+    private void appendMessage(ChatMessageDto message) {
+        Div bubble = new Div();
+        bubble.addClassName(message.getDirection() == MessageDirection.IN ? "incoming" : "outgoing");
+
+        Span meta = new Span(metaText(message));
+        meta.getStyle().set("font-size", "12px");
+        meta.getStyle().set("color", "var(--lumo-secondary-text-color)");
+
+        Span body = new Span(Optional.ofNullable(message.getBodyText()).orElse(""));
+        body.getStyle().set("white-space", "pre-wrap");
+
+        bubble.add(meta, body);
+
+        if (message.isHasAttachments() && message.getAttachments() != null && !message.getAttachments().isEmpty()) {
+            VerticalLayout attachments = new VerticalLayout();
+            attachments.setPadding(false);
+            attachments.setSpacing(false);
+            attachments.getStyle().set("margin-top", "8px");
+            message.getAttachments().forEach(att -> {
+                Button download = new Button(att.getFilename() != null ? att.getFilename() : "Вкладення");
+                download.addClickListener(e -> download.getUI().ifPresent(ui ->
+                        ui.getPage().open("/mail/messages/" + message.getMessageId() + "/attachments/" + att.getAttachmentId())));
+                download.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
+                attachments.add(download);
+            });
+            bubble.add(attachments);
+        }
+
+        messagePanel.add(bubble);
+    }
+
+    private String metaText(ChatMessageDto message) {
+        String time = message.getSentAt() != null ? dateTimeFormatter.format(message.getSentAt()) : "";
+        return "%s • %s".formatted(message.getDirection() == MessageDirection.IN ? "Вхідне" : "Вихідне", time);
+    }
+
+    private java.util.stream.Stream<ChatListItemDto> fetchChats(Query<ChatListItemDto, Void> query) {
+        Pageable pageable = PageRequest.of(query.getPage(), query.getPageSize(), Sort.by(Sort.Direction.DESC, "lastMessageAt"));
+        ChatFilter filter = new ChatFilter();
+        filter.setQuery(searchField.getValue());
+        if (statusFilter.getValue() != null) {
+            filter.setStatuses(List.of(statusFilter.getValue()));
+        }
+        Page<ChatListItemDto> page = chatService.findChats(filter, pageable);
+        return page.stream();
+    }
+
+    private int countChats(Query<ChatListItemDto, Void> query) {
+        Pageable pageable = PageRequest.of(0, 1);
+        ChatFilter filter = new ChatFilter();
+        filter.setQuery(searchField.getValue());
+        if (statusFilter.getValue() != null) {
+            filter.setStatuses(List.of(statusFilter.getValue()));
+        }
+        Page<ChatListItemDto> page = chatService.findChats(filter, pageable);
+        return (int) page.getTotalElements();
+    }
+
+    private void updateHeader() {
+        if (selectedChat != null) {
+            statusComboBox.setValue(selectedChat.getStatus());
+        }
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailMessageEntity.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailMessageEntity.java
@@ -1,0 +1,70 @@
+package com.esvar.dekanat.mail;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "mail_message", indexes = {
+        @Index(name = "idx_mail_message_peer_email_date", columnList = "peer_email, sent_at"),
+        @Index(name = "idx_mail_message_folder_uid", columnList = "folder, uid")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MailMessageEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "message_id", nullable = false, unique = true, length = 512)
+    private String messageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_id", nullable = false)
+    private ChatEntity chat;
+
+    @Column(name = "peer_email", nullable = false, length = 320)
+    private String peerEmail;
+
+    @Column(name = "folder", nullable = false, length = 64)
+    private String folder;
+
+    @Column(name = "uid", nullable = false)
+    private Long uid;
+
+    @Column(name = "sent_at")
+    private Instant sentAt;
+
+    @Column(name = "from_email", length = 320)
+    private String fromEmail;
+
+    @Column(name = "to_email", length = 320)
+    private String toEmail;
+
+    @Column(name = "subject", length = 500)
+    private String subject;
+
+    @Column(name = "snippet", length = 1000)
+    private String snippet;
+
+    @Column(name = "has_attachments", nullable = false)
+    private boolean hasAttachments;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "direction", nullable = false, length = 8)
+    private MessageDirection direction;
+
+    @OneToMany(mappedBy = "message", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MailAttachmentMetaEntity> attachments = new ArrayList<>();
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailMessageRepository.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailMessageRepository.java
@@ -1,0 +1,19 @@
+package com.esvar.dekanat.mail;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface MailMessageRepository extends JpaRepository<MailMessageEntity, Long> {
+
+    Optional<MailMessageEntity> findByMessageId(String messageId);
+
+    Page<MailMessageEntity> findByChatId(Long chatId, Pageable pageable);
+
+    Optional<MailMessageEntity> findTop1ByChatIdOrderBySentAtDesc(Long chatId);
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailSyncProperties.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailSyncProperties.java
@@ -1,0 +1,33 @@
+package com.esvar.dekanat.mail;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "mail")
+public class MailSyncProperties {
+
+    private ImapProperties imap = new ImapProperties();
+    private SyncProperties sync = new SyncProperties();
+
+    @Getter
+    @Setter
+    public static class ImapProperties {
+        private String host;
+        private Integer port = 993;
+        private String username;
+        private String password;
+        private String inboxFolder = "INBOX";
+        private String sentFolder = "Sent";
+        private boolean useSsl = true;
+    }
+
+    @Getter
+    @Setter
+    public static class SyncProperties {
+        private long intervalMs = 60_000;
+        private int batchSize = 100;
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailSyncService.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailSyncService.java
@@ -1,0 +1,241 @@
+package com.esvar.dekanat.mail;
+
+import com.sun.mail.imap.IMAPFolder;
+import jakarta.mail.Address;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Part;
+import jakarta.mail.internet.InternetAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Sort;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class MailSyncService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MailSyncService.class);
+
+    private final MailImapClient mailImapClient;
+    private final MailSyncProperties properties;
+    private final ChatRepository chatRepository;
+    private final MailMessageRepository mailMessageRepository;
+    private final MailAttachmentMetaRepository attachmentRepository;
+    private final MailSyncStateRepository syncStateRepository;
+    private final ChatProfileResolver profileResolver;
+
+    public MailSyncService(MailImapClient mailImapClient,
+                           MailSyncProperties properties,
+                           ChatRepository chatRepository,
+                           MailMessageRepository mailMessageRepository,
+                           MailAttachmentMetaRepository attachmentRepository,
+                           MailSyncStateRepository syncStateRepository,
+                           ChatProfileResolver profileResolver) {
+        this.mailImapClient = mailImapClient;
+        this.properties = properties;
+        this.chatRepository = chatRepository;
+        this.mailMessageRepository = mailMessageRepository;
+        this.attachmentRepository = attachmentRepository;
+        this.syncStateRepository = syncStateRepository;
+        this.profileResolver = profileResolver;
+    }
+
+    @Scheduled(fixedDelayString = "${mail.sync.interval-ms:60000}")
+    @Transactional
+    public void scheduledSync() {
+        syncFolder(properties.getImap().getInboxFolder(), MessageDirection.IN);
+        syncFolder(properties.getImap().getSentFolder(), MessageDirection.OUT);
+    }
+
+    protected void syncFolder(String folderName, MessageDirection direction) {
+        mailImapClient.withFolder(folderName, folder -> {
+            try {
+                Long lastSyncedUid = syncStateRepository.findById(folderName).map(MailSyncStateEntity::getLastUid).orElse(0L);
+                long nextUid = folder.getUIDNext();
+                if (nextUid <= 0) {
+                    return null;
+                }
+                long batchSize = properties.getSync().getBatchSize();
+                for (long start = lastSyncedUid + 1; start < nextUid; start += batchSize) {
+                    long end = Math.min(start + batchSize - 1, nextUid - 1);
+                    Message[] messages = folder.getMessagesByUID(start, end);
+                    for (Message message : messages) {
+                        try {
+                            upsertMessage(folder, message, direction);
+                            lastSyncedUid = Math.max(lastSyncedUid, folder.getUID(message));
+                        } catch (Exception ex) {
+                            LOGGER.warn("Failed to sync message {} in {}: {}", safeMessageId(message), folderName, ex.getMessage());
+                        }
+                    }
+                    syncStateRepository.save(new MailSyncStateEntity(folderName, lastSyncedUid));
+                }
+            } catch (MessagingException e) {
+                LOGGER.error("IMAP sync failed for {}: {}", folderName, e.getMessage());
+            }
+            return null;
+        });
+    }
+
+    private void upsertMessage(IMAPFolder folder, Message message, MessageDirection direction) throws MessagingException, IOException {
+        String messageId = extractMessageId(message);
+        if (!StringUtils.hasText(messageId)) {
+            LOGGER.debug("Skipping message without Message-ID in folder {}", folder.getFullName());
+            return;
+        }
+        Optional<MailMessageEntity> existing = mailMessageRepository.findByMessageId(messageId);
+        if (existing.isPresent()) {
+            return;
+        }
+
+        String peerEmail = resolvePeerEmail(message, direction);
+        if (!StringUtils.hasText(peerEmail)) {
+            LOGGER.debug("Skipping message {} without peer email", messageId);
+            return;
+        }
+
+        ChatEntity chat = chatRepository.findByPeerEmail(peerEmail)
+                .orElseGet(() -> createChat(peerEmail));
+
+        ParsedBody parsedBody = parseMessageBody(message);
+
+        MailMessageEntity entity = MailMessageEntity.builder()
+                .messageId(messageId)
+                .chat(chat)
+                .peerEmail(peerEmail)
+                .folder(folder.getFullName())
+                .uid(folder.getUID(message))
+                .sentAt(resolveSentAt(message))
+                .fromEmail(extractAddress(message.getFrom()))
+                .toEmail(extractAddress(message.getRecipients(Message.RecipientType.TO)))
+                .subject(message.getSubject())
+                .snippet(MailTextExtractor.sanitizeSnippet(parsedBody.snippet, 500))
+                .hasAttachments(!parsedBody.attachments.isEmpty())
+                .direction(direction)
+                .build();
+
+        parsedBody.attachments.forEach(attachment -> attachment.setMessage(entity));
+        entity.setAttachments(parsedBody.attachments);
+
+        mailMessageRepository.save(entity);
+
+        chat.setLastMessageAt(entity.getSentAt());
+        if (direction == MessageDirection.IN) {
+            chat.setHasUnprocessed(true);
+        }
+        chatRepository.save(chat);
+    }
+
+    private ParsedBody parseMessageBody(Message message) throws MessagingException, IOException {
+        List<MailAttachmentMetaEntity> attachments = new ArrayList<>();
+        String text = extractText(message, "", attachments);
+        return new ParsedBody(text, attachments);
+    }
+
+    private String extractText(Part part, String partId, List<MailAttachmentMetaEntity> attachments) throws MessagingException, IOException {
+        if (part.isMimeType("text/plain")) {
+            return part.getContent().toString();
+        }
+        if (part.isMimeType("text/html")) {
+            return MailTextExtractor.toPlainText(part.getContent().toString());
+        }
+        if (part.isMimeType("multipart/*")) {
+            Multipart multipart = (Multipart) part.getContent();
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < multipart.getCount(); i++) {
+                Part bodyPart = multipart.getBodyPart(i);
+                String childPartId = partId.isEmpty() ? String.valueOf(i + 1) : partId + "." + (i + 1);
+                String nestedText = extractText(bodyPart, childPartId, attachments);
+                if (StringUtils.hasText(nestedText)) {
+                    if (builder.length() > 0) {
+                        builder.append("\n\n");
+                    }
+                    builder.append(nestedText);
+                }
+            }
+            return builder.toString();
+        }
+        if (Part.ATTACHMENT.equalsIgnoreCase(part.getDisposition()) || StringUtils.hasText(part.getFileName())) {
+            attachments.add(MailAttachmentMetaEntity.builder()
+                    .partId(partId.isEmpty() ? "part" : partId)
+                    .filename(part.getFileName())
+                    .contentType(part.getContentType())
+                    .sizeBytes(part.getSize() >= 0 ? (long) part.getSize() : null)
+                    .build());
+        }
+        return "";
+    }
+
+    private String resolvePeerEmail(Message message, MessageDirection direction) throws MessagingException {
+        if (direction == MessageDirection.IN) {
+            return extractAddress(message.getFrom());
+        }
+        return extractAddress(message.getRecipients(Message.RecipientType.TO));
+    }
+
+    private String extractAddress(Address[] addresses) {
+        if (addresses == null || addresses.length == 0) {
+            return null;
+        }
+        Address address = addresses[0];
+        if (address instanceof InternetAddress internetAddress) {
+            return internetAddress.getAddress();
+        }
+        return address.toString();
+    }
+
+    private ChatEntity createChat(String peerEmail) {
+        ChatProfileResolver.ResolvedProfile profile = profileResolver.resolve(peerEmail);
+        return chatRepository.save(ChatEntity.builder()
+                .peerEmail(peerEmail)
+                .displayName(profile.displayName())
+                .orgUnit(profile.orgUnit())
+                .status(ChatStatus.NEW)
+                .hasUnprocessed(false)
+                .lastMessageAt(null)
+                .build());
+    }
+
+    private Instant resolveSentAt(Message message) throws MessagingException {
+        Date sentDate = message.getSentDate();
+        if (sentDate != null) {
+            return sentDate.toInstant();
+        }
+        Date received = message.getReceivedDate();
+        return received != null ? received.toInstant() : Instant.now();
+    }
+
+    private String extractMessageId(Message message) {
+        try {
+            String[] headers = message.getHeader("Message-ID");
+            if (headers != null && headers.length > 0) {
+                return headers[0];
+            }
+        } catch (MessagingException e) {
+            LOGGER.warn("Cannot read Message-ID: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private String safeMessageId(Message message) {
+        try {
+            return extractMessageId(message);
+        } catch (Exception ex) {
+            return "(unknown)";
+        }
+    }
+
+    private record ParsedBody(String snippet, List<MailAttachmentMetaEntity> attachments) {
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailSyncStateEntity.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailSyncStateEntity.java
@@ -1,0 +1,26 @@
+package com.esvar.dekanat.mail;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "mail_sync_state")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MailSyncStateEntity {
+
+    @Id
+    @Column(name = "folder", length = 64)
+    private String folder;
+
+    @Column(name = "last_uid")
+    private Long lastUid;
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailSyncStateRepository.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailSyncStateRepository.java
@@ -1,0 +1,8 @@
+package com.esvar.dekanat.mail;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MailSyncStateRepository extends JpaRepository<MailSyncStateEntity, String> {
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailTextExtractor.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailTextExtractor.java
@@ -1,0 +1,32 @@
+package com.esvar.dekanat.mail;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.safety.Safelist;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public final class MailTextExtractor {
+
+    private MailTextExtractor() {
+    }
+
+    public static String toPlainText(String html) {
+        if (html == null || html.isBlank()) {
+            return "";
+        }
+        Document document = Jsoup.parse(html);
+        document.select("style, script").remove();
+        return document.text();
+    }
+
+    public static String sanitizeSnippet(String content, int maxLength) {
+        String text = content == null ? "" : content.replaceAll("\\s+", " ").trim();
+        if (text.length() <= maxLength) {
+            return text;
+        }
+        return text.substring(0, Math.min(maxLength, text.length()));
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailpartExtractor.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailpartExtractor.java
@@ -1,0 +1,81 @@
+package com.esvar.dekanat.mail;
+
+import jakarta.mail.BodyPart;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Part;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+
+public final class MailpartExtractor {
+
+    private MailpartExtractor() {
+    }
+
+    public static String extractPlainText(Message message) {
+        try {
+            return extractText(message, "");
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    public static InputStream extractAttachmentStream(Message message, String partId) {
+        try {
+            return findAttachment(message, partId, "").orElseThrow(() -> new IllegalArgumentException("Attachment not found")).getInputStream();
+        } catch (Exception e) {
+            throw new IllegalStateException("Cannot load attachment: " + e.getMessage(), e);
+        }
+    }
+
+    private static Optional<Part> findAttachment(Part part, String targetPartId, String currentPartId) throws MessagingException, IOException {
+        if (part.isMimeType("multipart/*")) {
+            Multipart multipart = (Multipart) part.getContent();
+            for (int i = 0; i < multipart.getCount(); i++) {
+                BodyPart bodyPart = multipart.getBodyPart(i);
+                String childPartId = currentPartId.isEmpty() ? String.valueOf(i + 1) : currentPartId + "." + (i + 1);
+                Optional<Part> match = findAttachment(bodyPart, targetPartId, childPartId);
+                if (match.isPresent()) {
+                    return match;
+                }
+            }
+            return Optional.empty();
+        }
+        if (targetPartId.equals(currentPartId) || (currentPartId.isEmpty() && "part".equals(targetPartId))) {
+            if (Part.ATTACHMENT.equalsIgnoreCase(part.getDisposition()) || StringUtils.hasText(part.getFileName())) {
+                return Optional.of(part);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static String extractText(Part part, String partId) throws MessagingException, IOException {
+        if (part.isMimeType("text/plain")) {
+            return part.getContent().toString();
+        }
+        if (part.isMimeType("text/html")) {
+            return MailTextExtractor.toPlainText(part.getContent().toString());
+        }
+        if (part.isMimeType("multipart/*")) {
+            Multipart multipart = (Multipart) part.getContent();
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < multipart.getCount(); i++) {
+                BodyPart bodyPart = multipart.getBodyPart(i);
+                String childPartId = partId.isEmpty() ? String.valueOf(i + 1) : partId + "." + (i + 1);
+                String nested = extractText(bodyPart, childPartId);
+                if (StringUtils.hasText(nested)) {
+                    if (builder.length() > 0) {
+                        builder.append("\n\n");
+                    }
+                    builder.append(nested);
+                }
+            }
+            return builder.toString();
+        }
+        return "";
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mail/MessageDirection.java
+++ b/src/main/java/com/esvar/dekanat/mail/MessageDirection.java
@@ -1,0 +1,6 @@
+package com.esvar.dekanat.mail;
+
+public enum MessageDirection {
+    IN,
+    OUT
+}

--- a/src/main/java/com/esvar/dekanat/mail/dto/AttachmentDto.java
+++ b/src/main/java/com/esvar/dekanat/mail/dto/AttachmentDto.java
@@ -1,0 +1,13 @@
+package com.esvar.dekanat.mail.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class AttachmentDto {
+    Long id;
+    String attachmentId;
+    String filename;
+    Long sizeBytes;
+}

--- a/src/main/java/com/esvar/dekanat/mail/dto/ChatFilter.java
+++ b/src/main/java/com/esvar/dekanat/mail/dto/ChatFilter.java
@@ -1,0 +1,12 @@
+package com.esvar.dekanat.mail.dto;
+
+import com.esvar.dekanat.mail.ChatStatus;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ChatFilter {
+    private String query;
+    private List<ChatStatus> statuses;
+}

--- a/src/main/java/com/esvar/dekanat/mail/dto/ChatListItemDto.java
+++ b/src/main/java/com/esvar/dekanat/mail/dto/ChatListItemDto.java
@@ -1,0 +1,19 @@
+package com.esvar.dekanat.mail.dto;
+
+import com.esvar.dekanat.mail.ChatStatus;
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+
+@Value
+@Builder
+public class ChatListItemDto {
+    Long id;
+    String displayName;
+    String peerEmail;
+    String orgUnit;
+    ChatStatus status;
+    boolean hasUnprocessed;
+    Instant lastMessageAt;
+}

--- a/src/main/java/com/esvar/dekanat/mail/dto/ChatMessageDto.java
+++ b/src/main/java/com/esvar/dekanat/mail/dto/ChatMessageDto.java
@@ -1,0 +1,23 @@
+package com.esvar.dekanat.mail.dto;
+
+import com.esvar.dekanat.mail.MessageDirection;
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+import java.util.List;
+
+@Value
+@Builder
+public class ChatMessageDto {
+    Long id;
+    String messageId;
+    String from;
+    String to;
+    String subject;
+    String bodyText;
+    Instant sentAt;
+    MessageDirection direction;
+    boolean hasAttachments;
+    List<AttachmentDto> attachments;
+}

--- a/src/main/java/com/esvar/dekanat/mail/dto/ReplyRequest.java
+++ b/src/main/java/com/esvar/dekanat/mail/dto/ReplyRequest.java
@@ -1,0 +1,9 @@
+package com.esvar.dekanat.mail.dto;
+
+import lombok.Data;
+
+@Data
+public class ReplyRequest {
+    private String body;
+    private String subject;
+}

--- a/src/main/java/com/esvar/dekanat/view/MainLayout.java
+++ b/src/main/java/com/esvar/dekanat/view/MainLayout.java
@@ -2,6 +2,7 @@ package com.esvar.dekanat.view;
 
 import com.esvar.dekanat.entity.SessionEntity;
 import com.esvar.dekanat.mark.EnterMarksView;
+import com.esvar.dekanat.mail.MailInboxView;
 import com.esvar.dekanat.plan.PlanView;
 import com.esvar.dekanat.card.CardView;
 import com.esvar.dekanat.progress.SuccessView;
@@ -119,7 +120,8 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
                     createTab(VaadinIcon.USER_CARD, "Перегляд карток", CardView.class),
                     createTab(VaadinIcon.PENCIL, "Введення оцінок", EnterMarksView.class, seasonIcon),
                     createTab(VaadinIcon.BAR_CHART, "Рейтинг", RatingView.class),
-                    createTab(VaadinIcon.BOOK, "Успішність", SuccessView.class)
+                    createTab(VaadinIcon.BOOK, "Успішність", SuccessView.class),
+                    createTab(VaadinIcon.ENVELOPE, "Пошта", MailInboxView.class)
             );
 
             if (isAdmin) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,6 +38,16 @@ upload:
 
 mail:
   default-from: ${MAIL_DEFAULT_FROM:}
+  imap:
+    host: ${MAIL_IMAP_HOST:}
+    port: ${MAIL_IMAP_PORT:993}
+    username: ${MAIL_IMAP_USERNAME:}
+    password: ${MAIL_IMAP_PASSWORD:}
+    inbox-folder: ${MAIL_IMAP_INBOX:INBOX}
+    sent-folder: ${MAIL_IMAP_SENT:Sent}
+    use-ssl: ${MAIL_IMAP_SSL:true}
+  sync:
+    interval-ms: ${MAIL_SYNC_INTERVAL_MS:60000}
 
 #server:
 #  # Порт береться із змінної оточення SERVER_PORT (за замовчуванням 8080)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -5,3 +5,55 @@ ALTER TABLE users
     MODIFY COLUMN id BIGINT NOT NULL AUTO_INCREMENT;
 
 SET FOREIGN_KEY_CHECKS = @OLD_FOREIGN_KEY_CHECKS;
+
+-- Mail module tables
+CREATE TABLE IF NOT EXISTS mail_chat
+(
+    id               BIGINT PRIMARY KEY AUTO_INCREMENT,
+    peer_email       VARCHAR(320) NOT NULL,
+    display_name     VARCHAR(255),
+    org_unit         VARCHAR(255),
+    status           VARCHAR(32)  NOT NULL DEFAULT 'NEW',
+    has_unprocessed  TINYINT(1)    NOT NULL DEFAULT 0,
+    last_message_at  DATETIME,
+    CONSTRAINT uq_mail_chat_peer_email UNIQUE (peer_email),
+    INDEX idx_mail_chat_last_message_at (last_message_at)
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS mail_message
+(
+    id              BIGINT PRIMARY KEY AUTO_INCREMENT,
+    message_id      VARCHAR(512) NOT NULL,
+    chat_id         BIGINT       NOT NULL,
+    peer_email      VARCHAR(320) NOT NULL,
+    folder          VARCHAR(64)  NOT NULL,
+    uid             BIGINT       NOT NULL,
+    sent_at         DATETIME,
+    from_email      VARCHAR(320),
+    to_email        VARCHAR(320),
+    subject         VARCHAR(500),
+    snippet         VARCHAR(1000),
+    has_attachments TINYINT(1)   NOT NULL DEFAULT 0,
+    direction       VARCHAR(8)   NOT NULL,
+    CONSTRAINT uq_mail_message_message_id UNIQUE (message_id),
+    INDEX idx_mail_message_peer_email_date (peer_email, sent_at),
+    INDEX idx_mail_message_folder_uid (folder, uid),
+    CONSTRAINT fk_mail_message_chat FOREIGN KEY (chat_id) REFERENCES mail_chat (id)
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS mail_attachment_meta
+(
+    id           BIGINT PRIMARY KEY AUTO_INCREMENT,
+    message_id   BIGINT       NOT NULL,
+    part_id      VARCHAR(128) NOT NULL,
+    filename     VARCHAR(500),
+    content_type VARCHAR(255),
+    size_bytes   BIGINT,
+    CONSTRAINT fk_mail_attachment_message FOREIGN KEY (message_id) REFERENCES mail_message (id)
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS mail_sync_state
+(
+    folder   VARCHAR(64) PRIMARY KEY,
+    last_uid BIGINT
+) ENGINE = InnoDB;


### PR DESCRIPTION
## Summary
- add mail chat entities, sync state, repositories, and IMAP polling service with Message-ID deduplication and chat aggregation by peer email
- expose REST endpoints and Vaadin mail inbox view with chat list, message history, attachments download, status/processed toggles, and reply via SMTP
- extend configuration/schema, add jsoup dependency and mail setup notes for IMAP/SMTP environment values

## Testing
- `./mvnw -q -DskipTests compile` *(fails: unable to download Maven wrapper distribution from repo.maven.apache.org in sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694685639834832696b41022204aac18)