### PR TITLE
Reverse mail message order and highlight addresses

### DIFF
--- a/src/main/frontend/styles/mail-view.css
+++ b/src/main/frontend/styles/mail-view.css
@@ -15,6 +15,7 @@
 .message-header {
     align-items: center;
     justify-content: space-between;
+    margin-bottom: var(--lumo-space-xs);
 }
 
 .direction-badge {
@@ -42,10 +43,39 @@
 .message-addresses {
     display: flex;
     flex-direction: column;
-    gap: 2px;
-    color: var(--lumo-secondary-text-color);
+    gap: var(--lumo-space-xs);
+    color: var(--lumo-body-text-color);
     font-size: var(--lumo-font-size-s);
-    margin-top: var(--lumo-space-xs);
+    margin-top: var(--lumo-space-s);
+    padding: var(--lumo-space-s);
+    background-color: var(--lumo-contrast-10pct);
+    border-radius: var(--lumo-border-radius-m);
+    border: 1px solid var(--lumo-contrast-10pct);
+}
+
+.address-row {
+    display: flex;
+    align-items: baseline;
+    gap: var(--lumo-space-s);
+}
+
+.address-label {
+    font-weight: 700;
+    min-width: 64px;
+    color: var(--lumo-secondary-text-color);
+}
+
+.from-address .address-label {
+    color: var(--lumo-success-text-color);
+}
+
+.to-address .address-label {
+    color: var(--lumo-primary-text-color);
+}
+
+.address-value {
+    color: var(--lumo-body-text-color);
+    word-break: break-word;
 }
 
 .message-body {

--- a/src/main/java/com/esvar/dekanat/mail/MailInboxView.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailInboxView.java
@@ -224,7 +224,7 @@ public class MailInboxView extends VerticalLayout {
         if (selectedChat == null) {
             return;
         }
-        Pageable pageable = PageRequest.of(page, 50, Sort.by(Sort.Direction.ASC, "sentAt"));
+        Pageable pageable = PageRequest.of(page, 50, Sort.by(Sort.Direction.DESC, "sentAt"));
         Page<ChatMessageDto> messages = chatService.findMessages(selectedChat.getId(), pageable);
         if (!append) {
             messagePanel.removeAll();
@@ -250,8 +250,8 @@ public class MailInboxView extends VerticalLayout {
 
         Div addresses = new Div();
         addresses.addClassName("message-addresses");
-        addresses.add(new Span("Від: " + Optional.ofNullable(message.getFrom()).orElse("")));
-        addresses.add(new Span("Кому: " + Optional.ofNullable(message.getTo()).orElse("")));
+        addresses.add(buildAddressRow("Від", message.getFrom(), "from"));
+        addresses.add(buildAddressRow("Кому", message.getTo(), "to"));
 
         Paragraph body = new Paragraph(Optional.ofNullable(message.getBodyText()).orElse(""));
         body.addClassName("message-body");
@@ -281,6 +281,20 @@ public class MailInboxView extends VerticalLayout {
 
     private String metaText(ChatMessageDto message) {
         return message.getSentAt() != null ? dateTimeFormatter.format(message.getSentAt()) : "";
+    }
+
+    private Div buildAddressRow(String labelText, String value, String modifier) {
+        Div row = new Div();
+        row.addClassNames("address-row", modifier + "-address");
+
+        Span label = new Span(labelText);
+        label.addClassName("address-label");
+
+        Span valueSpan = new Span(Optional.ofNullable(value).orElse(""));
+        valueSpan.addClassName("address-value");
+
+        row.add(label, valueSpan);
+        return row;
     }
 
     private java.util.stream.Stream<ChatListItemDto> fetchChats(Query<ChatListItemDto, Void> query) {


### PR DESCRIPTION
## Summary
- show newest chat messages first in the mail inbox and load older messages afterward
- improve spacing and add highlighted sender/recipient rows for better readability

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c812f8e883269ce4b488e32854e1)