### PR TITLE
Use cached mail snippets for chat messages

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/ChatService.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatService.java
@@ -167,7 +167,7 @@ public class ChatService {
     }
 
     private ChatMessageDto toMessageDto(MailMessageEntity entity) throws MessagingException {
-        String bodyText = fetchPlainBody(entity);
+        String bodyText = resolveBodyText(entity);
         return ChatMessageDto.builder()
                 .id(entity.getId())
                 .messageId(entity.getMessageId())
@@ -185,6 +185,13 @@ public class ChatService {
     private String fetchPlainBody(MailMessageEntity entity) throws MessagingException {
         Message message = mailImapClient.getMessage(entity.getFolder(), entity.getUid());
         return MailpartExtractor.extractPlainText(message);
+    }
+
+    private String resolveBodyText(MailMessageEntity entity) throws MessagingException {
+        if (StringUtils.hasText(entity.getSnippet())) {
+            return entity.getSnippet();
+        }
+        return fetchPlainBody(entity);
     }
 
     private AttachmentDto toAttachmentDto(MailAttachmentMetaEntity attachment) {


### PR DESCRIPTION
## Summary
- show chat messages using the stored snippet so the message text appears without reloading IMAP
- fall back to fetching from IMAP only when a snippet is missing to preserve compatibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946bfd43550832699f77820d304e1d5)