### PR TITLE
mail: render full body and fix attachment layout

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/AttachmentList.java
+++ b/src/main/java/com/esvar/dekanat/mail/AttachmentList.java
@@ -5,7 +5,7 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
-import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import org.springframework.util.unit.DataSize;
@@ -33,15 +33,25 @@ public class AttachmentList extends VerticalLayout {
         Icon icon = iconForMime(attachment.getMimeType());
         icon.addClassName("attachment-icon");
 
-        Text name = new Text(attachment.getFilename() != null ? attachment.getFilename() : "Вкладення");
-        Text size = new Text(formatSize(attachment.getSizeBytes()));
+        Span name = new Span(attachment.getFilename() != null ? attachment.getFilename() : "Вкладення");
+        name.addClassName("attachment-name");
+
+        Span size = new Span(formatSize(attachment.getSizeBytes()));
+        size.addClassName("attachment-size");
 
         Button download = new Button("Завантажити", new Icon(VaadinIcon.DOWNLOAD_ALT));
         download.addThemeVariants(ButtonVariant.LUMO_TERTIARY, ButtonVariant.LUMO_SMALL);
         download.addClickListener(e -> download.getUI().ifPresent(ui -> ui.getPage().open("/mail/attachments/" + attachment.getId())));
 
-        row.add(icon, name, size, download);
-        row.setFlexGrow(1, name);
+        HorizontalLayout textWrapper = new HorizontalLayout(name, size);
+        textWrapper.setAlignItems(Alignment.BASELINE);
+        textWrapper.setSpacing(true);
+        textWrapper.setWidthFull();
+        textWrapper.setFlexGrow(1, name);
+        textWrapper.addClassName("attachment-text");
+
+        row.add(icon, textWrapper, download);
+        row.setFlexGrow(1, textWrapper);
         add(row);
     }
 

--- a/src/main/java/com/esvar/dekanat/mail/ChatService.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatService.java
@@ -194,15 +194,19 @@ public class ChatService {
     }
 
     private MailpartExtractor.BodyContent resolveBodyText(MailMessageEntity entity) throws MessagingException {
-        if (StringUtils.hasText(entity.getSnippet())) {
-            return new MailpartExtractor.BodyContent("", entity.getSnippet());
+        try {
+            Message message = mailImapClient.getMessage(entity.getFolder(), entity.getUid());
+            MailpartExtractor.BodyContent body = MailpartExtractor.extractBody(message);
+            String sanitizedHtml = MailTextExtractor.sanitizeHtml(body.html());
+            String plain = StringUtils.hasText(body.plain()) ? MailTextExtractor.stripInlinePlaceholders(body.plain())
+                    : MailTextExtractor.toPlainText(sanitizedHtml);
+            return new MailpartExtractor.BodyContent(sanitizedHtml, plain);
+        } catch (MessagingException e) {
+            if (StringUtils.hasText(entity.getSnippet())) {
+                return new MailpartExtractor.BodyContent("", entity.getSnippet());
+            }
+            throw e;
         }
-        Message message = mailImapClient.getMessage(entity.getFolder(), entity.getUid());
-        MailpartExtractor.BodyContent body = MailpartExtractor.extractBody(message);
-        String sanitizedHtml = MailTextExtractor.sanitizeHtml(body.html());
-        String plain = StringUtils.hasText(body.plain()) ? MailTextExtractor.stripInlinePlaceholders(body.plain()) :
-                MailTextExtractor.toPlainText(sanitizedHtml);
-        return new MailpartExtractor.BodyContent(sanitizedHtml, plain);
     }
 
     private AttachmentDto toAttachmentDto(MailAttachmentMetaEntity attachment) {

--- a/src/main/java/com/esvar/dekanat/mail/MessageBubble.java
+++ b/src/main/java/com/esvar/dekanat/mail/MessageBubble.java
@@ -3,8 +3,8 @@ package com.esvar.dekanat.mail;
 import com.esvar.dekanat.mail.dto.AttachmentDto;
 import com.esvar.dekanat.mail.dto.ChatMessageDto;
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
@@ -58,7 +58,10 @@ public class MessageBubble extends Div {
 
         Div bodyWrapper = new Div();
         bodyWrapper.addClassName("bubble-body");
-        bodyWrapper.add(new Html("<div class='message-body-html'>" + mainHtml + "</div>"));
+        Span body = new Span();
+        body.addClassName("message-body-html");
+        body.getElement().setProperty("innerHTML", mainHtml);
+        bodyWrapper.add(body);
 
         if (hasQuote) {
             bodyWrapper.add(new QuoteCollapsePanel(toSafeHtml(extraction.quote())));


### PR DESCRIPTION
## Summary
- switch message rendering to inject sanitized HTML via component property instead of Html component to preserve full content and avoid trimming
- adjust attachment list layout to use spans and a flex wrapper so text grows correctly and the layout remains mutable
- fall back to stored snippet only when IMAP fetch fails so full message body is shown whenever available

## Testing
- ⚠️ `./mvnw -q -DskipTests compile` (fails: unable to download Maven distribution due to network fetch error)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946d52265588326bd0ed8924cbe7af9)