### PR TITLE
mail: improve inbox message presentation

### DIFF
--- a/src/main/frontend/styles/mail-view.css
+++ b/src/main/frontend/styles/mail-view.css
@@ -11,3 +11,57 @@
     border-radius: var(--lumo-border-radius-l);
     margin-bottom: var(--lumo-space-m);
 }
+
+.message-header {
+    align-items: center;
+    justify-content: space-between;
+}
+
+.direction-badge {
+    font-size: var(--lumo-font-size-s);
+    padding: 4px 8px;
+    border-radius: 999px;
+    font-weight: 600;
+}
+
+.incoming-badge {
+    background-color: var(--lumo-success-color-10pct);
+    color: var(--lumo-success-text-color);
+}
+
+.outgoing-badge {
+    background-color: var(--lumo-primary-color-20pct);
+    color: var(--lumo-primary-text-color);
+}
+
+.message-time {
+    color: var(--lumo-secondary-text-color);
+    font-size: var(--lumo-font-size-xs);
+}
+
+.message-addresses {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    color: var(--lumo-secondary-text-color);
+    font-size: var(--lumo-font-size-s);
+    margin-top: var(--lumo-space-xs);
+}
+
+.message-body {
+    white-space: pre-wrap;
+    margin: var(--lumo-space-s) 0;
+}
+
+.message-attachments {
+    border-top: 1px solid var(--lumo-contrast-10pct);
+    padding-top: var(--lumo-space-xs);
+    margin-top: var(--lumo-space-xs);
+    gap: 4px;
+}
+
+.attachments-label {
+    font-size: var(--lumo-font-size-s);
+    color: var(--lumo-secondary-text-color);
+    font-weight: 600;
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailInboxView.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailInboxView.java
@@ -13,6 +13,7 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridVariant;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H3;
+import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
@@ -237,20 +238,34 @@ public class MailInboxView extends VerticalLayout {
         Div bubble = new Div();
         bubble.addClassName(message.getDirection() == MessageDirection.IN ? "incoming" : "outgoing");
 
-        Span meta = new Span(metaText(message));
-        meta.getStyle().set("font-size", "12px");
-        meta.getStyle().set("color", "var(--lumo-secondary-text-color)");
+        HorizontalLayout header = new HorizontalLayout();
+        header.addClassName("message-header");
+        Span directionBadge = new Span(message.getDirection() == MessageDirection.IN ? "Вхідне" : "Вихідне");
+        directionBadge.addClassNames("direction-badge",
+                message.getDirection() == MessageDirection.IN ? "incoming-badge" : "outgoing-badge");
+        Span time = new Span(metaText(message));
+        time.addClassName("message-time");
+        header.add(directionBadge, time);
+        header.setWidthFull();
 
-        Span body = new Span(Optional.ofNullable(message.getBodyText()).orElse(""));
-        body.getStyle().set("white-space", "pre-wrap");
+        Div addresses = new Div();
+        addresses.addClassName("message-addresses");
+        addresses.add(new Span("Від: " + Optional.ofNullable(message.getFrom()).orElse("")));
+        addresses.add(new Span("Кому: " + Optional.ofNullable(message.getTo()).orElse("")));
 
-        bubble.add(meta, body);
+        Paragraph body = new Paragraph(Optional.ofNullable(message.getBodyText()).orElse(""));
+        body.addClassName("message-body");
+
+        bubble.add(header, addresses, body);
 
         if (message.isHasAttachments() && message.getAttachments() != null && !message.getAttachments().isEmpty()) {
             VerticalLayout attachments = new VerticalLayout();
+            attachments.addClassName("message-attachments");
             attachments.setPadding(false);
             attachments.setSpacing(false);
-            attachments.getStyle().set("margin-top", "8px");
+            Span label = new Span("Вкладення");
+            label.addClassName("attachments-label");
+            attachments.add(label);
             message.getAttachments().forEach(att -> {
                 Button download = new Button(att.getFilename() != null ? att.getFilename() : "Вкладення");
                 download.addClickListener(e -> download.getUI().ifPresent(ui ->
@@ -265,8 +280,7 @@ public class MailInboxView extends VerticalLayout {
     }
 
     private String metaText(ChatMessageDto message) {
-        String time = message.getSentAt() != null ? dateTimeFormatter.format(message.getSentAt()) : "";
-        return "%s • %s".formatted(message.getDirection() == MessageDirection.IN ? "Вхідне" : "Вихідне", time);
+        return message.getSentAt() != null ? dateTimeFormatter.format(message.getSentAt()) : "";
     }
 
     private java.util.stream.Stream<ChatListItemDto> fetchChats(Query<ChatListItemDto, Void> query) {


### PR DESCRIPTION
## Summary
- show incoming vs outgoing messages with badges and structured header information
- display sender/recipient lines and clearly list message attachments
- add styling for message metadata, body text, and attachment blocks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c558e2fc8326b935e78982258e4b)