### PR TITLE
Fix mail attachment downloads and styles

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/ChatService.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatService.java
@@ -103,9 +103,20 @@ public class ChatService {
         if (meta == null) {
             throw new IllegalArgumentException("Attachment not found");
         }
+        return loadAttachment(meta);
+    }
+
+    @Transactional(readOnly = true)
+    public InputStream loadAttachment(Long attachmentMetaId) throws MessagingException {
+        MailAttachmentMetaEntity meta = attachmentRepository.findById(attachmentMetaId)
+                .orElseThrow(() -> new IllegalArgumentException("Attachment not found"));
+        return loadAttachment(meta);
+    }
+
+    private InputStream loadAttachment(MailAttachmentMetaEntity meta) throws MessagingException {
         MailMessageEntity message = meta.getMessage();
         Message mimeMessage = mailImapClient.getMessage(message.getFolder(), message.getUid());
-        return MailpartExtractor.extractAttachmentStream(mimeMessage, attachmentId);
+        return MailpartExtractor.extractAttachmentStream(mimeMessage, meta.getPartId());
     }
 
     public void replyToChat(Long chatId, String body, String subjectOverride) {

--- a/src/main/java/com/esvar/dekanat/mail/MailController.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailController.java
@@ -62,10 +62,20 @@ public class MailController {
         chatService.replyToChat(chatId, request.getBody(), request.getSubject());
     }
 
+    @GetMapping("/attachments/{attachmentId}")
+    public ResponseEntity<InputStreamResource> downloadAttachment(@PathVariable Long attachmentId) throws MessagingException {
+        InputStream stream = chatService.loadAttachment(attachmentId);
+        return buildAttachmentResponse(stream);
+    }
+
     @GetMapping("/messages/{messageId}/attachments/{attachmentId}")
     public ResponseEntity<InputStreamResource> downloadAttachment(@PathVariable String messageId,
                                                                   @PathVariable String attachmentId) throws MessagingException {
         InputStream stream = chatService.loadAttachment(messageId, attachmentId);
+        return buildAttachmentResponse(stream);
+    }
+
+    private ResponseEntity<InputStreamResource> buildAttachmentResponse(InputStream stream) {
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment")
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)

--- a/src/main/java/com/esvar/dekanat/mail/MailInboxView.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailInboxView.java
@@ -40,7 +40,7 @@ import java.util.Optional;
 @Route(value = "mail", layout = MainLayout.class)
 @PageTitle("Пошта як месенджер")
 @RolesAllowed({"ROLE_ADMIN", "ROLE_DEKANAT"})
-@CssImport(value = "./styles/mail-view.css", themeFor = "vaadin-grid")
+@CssImport("./styles/mail-view.css")
 public class MailInboxView extends VerticalLayout {
 
     private final ChatService chatService;
@@ -269,7 +269,7 @@ public class MailInboxView extends VerticalLayout {
             message.getAttachments().forEach(att -> {
                 Button download = new Button(att.getFilename() != null ? att.getFilename() : "Вкладення");
                 download.addClickListener(e -> download.getUI().ifPresent(ui ->
-                        ui.getPage().open("/mail/messages/" + message.getMessageId() + "/attachments/" + att.getAttachmentId())));
+                        ui.getPage().open("/mail/attachments/" + att.getId())));
                 download.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
                 attachments.add(download);
             });


### PR DESCRIPTION
## Summary
- add an attachment download endpoint that uses attachment metadata IDs and refactor service access to reuse common loading logic
- update the mail inbox view to consume the new endpoint and import the mail view styles so message spacing renders correctly

## Testing
- ./mvnw -q -DskipTests compile *(fails: Maven download blocked in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ca09edf883269efb7d202767c6ec)