### PR TITLE
Load mail message details on demand

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/ChatService.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatService.java
@@ -2,11 +2,11 @@ package com.esvar.dekanat.mail;
 
 import com.esvar.dekanat.mail.dto.AttachmentDto;
 import com.esvar.dekanat.mail.dto.ChatListItemDto;
-import com.esvar.dekanat.mail.dto.ChatMessageDto;
+import com.esvar.dekanat.mail.dto.ChatMessageDetailDto;
+import com.esvar.dekanat.mail.dto.ChatMessageHeaderDto;
 import com.esvar.dekanat.mail.dto.ChatFilter;
 import jakarta.mail.*;
 import jakarta.mail.internet.MimeMessage;
-import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.mail.MailProperties;
 import org.springframework.data.domain.Page;
@@ -19,12 +19,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static org.reflections.Reflections.log;
 
 @Service
 public class ChatService {
@@ -73,15 +75,9 @@ public class ChatService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ChatMessageDto> findMessages(Long chatId, Pageable pageable) {
+    public Page<ChatMessageHeaderDto> findMessageHeaders(Long chatId, Pageable pageable) {
         Page<MailMessageEntity> page = mailMessageRepository.findByChatId(chatId, pageable);
-        return page.map(entity -> {
-            try {
-                return toMessageDto(entity);
-            } catch (MessagingException e) {
-                throw new IllegalStateException("Failed to map mail message", e);
-            }
-        });
+        return page.map(this::toHeaderDto);
     }
 
     public void updateStatus(Long chatId, ChatStatus status) {
@@ -177,17 +173,19 @@ public class ChatService {
                 .build();
     }
 
-    private ChatMessageDto toMessageDto(MailMessageEntity entity) throws MessagingException {
-        MailpartExtractor.BodyContent body = resolveBodyText(entity);
+    public ChatMessageDetailDto getMessageDetails(Long messageId) throws MessagingException {
+        MailMessageEntity entity = mailMessageRepository.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("Message not found"));
 
-        String htmlText  = body != null && body.html()  != null ? body.html()  : "";
+        MailpartExtractor.BodyContent body = ensureContentCached(entity);
+
+        String htmlText = body != null && body.html() != null ? body.html() : "";
         String plainText = body != null && body.plain() != null ? body.plain() : "";
 
         MailReplySplitter.SplitResult split = MailReplySplitter.split(plainText);
         String replyText = split.reply();
         String quotedText = split.quoted();
 
-        // якщо ти хочеш quoted ще й як html (просто для простого відображення)
         String quotedHtml = "";
         if (StringUtils.hasText(quotedText)) {
             quotedHtml = "<pre style=\"white-space:pre-wrap;\">" +
@@ -195,7 +193,7 @@ public class ChatService {
                     "</pre>";
         }
 
-        return ChatMessageDto.builder()
+        return ChatMessageDetailDto.builder()
                 .id(entity.getId())
                 .messageId(entity.getMessageId())
                 .from(entity.getFromEmail())
@@ -203,8 +201,9 @@ public class ChatService {
                 .subject(entity.getSubject())
                 .bodyHtml(htmlText)
                 .bodyText(replyText)
-                .quotedText(quotedText)     // <-- нове поле
-                .quotedHtml(quotedHtml)     // <-- опційно
+                .quotedText(quotedText)
+                .quotedHtml(quotedHtml)
+                .snippet(entity.getSnippet())
                 .sentAt(entity.getSentAt())
                 .direction(entity.getDirection())
                 .hasAttachments(entity.isHasAttachments())
@@ -212,31 +211,37 @@ public class ChatService {
                 .build();
     }
 
-    private static String escapeHtml(String s) {
-        if (s == null) return "";
-        return s.replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;")
-                .replace("\"", "&quot;")
-                .replace("'", "&#39;");
+    private ChatMessageHeaderDto toHeaderDto(MailMessageEntity entity) {
+        String snippet = entity.getSnippet();
+        if (!StringUtils.hasText(snippet) && StringUtils.hasText(entity.getCachedPlainBody())) {
+            snippet = MailTextExtractor.sanitizeSnippet(entity.getCachedPlainBody(), 500);
+        }
+
+        return ChatMessageHeaderDto.builder()
+                .id(entity.getId())
+                .messageId(entity.getMessageId())
+                .from(entity.getFromEmail())
+                .to(entity.getToEmail())
+                .subject(entity.getSubject())
+                .snippet(snippet)
+                .sentAt(entity.getSentAt())
+                .direction(entity.getDirection())
+                .hasAttachments(entity.isHasAttachments())
+                .build();
     }
 
+    private MailpartExtractor.BodyContent ensureContentCached(MailMessageEntity entity) throws MessagingException {
+        if (entity.getContentLoadedAt() != null && (StringUtils.hasText(entity.getCachedPlainBody()) || StringUtils.hasText(entity.getCachedHtmlBody()))) {
+            return new MailpartExtractor.BodyContent(entity.getCachedHtmlBody(), entity.getCachedPlainBody());
+        }
 
-
-
-    private MailpartExtractor.BodyContent resolveBodyText(MailMessageEntity entity) throws MessagingException {
         try {
             Message message = mailImapClient.getMessage(entity.getFolder(), entity.getUid());
-
-            // force load content (інколи критично для IMAP)
-            // message.getContent();
-
             MailpartExtractor.BodyContent body = MailpartExtractor.extractBody(message);
 
             String html = body != null ? body.html() : null;
             String plain = body != null ? body.plain() : null;
 
-            // Фолбек, якщо витяг не дав нічого
             if (!StringUtils.hasText(html) && !StringUtils.hasText(plain)) {
                 Extracted ex = extractTextFallback(message);
                 html = ex.html;
@@ -248,10 +253,11 @@ public class ChatService {
                     ? MailTextExtractor.stripInlinePlaceholders(plain)
                     : (StringUtils.hasText(sanitizedHtml) ? MailTextExtractor.toPlainText(sanitizedHtml) : "");
 
-            // останній фолбек — snippet
             if (!StringUtils.hasText(finalPlain) && StringUtils.hasText(entity.getSnippet())) {
                 finalPlain = entity.getSnippet();
             }
+
+            persistContent(entity, sanitizedHtml, finalPlain, message);
 
             return new MailpartExtractor.BodyContent(sanitizedHtml, finalPlain);
         } catch (MessagingException e) {
@@ -259,7 +265,58 @@ public class ChatService {
                 return new MailpartExtractor.BodyContent("", entity.getSnippet());
             }
             throw e;
+        } catch (IOException e) {
+            throw new MessagingException("Failed to load message content", e);
         }
+    }
+
+    private void persistContent(MailMessageEntity entity, String html, String plain, Message message) throws MessagingException, IOException {
+        String sanitizedPlain = StringUtils.hasText(plain) ? plain : "";
+        entity.setCachedHtmlBody(html);
+        entity.setCachedPlainBody(sanitizedPlain);
+
+        if (!StringUtils.hasText(entity.getSnippet())) {
+            entity.setSnippet(MailTextExtractor.sanitizeSnippet(sanitizedPlain, 500));
+        }
+
+        List<MailAttachmentMetaEntity> attachments = new ArrayList<>();
+        collectAttachments(message, "", attachments);
+        attachments.forEach(a -> a.setMessage(entity));
+        entity.getAttachments().clear();
+        entity.getAttachments().addAll(attachments);
+        entity.setHasAttachments(!attachments.isEmpty());
+        entity.setContentLoadedAt(Instant.now());
+        mailMessageRepository.save(entity);
+    }
+
+    private void collectAttachments(Part part, String partId, List<MailAttachmentMetaEntity> attachments) throws MessagingException, IOException {
+        if (part.isMimeType("multipart/*")) {
+            Multipart multipart = (Multipart) part.getContent();
+            for (int i = 0; i < multipart.getCount(); i++) {
+                Part bodyPart = multipart.getBodyPart(i);
+                String childPartId = partId.isEmpty() ? String.valueOf(i + 1) : partId + "." + (i + 1);
+                collectAttachments(bodyPart, childPartId, attachments);
+            }
+            return;
+        }
+
+        if (Part.ATTACHMENT.equalsIgnoreCase(part.getDisposition()) || StringUtils.hasText(part.getFileName())) {
+            attachments.add(MailAttachmentMetaEntity.builder()
+                    .partId(partId.isEmpty() ? "part" : partId)
+                    .filename(part.getFileName())
+                    .contentType(part.getContentType())
+                    .sizeBytes(part.getSize() >= 0 ? (long) part.getSize() : null)
+                    .build());
+        }
+    }
+
+    private static String escapeHtml(String s) {
+        if (s == null) return "";
+        return s.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
     }
 
     private static class Extracted {
@@ -372,8 +429,6 @@ public class ChatService {
 
         return c.toString();
     }
-
-
 
     private AttachmentDto toAttachmentDto(MailAttachmentMetaEntity attachment) {
         return AttachmentDto.builder()

--- a/src/main/java/com/esvar/dekanat/mail/ConversationView.java
+++ b/src/main/java/com/esvar/dekanat/mail/ConversationView.java
@@ -1,7 +1,8 @@
 package com.esvar.dekanat.mail;
 
 import com.esvar.dekanat.mail.dto.ChatListItemDto;
-import com.esvar.dekanat.mail.dto.ChatMessageDto;
+import com.esvar.dekanat.mail.dto.ChatMessageDetailDto;
+import com.esvar.dekanat.mail.dto.ChatMessageHeaderDto;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
@@ -13,6 +14,7 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import jakarta.mail.MessagingException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -44,7 +46,7 @@ public class ConversationView extends VerticalLayout {
 
     private ChatListItemDto currentChat;
     private int currentPage = 0;
-    private final List<ChatMessageDto> loadedMessages = new ArrayList<>();
+    private final List<ChatMessageHeaderDto> loadedMessages = new ArrayList<>();
     private Consumer<ChatListItemDto> chatUpdateListener;
 
     private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm")
@@ -186,7 +188,7 @@ public class ConversationView extends VerticalLayout {
         if (CollectionUtils.isEmpty(loadedMessages)) {
             return "";
         }
-        ChatMessageDto last = loadedMessages.get(loadedMessages.size() - 1);
+        ChatMessageHeaderDto last = loadedMessages.get(loadedMessages.size() - 1);
         String lastTime = last.getSentAt() != null ? dateTimeFormatter.format(last.getSentAt()) : "";
         return String.format("Останнє повідомлення: %s • %d повідомлень", lastTime, loadedMessages.size());
     }
@@ -196,12 +198,12 @@ public class ConversationView extends VerticalLayout {
             return;
         }
         Pageable pageable = PageRequest.of(currentPage, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "sentAt"));
-        Page<ChatMessageDto> page = chatService.findMessages(currentChat.getId(), pageable);
-        List<ChatMessageDto> batch = new ArrayList<>(page.getContent());
-        batch.sort(Comparator.comparing(ChatMessageDto::getSentAt, Comparator.nullsLast(Comparator.naturalOrder())));
+        Page<ChatMessageHeaderDto> page = chatService.findMessageHeaders(currentChat.getId(), pageable);
+        List<ChatMessageHeaderDto> batch = new ArrayList<>(page.getContent());
+        batch.sort(Comparator.comparing(ChatMessageHeaderDto::getSentAt, Comparator.nullsLast(Comparator.naturalOrder())));
 
         loadedMessages.addAll(batch);
-        loadedMessages.sort(Comparator.comparing(ChatMessageDto::getSentAt, Comparator.nullsLast(Comparator.naturalOrder())));
+        loadedMessages.sort(Comparator.comparing(ChatMessageHeaderDto::getSentAt, Comparator.nullsLast(Comparator.naturalOrder())));
 
         renderMessages(initial);
 
@@ -218,7 +220,7 @@ public class ConversationView extends VerticalLayout {
     private void renderMessages(boolean initial) {
         messagesContainer.removeAll();
         LocalDate lastDate = null;
-        for (ChatMessageDto message : loadedMessages) {
+        for (ChatMessageHeaderDto message : loadedMessages) {
             LocalDate date = Optional.ofNullable(message.getSentAt())
                     .map(instant -> instant.atZone(ZoneId.systemDefault()).toLocalDate())
                     .orElse(null);
@@ -226,10 +228,18 @@ public class ConversationView extends VerticalLayout {
                 messagesContainer.add(new MessageDateDivider(date != null ? dateFormatter.format(date) : ""));
                 lastDate = date;
             }
-            messagesContainer.add(new MessageBubble(message));
+            messagesContainer.add(new MessageBubble(message, this::loadMessageDetails));
         }
         if (!initial) {
             messagesContainer.getElement().executeJs("this.scrollTop = this.scrollHeight;");
+        }
+    }
+
+    private ChatMessageDetailDto loadMessageDetails(Long messageId) {
+        try {
+            return chatService.getMessageDetails(messageId);
+        } catch (MessagingException e) {
+            throw new IllegalStateException("Не вдалося завантажити повідомлення", e);
         }
     }
 

--- a/src/main/java/com/esvar/dekanat/mail/MailController.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailController.java
@@ -2,7 +2,8 @@ package com.esvar.dekanat.mail;
 
 import com.esvar.dekanat.mail.dto.ChatFilter;
 import com.esvar.dekanat.mail.dto.ChatListItemDto;
-import com.esvar.dekanat.mail.dto.ChatMessageDto;
+import com.esvar.dekanat.mail.dto.ChatMessageDetailDto;
+import com.esvar.dekanat.mail.dto.ChatMessageHeaderDto;
 import com.esvar.dekanat.mail.dto.ReplyRequest;
 import jakarta.mail.MessagingException;
 import org.springframework.data.domain.Page;
@@ -40,11 +41,16 @@ public class MailController {
     }
 
     @GetMapping("/chats/{chatId}/messages")
-    public Page<ChatMessageDto> getMessages(@PathVariable Long chatId,
-                                            @RequestParam(name = "page", defaultValue = "0") int page,
-                                            @RequestParam(name = "size", defaultValue = "50") int size) {
+    public Page<ChatMessageHeaderDto> getMessages(@PathVariable Long chatId,
+                                                  @RequestParam(name = "page", defaultValue = "0") int page,
+                                                  @RequestParam(name = "size", defaultValue = "50") int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "sentAt"));
-        return chatService.findMessages(chatId, pageable);
+        return chatService.findMessageHeaders(chatId, pageable);
+    }
+
+    @GetMapping("/messages/{messageId}")
+    public ChatMessageDetailDto getMessageDetails(@PathVariable Long messageId) throws MessagingException {
+        return chatService.getMessageDetails(messageId);
     }
 
     @PostMapping("/chats/{chatId}/status")

--- a/src/main/java/com/esvar/dekanat/mail/MailMessageEntity.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailMessageEntity.java
@@ -58,6 +58,17 @@ public class MailMessageEntity {
     @Column(name = "snippet", length = 1000)
     private String snippet;
 
+    @Lob
+    @Column(name = "cached_plain_body")
+    private String cachedPlainBody;
+
+    @Lob
+    @Column(name = "cached_html_body")
+    private String cachedHtmlBody;
+
+    @Column(name = "content_loaded_at")
+    private Instant contentLoadedAt;
+
     @Column(name = "has_attachments", nullable = false)
     private boolean hasAttachments;
 

--- a/src/main/java/com/esvar/dekanat/mail/MailSyncService.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailSyncService.java
@@ -17,9 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -33,7 +31,6 @@ public class MailSyncService {
     private final MailSyncProperties properties;
     private final ChatRepository chatRepository;
     private final MailMessageRepository mailMessageRepository;
-    private final MailAttachmentMetaRepository attachmentRepository;
     private final MailSyncStateRepository syncStateRepository;
     private final ChatProfileResolver profileResolver;
 
@@ -41,14 +38,12 @@ public class MailSyncService {
                            MailSyncProperties properties,
                            ChatRepository chatRepository,
                            MailMessageRepository mailMessageRepository,
-                           MailAttachmentMetaRepository attachmentRepository,
                            MailSyncStateRepository syncStateRepository,
                            ChatProfileResolver profileResolver) {
         this.mailImapClient = mailImapClient;
         this.properties = properties;
         this.chatRepository = chatRepository;
         this.mailMessageRepository = mailMessageRepository;
-        this.attachmentRepository = attachmentRepository;
         this.syncStateRepository = syncStateRepository;
         this.profileResolver = profileResolver;
     }
@@ -109,8 +104,6 @@ public class MailSyncService {
         ChatEntity chat = chatRepository.findByPeerEmail(peerEmail)
                 .orElseGet(() -> createChat(peerEmail));
 
-        ParsedBody parsedBody = parseMessageBody(message);
-
         MailMessageEntity entity = MailMessageEntity.builder()
                 .messageId(messageId)
                 .chat(chat)
@@ -121,13 +114,9 @@ public class MailSyncService {
                 .fromEmail(extractAddress(message.getFrom()))
                 .toEmail(extractAddress(message.getRecipients(Message.RecipientType.TO)))
                 .subject(message.getSubject())
-                .snippet(MailTextExtractor.sanitizeSnippet(parsedBody.snippet, 500))
-                .hasAttachments(!parsedBody.attachments.isEmpty())
+                .hasAttachments(hasAttachments(message))
                 .direction(direction)
                 .build();
-
-        parsedBody.attachments.forEach(attachment -> attachment.setMessage(entity));
-        entity.setAttachments(parsedBody.attachments);
 
         mailMessageRepository.save(entity);
 
@@ -138,44 +127,21 @@ public class MailSyncService {
         chatRepository.save(chat);
     }
 
-    private ParsedBody parseMessageBody(Message message) throws MessagingException, IOException {
-        List<MailAttachmentMetaEntity> attachments = new ArrayList<>();
-        String text = extractText(message, "", attachments);
-        return new ParsedBody(text, attachments);
-    }
-
-    private String extractText(Part part, String partId, List<MailAttachmentMetaEntity> attachments) throws MessagingException, IOException {
-        if (part.isMimeType("text/plain")) {
-            return part.getContent().toString();
-        }
-        if (part.isMimeType("text/html")) {
-            return MailTextExtractor.toPlainText(part.getContent().toString());
-        }
+    private boolean hasAttachments(Part part) throws MessagingException, IOException {
         if (part.isMimeType("multipart/*")) {
             Multipart multipart = (Multipart) part.getContent();
-            StringBuilder builder = new StringBuilder();
             for (int i = 0; i < multipart.getCount(); i++) {
                 Part bodyPart = multipart.getBodyPart(i);
-                String childPartId = partId.isEmpty() ? String.valueOf(i + 1) : partId + "." + (i + 1);
-                String nestedText = extractText(bodyPart, childPartId, attachments);
-                if (StringUtils.hasText(nestedText)) {
-                    if (builder.length() > 0) {
-                        builder.append("\n\n");
-                    }
-                    builder.append(nestedText);
+                if (isAttachment(bodyPart) || hasAttachments(bodyPart)) {
+                    return true;
                 }
             }
-            return builder.toString();
         }
-        if (Part.ATTACHMENT.equalsIgnoreCase(part.getDisposition()) || StringUtils.hasText(part.getFileName())) {
-            attachments.add(MailAttachmentMetaEntity.builder()
-                    .partId(partId.isEmpty() ? "part" : partId)
-                    .filename(part.getFileName())
-                    .contentType(part.getContentType())
-                    .sizeBytes(part.getSize() >= 0 ? (long) part.getSize() : null)
-                    .build());
-        }
-        return "";
+        return isAttachment(part);
+    }
+
+    private boolean isAttachment(Part part) throws MessagingException {
+        return Part.ATTACHMENT.equalsIgnoreCase(part.getDisposition()) || StringUtils.hasText(part.getFileName());
     }
 
     private String resolvePeerEmail(Message message, MessageDirection direction) throws MessagingException {
@@ -235,8 +201,5 @@ public class MailSyncService {
         } catch (Exception ex) {
             return "(unknown)";
         }
-    }
-
-    private record ParsedBody(String snippet, List<MailAttachmentMetaEntity> attachments) {
     }
 }

--- a/src/main/java/com/esvar/dekanat/mail/MessageBubble.java
+++ b/src/main/java/com/esvar/dekanat/mail/MessageBubble.java
@@ -1,10 +1,10 @@
 package com.esvar.dekanat.mail;
 
 import com.esvar.dekanat.mail.dto.AttachmentDto;
-import com.esvar.dekanat.mail.dto.ChatMessageDto;
+import com.esvar.dekanat.mail.dto.ChatMessageDetailDto;
+import com.esvar.dekanat.mail.dto.ChatMessageHeaderDto;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
@@ -21,21 +21,42 @@ public class MessageBubble extends Div {
     private final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
             .withZone(ZoneId.systemDefault());
 
-    public MessageBubble(ChatMessageDto message) {
+    private final Div bodyWrapper = new Div();
+    private final Div attachmentsWrapper = new Div();
+    private final MessageDetailLoader detailLoader;
+
+    private ChatMessageHeaderDto header;
+    private ChatMessageDetailDto detail;
+
+    public MessageBubble(ChatMessageHeaderDto header, MessageDetailLoader detailLoader) {
+        this.header = header;
+        this.detailLoader = detailLoader;
         addClassName("message-bubble");
-        addClassName(message.getDirection() == MessageDirection.IN ? "incoming" : "outgoing");
-        add(buildHeader(message), buildBody(message), buildAttachments(message.getAttachments()));
+        addClassName(header.getDirection() == MessageDirection.IN ? "incoming" : "outgoing");
+
+        bodyWrapper.addClassName("bubble-body");
+        attachmentsWrapper.addClassName("bubble-attachments");
+
+        add(buildHeader(), bodyWrapper, attachmentsWrapper);
+        renderBody();
+        renderAttachments();
+
+        addClickListener(e -> {
+            if (detail == null) {
+                loadDetails();
+            }
+        });
     }
 
-    private Component buildHeader(ChatMessageDto message) {
-        Span directionBadge = new Span(message.getDirection() == MessageDirection.IN ? "Вхідне" : "Вихідне");
+    private Component buildHeader() {
+        Span directionBadge = new Span(header.getDirection() == MessageDirection.IN ? "Вхідне" : "Вихідне");
         directionBadge.addClassName("direction-badge");
-        directionBadge.addClassName(message.getDirection() == MessageDirection.IN ? "incoming-badge" : "outgoing-badge");
+        directionBadge.addClassName(header.getDirection() == MessageDirection.IN ? "incoming-badge" : "outgoing-badge");
 
-        Span addresses = new Span(shortAddress(message));
+        Span addresses = new Span(shortAddress());
         addresses.addClassName("bubble-address");
 
-        Span time = new Span(message.getSentAt() != null ? timeFormatter.format(message.getSentAt()) : "");
+        Span time = new Span(header.getSentAt() != null ? timeFormatter.format(header.getSentAt()) : "");
         time.addClassName("message-time");
 
         HorizontalLayout header = new HorizontalLayout(directionBadge, addresses, time);
@@ -46,18 +67,26 @@ public class MessageBubble extends Div {
         return header;
     }
 
-    private Component buildBody(ChatMessageDto message) {
-        QuoteCollapsePanel.QuoteExtraction extraction = QuoteCollapsePanel.extract(message.getBodyText());
+    private void renderBody() {
+        bodyWrapper.removeAll();
+        if (detail == null) {
+            String previewText = toSafeHtml(Optional.ofNullable(header.getSnippet()).orElse("Натисніть, щоб завантажити"));
+            Span preview = new Span();
+            preview.addClassName("message-body-html");
+            preview.getElement().setProperty("innerHTML", previewText);
+            bodyWrapper.add(preview);
+            return;
+        }
+
+        QuoteCollapsePanel.QuoteExtraction extraction = QuoteCollapsePanel.extract(detail.getBodyText());
         boolean hasQuote = extraction.hasQuote();
         String mainHtml;
-        if (!hasQuote && StringUtils.hasText(message.getBodyHtml())) {
-            mainHtml = message.getBodyHtml();
+        if (!hasQuote && StringUtils.hasText(detail.getBodyHtml())) {
+            mainHtml = detail.getBodyHtml();
         } else {
             mainHtml = toSafeHtml(extraction.main());
         }
 
-        Div bodyWrapper = new Div();
-        bodyWrapper.addClassName("bubble-body");
         Span body = new Span();
         body.addClassName("message-body-html");
         body.getElement().setProperty("innerHTML", mainHtml);
@@ -66,21 +95,24 @@ public class MessageBubble extends Div {
         if (hasQuote) {
             bodyWrapper.add(new QuoteCollapsePanel(toSafeHtml(extraction.quote())));
         }
-        return bodyWrapper;
     }
 
-    private Component buildAttachments(List<AttachmentDto> attachments) {
-        if (attachments == null || attachments.isEmpty()) {
-            return new Div();
+    private void renderAttachments() {
+        attachmentsWrapper.removeAll();
+        if (detail == null) {
+            return;
         }
-        return new AttachmentList(attachments);
+        List<AttachmentDto> attachments = detail.getAttachments();
+        if (attachments != null && !attachments.isEmpty()) {
+            attachmentsWrapper.add(new AttachmentList(attachments));
+        }
     }
 
-    private String shortAddress(ChatMessageDto message) {
-        if (message.getDirection() == MessageDirection.IN) {
-            return "Від: " + Optional.ofNullable(message.getFrom()).orElse("");
+    private String shortAddress() {
+        if (header.getDirection() == MessageDirection.IN) {
+            return "Від: " + Optional.ofNullable(header.getFrom()).orElse("");
         }
-        return "Кому: " + Optional.ofNullable(message.getTo()).orElse("");
+        return "Кому: " + Optional.ofNullable(header.getTo()).orElse("");
     }
 
     private String toSafeHtml(String text) {
@@ -88,5 +120,22 @@ public class MessageBubble extends Div {
             return "";
         }
         return HtmlUtils.htmlEscape(text).replace("\n", "<br/>");
+    }
+
+    private void loadDetails() {
+        if (detailLoader == null) {
+            return;
+        }
+        ChatMessageDetailDto loaded = detailLoader.load(header.getId());
+        if (loaded != null) {
+            this.detail = loaded;
+            renderBody();
+            renderAttachments();
+        }
+    }
+
+    @FunctionalInterface
+    public interface MessageDetailLoader {
+        ChatMessageDetailDto load(Long messageId);
     }
 }

--- a/src/main/java/com/esvar/dekanat/mail/dto/ChatMessageDetailDto.java
+++ b/src/main/java/com/esvar/dekanat/mail/dto/ChatMessageDetailDto.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Value
 @Builder
-public class ChatMessageDto {
+public class ChatMessageDetailDto {
     Long id;
     String messageId;
     String from;
@@ -19,6 +19,7 @@ public class ChatMessageDto {
     String bodyText;
     String quotedText;
     String quotedHtml;
+    String snippet;
     Instant sentAt;
     MessageDirection direction;
     boolean hasAttachments;

--- a/src/main/java/com/esvar/dekanat/mail/dto/ChatMessageHeaderDto.java
+++ b/src/main/java/com/esvar/dekanat/mail/dto/ChatMessageHeaderDto.java
@@ -1,0 +1,21 @@
+package com.esvar.dekanat.mail.dto;
+
+import com.esvar.dekanat.mail.MessageDirection;
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+
+@Value
+@Builder
+public class ChatMessageHeaderDto {
+    Long id;
+    String messageId;
+    String from;
+    String to;
+    String subject;
+    String snippet;
+    Instant sentAt;
+    MessageDirection direction;
+    boolean hasAttachments;
+}


### PR DESCRIPTION
## Summary
- stop eagerly parsing message bodies during sync and add caching fields for body/snippet metadata
- introduce header vs. detail DTOs with a lazy ChatService detail loader that caches content and attachments
- update mail endpoints and Vaadin conversation UI to load message details/attachments on click using the new detail API

## Testing
- `./mvnw -q -DskipTests compile` *(fails: Maven wrapper download from repo.maven.apache.org blocked in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947c0518c308326814c20d511c8ce29)