### PR TITLE
Add thread-based mail inbox experience

### DIFF
--- a/src/main/frontend/styles/conversation-view.css
+++ b/src/main/frontend/styles/conversation-view.css
@@ -13,7 +13,7 @@
 }
 
 .conversation-messages {
-    height: calc(100% - 48px);
+    height: 100%;
     overflow-y: auto;
     padding: var(--lumo-space-m);
     background: var(--lumo-contrast-5pct);

--- a/src/main/frontend/styles/mail-view.css
+++ b/src/main/frontend/styles/mail-view.css
@@ -95,3 +95,45 @@
     color: var(--lumo-secondary-text-color);
     font-weight: 600;
 }
+
+.thread-preview {
+    display: flex;
+    flex-direction: column;
+    gap: var(--lumo-space-xs);
+    padding: var(--lumo-space-xs);
+}
+
+.thread-title {
+    font-weight: 700;
+    font-size: var(--lumo-font-size-m);
+}
+
+.thread-counterparty {
+    color: var(--lumo-secondary-text-color);
+    font-size: var(--lumo-font-size-s);
+}
+
+.thread-snippet {
+    color: var(--lumo-body-text-color);
+    font-size: var(--lumo-font-size-s);
+}
+
+.thread-unread {
+    background: var(--lumo-primary-color-10pct);
+    color: var(--lumo-primary-text-color);
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: var(--lumo-font-size-xs);
+    font-weight: 600;
+}
+
+.thread-attachment {
+    color: var(--lumo-secondary-text-color);
+}
+
+.thread-status {
+    color: var(--lumo-secondary-text-color);
+    font-size: var(--lumo-font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}

--- a/src/main/java/com/esvar/dekanat/mail/AttachmentList.java
+++ b/src/main/java/com/esvar/dekanat/mail/AttachmentList.java
@@ -41,7 +41,7 @@ public class AttachmentList extends VerticalLayout {
 
         Button download = new Button("Завантажити", new Icon(VaadinIcon.DOWNLOAD_ALT));
         download.addThemeVariants(ButtonVariant.LUMO_TERTIARY, ButtonVariant.LUMO_SMALL);
-        download.addClickListener(e -> download.getUI().ifPresent(ui -> ui.getPage().open("/mail/attachments/" + attachment.getId())));
+        download.addClickListener(e -> download.getUI().ifPresent(ui -> ui.getPage().open("/api/mail/attachments/" + attachment.getId())));
 
         HorizontalLayout textWrapper = new HorizontalLayout(name, size);
         textWrapper.setAlignItems(Alignment.BASELINE);

--- a/src/main/java/com/esvar/dekanat/mail/ChatEntity.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatEntity.java
@@ -12,7 +12,8 @@ import java.time.Instant;
 
 @Entity
 @Table(name = "mail_chat", indexes = {
-        @Index(name = "idx_mail_chat_peer_email", columnList = "peer_email", unique = true),
+        @Index(name = "idx_mail_chat_peer_email", columnList = "peer_email"),
+        @Index(name = "idx_mail_chat_thread_key", columnList = "thread_key", unique = true),
         @Index(name = "idx_mail_chat_last_message_at", columnList = "last_message_at")
 })
 @Getter
@@ -26,7 +27,16 @@ public class ChatEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "peer_email", nullable = false, unique = true, length = 320)
+    @Column(name = "thread_key", nullable = false, unique = true, length = 700)
+    private String threadKey;
+
+    @Column(name = "title", length = 500)
+    private String title;
+
+    @Column(name = "normalized_subject", length = 500)
+    private String normalizedSubject;
+
+    @Column(name = "peer_email", nullable = false, length = 320)
     private String peerEmail;
 
     @Column(name = "display_name", length = 255)
@@ -42,6 +52,15 @@ public class ChatEntity {
 
     @Column(name = "has_unprocessed", nullable = false)
     private boolean hasUnprocessed = false;
+
+    @Column(name = "unread_count", nullable = false)
+    private int unreadCount = 0;
+
+    @Column(name = "has_attachments", nullable = false)
+    private boolean hasAttachments = false;
+
+    @Column(name = "last_snippet", length = 1000)
+    private String lastSnippet;
 
     @Column(name = "last_message_at")
     private Instant lastMessageAt;

--- a/src/main/java/com/esvar/dekanat/mail/ChatRepository.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatRepository.java
@@ -3,6 +3,8 @@ package com.esvar.dekanat.mail;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,9 +14,18 @@ public interface ChatRepository extends JpaRepository<ChatEntity, Long> {
 
     Optional<ChatEntity> findByPeerEmail(String peerEmail);
 
-    Page<ChatEntity> findByPeerEmailContainingIgnoreCaseAndDisplayNameContainingIgnoreCaseAndStatusIn(
-            String peerEmail, String displayName, Iterable<ChatStatus> statuses, Pageable pageable);
+    Optional<ChatEntity> findByThreadKey(String threadKey);
 
-    Page<ChatEntity> findByPeerEmailContainingIgnoreCaseAndDisplayNameContainingIgnoreCase(
-            String peerEmail, String displayName, Pageable pageable);
+    @Query("""
+            select c from ChatEntity c
+            where (:statusesEmpty = true or c.status in :statuses)
+              and (lower(c.peerEmail) like lower(concat('%', :query, '%'))
+                or lower(coalesce(c.displayName,'')) like lower(concat('%', :query, '%'))
+                or lower(coalesce(c.title,'')) like lower(concat('%', :query, '%')))
+            """)
+    Page<ChatEntity> search(@Param("query") String query,
+                            @Param("statuses") Iterable<ChatStatus> statuses,
+                            @Param("statusesEmpty") boolean statusesEmpty,
+                            Pageable pageable);
+
 }

--- a/src/main/java/com/esvar/dekanat/mail/ChatService.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatService.java
@@ -1,12 +1,17 @@
 package com.esvar.dekanat.mail;
 
 import com.esvar.dekanat.mail.dto.AttachmentDto;
+import com.esvar.dekanat.mail.dto.ChatFilter;
 import com.esvar.dekanat.mail.dto.ChatListItemDto;
 import com.esvar.dekanat.mail.dto.ChatMessageDetailDto;
-import com.esvar.dekanat.mail.dto.ChatMessageHeaderDto;
-import com.esvar.dekanat.mail.dto.ChatFilter;
-import jakarta.mail.*;
+import jakarta.mail.BodyPart;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Part;
 import jakarta.mail.internet.MimeMessage;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.mail.MailProperties;
 import org.springframework.data.domain.Page;
@@ -18,12 +23,15 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import org.springframework.web.util.HtmlUtils;
+import org.springframework.web.util.UriUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -39,6 +47,9 @@ public class ChatService {
     private final MailSyncProperties properties;
     private final MailProperties mailProperties;
     private final String defaultFrom;
+
+    public record AttachmentContent(InputStream stream, String contentType, String filename) {
+    }
 
     public ChatService(ChatRepository chatRepository,
                        MailMessageRepository mailMessageRepository,
@@ -63,38 +74,69 @@ public class ChatService {
         String query = filter != null && StringUtils.hasText(filter.getQuery()) ? filter.getQuery() : "";
         Sort sort = pageable.getSort().isUnsorted() ? Sort.by(Sort.Direction.DESC, "lastMessageAt") : pageable.getSort();
         Pageable effectivePageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
-        Page<ChatEntity> page;
-        if (filter != null && filter.getStatuses() != null && !filter.getStatuses().isEmpty()) {
-            page = chatRepository.findByPeerEmailContainingIgnoreCaseAndDisplayNameContainingIgnoreCaseAndStatusIn(
-                    query, query, filter.getStatuses(), effectivePageable);
-        } else {
-            page = chatRepository.findByPeerEmailContainingIgnoreCaseAndDisplayNameContainingIgnoreCase(
-                    query, query, effectivePageable);
-        }
+        List<ChatStatus> statuses = filter != null && filter.getStatuses() != null ? filter.getStatuses() : List.of();
+        boolean statusesEmpty = statuses.isEmpty();
+        Page<ChatEntity> page = chatRepository.search(query, statuses, statusesEmpty, effectivePageable);
         return page.map(this::toDto);
     }
 
     @Transactional(readOnly = true)
-    public Page<ChatMessageHeaderDto> findMessageHeaders(Long chatId, Pageable pageable) {
-        Page<MailMessageEntity> page = mailMessageRepository.findByChatId(chatId, pageable);
-        return page.map(this::toHeaderDto);
+    public List<ChatMessageDetailDto> findThreadMessages(String threadKey, int limit, Instant before) throws MessagingException {
+        Pageable pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "sentAt"));
+        Page<MailMessageEntity> page = before != null
+                ? mailMessageRepository.findByThreadKeyAndSentAtBefore(threadKey, before, pageable)
+                : mailMessageRepository.findByThreadKey(threadKey, pageable);
+        List<MailMessageEntity> messages = new ArrayList<>(page.getContent());
+        messages.sort(Comparator.comparing(MailMessageEntity::getSentAt, Comparator.nullsLast(Comparator.naturalOrder())));
+
+        List<ChatMessageDetailDto> details = new ArrayList<>();
+        for (MailMessageEntity message : messages) {
+            details.add(toDetailDto(message));
+        }
+        return details;
+    }
+
+    @Transactional
+    public ChatMessageDetailDto getMessageDetails(Long messageId) throws MessagingException {
+        MailMessageEntity entity = mailMessageRepository.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("Message not found"));
+        return toDetailDto(entity);
     }
 
     public void updateStatus(Long chatId, ChatStatus status) {
-        ChatEntity chat = chatRepository.findById(chatId).orElseThrow();
-        chat.setStatus(status);
-        chatRepository.save(chat);
-    }
-
-    public void markProcessed(Long chatId) {
         chatRepository.findById(chatId).ifPresent(chat -> {
+            chat.setStatus(status);
             chat.setHasUnprocessed(false);
             chatRepository.save(chat);
         });
     }
 
+    public void updateStatus(String threadKey, ChatStatus status) {
+        chatRepository.findByThreadKey(threadKey).ifPresent(chat -> {
+            chat.setStatus(status);
+            chat.setHasUnprocessed(false);
+            chatRepository.save(chat);
+        });
+    }
+
+    public void markProcessed(Long chatId) {
+        chatRepository.findById(chatId).ifPresent(chat -> {
+            chat.setHasUnprocessed(false);
+            chat.setUnreadCount(0);
+            chatRepository.save(chat);
+        });
+    }
+
+    public void markProcessed(String threadKey) {
+        chatRepository.findByThreadKey(threadKey).ifPresent(chat -> {
+            chat.setHasUnprocessed(false);
+            chat.setUnreadCount(0);
+            chatRepository.save(chat);
+        });
+    }
+
     @Transactional(readOnly = true)
-    public InputStream loadAttachment(String messageId, String attachmentId) throws MessagingException {
+    public AttachmentContent loadAttachment(String messageId, String attachmentId) throws MessagingException {
         MailAttachmentMetaEntity meta = attachmentRepository.findByMessage_MessageIdAndPartId(messageId, attachmentId);
         if (meta == null) {
             throw new IllegalArgumentException("Attachment not found");
@@ -103,16 +145,35 @@ public class ChatService {
     }
 
     @Transactional(readOnly = true)
-    public InputStream loadAttachment(Long attachmentMetaId) throws MessagingException {
+    public AttachmentContent loadAttachment(Long attachmentMetaId) throws MessagingException {
         MailAttachmentMetaEntity meta = attachmentRepository.findById(attachmentMetaId)
                 .orElseThrow(() -> new IllegalArgumentException("Attachment not found"));
         return loadAttachment(meta);
     }
 
-    private InputStream loadAttachment(MailAttachmentMetaEntity meta) throws MessagingException {
+    @Transactional(readOnly = true)
+    public AttachmentContent loadInline(Long messageId, String contentId) throws MessagingException {
+        MailMessageEntity entity = mailMessageRepository.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("Message not found"));
+        String normalizedCid = normalizeContentId(contentId);
+        MailAttachmentMetaEntity meta = attachmentRepository.findByMessage_IdAndContentId(messageId, normalizedCid);
+        Message mimeMessage = mailImapClient.getMessage(entity.getFolder(), entity.getUid());
+        MailpartExtractor.InlineContent inlineContent = MailpartExtractor.extractInlineContent(mimeMessage, normalizedCid);
+        if (inlineContent == null) {
+            throw new IllegalArgumentException("Inline attachment not found");
+        }
+        String contentType = inlineContent.contentType() != null
+                ? inlineContent.contentType()
+                : (meta != null ? meta.getContentType() : "application/octet-stream");
+        String filename = meta != null ? meta.getFilename() : null;
+        return new AttachmentContent(inlineContent.stream(), contentType, filename);
+    }
+
+    private AttachmentContent loadAttachment(MailAttachmentMetaEntity meta) throws MessagingException {
         MailMessageEntity message = meta.getMessage();
         Message mimeMessage = mailImapClient.getMessage(message.getFolder(), message.getUid());
-        return MailpartExtractor.extractAttachmentStream(mimeMessage, meta.getPartId());
+        InputStream stream = MailpartExtractor.extractAttachmentStream(mimeMessage, meta.getPartId());
+        return new AttachmentContent(stream, meta.getContentType(), meta.getFilename());
     }
 
     public void replyToChat(Long chatId, String body, String subjectOverride) {
@@ -134,12 +195,6 @@ public class ChatService {
             lastMessage.map(MailMessageEntity::getMessageId).ifPresent(id -> {
                 try {
                     mimeMessage.setHeader("In-Reply-To", id);
-                } catch (MessagingException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-            lastMessage.map(MailMessageEntity::getMessageId).ifPresent(id -> {
-                try {
                     mimeMessage.setHeader("References", id);
                 } catch (MessagingException e) {
                     throw new RuntimeException(e);
@@ -162,37 +217,49 @@ public class ChatService {
     }
 
     private ChatListItemDto toDto(ChatEntity chat) {
+        String resolvedTitle = StringUtils.hasText(chat.getTitle()) ? chat.getTitle() : MailThreadUtils.stripPrefixes(chat.getNormalizedSubject());
         return ChatListItemDto.builder()
                 .id(chat.getId())
-                .displayName(StringUtils.hasText(chat.getDisplayName()) ? chat.getDisplayName() : "Невідомий")
+                .threadKey(chat.getThreadKey())
+                .title(resolvedTitle)
+                .displayName(StringUtils.hasText(chat.getDisplayName()) ? chat.getDisplayName() : chat.getPeerEmail())
                 .peerEmail(chat.getPeerEmail())
                 .orgUnit(chat.getOrgUnit())
                 .status(chat.getStatus())
                 .hasUnprocessed(chat.isHasUnprocessed())
+                .unreadCount(chat.getUnreadCount())
                 .lastMessageAt(chat.getLastMessageAt())
+                .lastSnippet(chat.getLastSnippet())
+                .hasAttachments(chat.isHasAttachments())
                 .build();
     }
 
-    @Transactional
-    public ChatMessageDetailDto getMessageDetails(Long messageId) throws MessagingException {
-        MailMessageEntity entity = mailMessageRepository.findById(messageId)
-                .orElseThrow(() -> new IllegalArgumentException("Message not found"));
-
+    private ChatMessageDetailDto toDetailDto(MailMessageEntity entity) throws MessagingException {
         MailpartExtractor.BodyContent body = ensureContentCached(entity);
 
         String htmlText = body != null && body.html() != null ? body.html() : "";
         String plainText = body != null && body.plain() != null ? body.plain() : "";
-
-        MailReplySplitter.SplitResult split = MailReplySplitter.split(plainText);
-        String replyText = split.reply();
-        String quotedText = split.quoted();
-
-        String quotedHtml = "";
-        if (StringUtils.hasText(quotedText)) {
-            quotedHtml = "<pre style=\"white-space:pre-wrap;\">" +
-                    escapeHtml(quotedText) +
-                    "</pre>";
+        if (!StringUtils.hasText(plainText) && StringUtils.hasText(htmlText)) {
+            plainText = MailTextExtractor.toPlainText(htmlText);
         }
+
+        String bodyTextClean = MailQuotedStripper.stripQuotedPlain(plainText);
+        String sanitizedHtml = StringUtils.hasText(htmlText) ? MailTextExtractor.sanitizeHtml(htmlText) : "";
+        String bodyHtmlClean = MailQuotedStripper.stripQuotedHtml(sanitizedHtml);
+
+        if (!StringUtils.hasText(bodyTextClean) && StringUtils.hasText(bodyHtmlClean)) {
+            bodyTextClean = MailTextExtractor.toPlainText(bodyHtmlClean);
+        }
+
+        String htmlWithInline = rewriteInlineCid(sanitizedHtml, entity.getId());
+        String cleanHtmlWithInline = rewriteInlineCid(bodyHtmlClean, entity.getId());
+        if (!StringUtils.hasText(cleanHtmlWithInline) && StringUtils.hasText(bodyTextClean)) {
+            cleanHtmlWithInline = toSimpleHtml(bodyTextClean);
+        }
+
+        String snippet = StringUtils.hasText(entity.getSnippet())
+                ? entity.getSnippet()
+                : MailTextExtractor.sanitizeSnippet(bodyTextClean, 500);
 
         return ChatMessageDetailDto.builder()
                 .id(entity.getId())
@@ -200,34 +267,20 @@ public class ChatService {
                 .from(entity.getFromEmail())
                 .to(entity.getToEmail())
                 .subject(entity.getSubject())
-                .bodyHtml(htmlText)
-                .bodyText(replyText)
-                .quotedText(quotedText)
-                .quotedHtml(quotedHtml)
-                .snippet(entity.getSnippet())
-                .sentAt(entity.getSentAt())
-                .direction(entity.getDirection())
-                .hasAttachments(entity.isHasAttachments())
-                .attachments(entity.getAttachments().stream().map(this::toAttachmentDto).collect(Collectors.toList()))
-                .build();
-    }
-
-    private ChatMessageHeaderDto toHeaderDto(MailMessageEntity entity) {
-        String snippet = entity.getSnippet();
-        if (!StringUtils.hasText(snippet) && StringUtils.hasText(entity.getCachedPlainBody())) {
-            snippet = MailTextExtractor.sanitizeSnippet(entity.getCachedPlainBody(), 500);
-        }
-
-        return ChatMessageHeaderDto.builder()
-                .id(entity.getId())
-                .messageId(entity.getMessageId())
-                .from(entity.getFromEmail())
-                .to(entity.getToEmail())
-                .subject(entity.getSubject())
+                .bodyHtml(htmlWithInline)
+                .bodyHtmlClean(cleanHtmlWithInline)
+                .bodyText(plainText)
+                .bodyTextClean(bodyTextClean)
+                .quotedText("")
+                .quotedHtml("")
                 .snippet(snippet)
                 .sentAt(entity.getSentAt())
                 .direction(entity.getDirection())
                 .hasAttachments(entity.isHasAttachments())
+                .attachments(entity.getAttachments().stream()
+                        .filter(att -> !att.isInline())
+                        .map(this::toAttachmentDto)
+                        .collect(Collectors.toList()))
                 .build();
     }
 
@@ -259,7 +312,9 @@ public class ChatService {
                 finalPlain = entity.getSnippet();
             }
 
-            persistContent(entity, sanitizedHtml, finalPlain, message);
+            String cleanPlain = MailQuotedStripper.stripQuotedPlain(finalPlain);
+
+            persistContent(entity, sanitizedHtml, finalPlain, cleanPlain, message);
 
             return new MailpartExtractor.BodyContent(sanitizedHtml, finalPlain);
         } catch (MessagingException e) {
@@ -272,14 +327,13 @@ public class ChatService {
         }
     }
 
-    private void persistContent(MailMessageEntity entity, String html, String plain, Message message) throws MessagingException, IOException {
+    private void persistContent(MailMessageEntity entity, String html, String plain, String cleanPlain, Message message) throws MessagingException, IOException {
         String sanitizedPlain = StringUtils.hasText(plain) ? plain : "";
         entity.setCachedHtmlBody(html);
         entity.setCachedPlainBody(sanitizedPlain);
 
-        if (!StringUtils.hasText(entity.getSnippet())) {
-            entity.setSnippet(MailTextExtractor.sanitizeSnippet(sanitizedPlain, 500));
-        }
+        String snippetSource = StringUtils.hasText(cleanPlain) ? cleanPlain : sanitizedPlain;
+        entity.setSnippet(MailTextExtractor.sanitizeSnippet(snippetSource, 500));
 
         List<MailAttachmentMetaEntity> attachments = new ArrayList<>();
         collectAttachments(message, "", attachments);
@@ -287,9 +341,18 @@ public class ChatService {
         initializeAttachments(entity);
         entity.getAttachments().clear();
         entity.getAttachments().addAll(attachments);
-        entity.setHasAttachments(!entity.getAttachments().isEmpty());
+        entity.setHasAttachments(attachments.stream().anyMatch(att -> !att.isInline()));
         entity.setContentLoadedAt(Instant.now());
         mailMessageRepository.save(entity);
+
+        ChatEntity chat = entity.getChat();
+        if (chat != null && (chat.getLastMessageAt() == null
+                || entity.getSentAt() == null
+                || !chat.getLastMessageAt().isAfter(entity.getSentAt()))) {
+            chat.setLastSnippet(entity.getSnippet());
+            chat.setHasAttachments(chat.isHasAttachments() || entity.isHasAttachments());
+            chatRepository.save(chat);
+        }
     }
 
     private void initializeAttachments(MailMessageEntity entity) {
@@ -309,23 +372,20 @@ public class ChatService {
             return;
         }
 
-        if (Part.ATTACHMENT.equalsIgnoreCase(part.getDisposition()) || StringUtils.hasText(part.getFileName())) {
+        String contentId = MailpartExtractor.extractContentId(part);
+        boolean inline = Part.INLINE.equalsIgnoreCase(part.getDisposition()) || (StringUtils.hasText(contentId) && part.isMimeType("image/*"));
+        boolean downloadable = Part.ATTACHMENT.equalsIgnoreCase(part.getDisposition()) || StringUtils.hasText(part.getFileName());
+
+        if (inline || downloadable) {
             attachments.add(MailAttachmentMetaEntity.builder()
                     .partId(partId.isEmpty() ? "part" : partId)
                     .filename(part.getFileName())
                     .contentType(part.getContentType())
                     .sizeBytes(part.getSize() >= 0 ? (long) part.getSize() : null)
+                    .contentId(contentId)
+                    .inline(inline)
                     .build());
         }
-    }
-
-    private static String escapeHtml(String s) {
-        if (s == null) return "";
-        return s.replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;")
-                .replace("\"", "&quot;")
-                .replace("'", "&#39;");
     }
 
     private static class Extracted {
@@ -336,7 +396,6 @@ public class ChatService {
 
     private Extracted extractTextFallback(Part part) throws MessagingException {
         try {
-            // 1) Базові текстові типи
             if (part.isMimeType("text/plain")) {
                 String text = safeText(part);
                 return new Extracted(StringUtils.hasText(text) ? text : null, null);
@@ -346,54 +405,44 @@ public class ChatService {
                 return new Extracted(null, StringUtils.hasText(html) ? html : null);
             }
 
-            // 2) Вкладене повідомлення
             if (part.isMimeType("message/rfc822")) {
                 Object c = part.getContent();
                 if (c instanceof Part p) return extractTextFallback(p);
                 return new Extracted(null, null);
             }
 
-            // 3) Мультипарти
             if (part.isMimeType("multipart/*")) {
                 Multipart mp = (Multipart) part.getContent();
                 String plain = null;
                 String html = null;
 
-                // Спец-випадок: multipart/alternative (plain+html)
                 boolean isAlternative = part.isMimeType("multipart/alternative");
-
-                // Спец-випадок: multipart/related (html + inline resources)
                 boolean isRelated = part.isMimeType("multipart/related");
 
                 for (int i = 0; i < mp.getCount(); i++) {
                     BodyPart bp = mp.getBodyPart(i);
 
-                    // ❌ Пропускаємо вкладення/ресурси
                     if (shouldSkipBodyPart(bp)) continue;
 
                     Extracted ex = extractTextFallback(bp);
 
-                    // В alternative: html важливіше, але plain теж треба
                     if (StringUtils.hasText(ex.html) && !StringUtils.hasText(html)) {
                         html = ex.html;
-                        if (isAlternative && StringUtils.hasText(plain)) break; // вже є і plain і html
+                        if (isAlternative && StringUtils.hasText(plain)) break;
                     }
                     if (StringUtils.hasText(ex.plain) && !StringUtils.hasText(plain)) {
                         plain = ex.plain;
                         if (isAlternative && StringUtils.hasText(html)) break;
                     }
 
-                    // У related часто достатньо лише html (plain може не існувати)
                     if (isRelated && StringUtils.hasText(html)) {
-                        // але не break якщо хочеш ще plain, тут зазвичай можна break
-                        // break;
+                        // intentionally continue to allow plain extraction if available
                     }
                 }
 
                 return new Extracted(plain, html);
             }
 
-            // Інші mime-типы ігноруємо
             return new Extracted(null, null);
 
         } catch (Exception ex) {
@@ -406,19 +455,10 @@ public class ChatService {
         String fileName = bp.getFileName();
         String ct = bp.getContentType() != null ? bp.getContentType().toLowerCase() : "";
 
-        // 1) Явні вкладення
         if (disp != null && disp.equalsIgnoreCase(Part.ATTACHMENT)) return true;
-
-        // 2) Inline з filename — дуже часто це теж “вкладення”
         if (disp != null && disp.equalsIgnoreCase(Part.INLINE) && StringUtils.hasText(fileName)) return true;
-
-        // 3) Inline картинки / ресурси в multipart/related
         if (disp != null && disp.equalsIgnoreCase(Part.INLINE) && ct.startsWith("image/")) return true;
-
-        // 4) Часто зустрічається: application/* як частина листа — це не body
         if (ct.startsWith("application/")) return true;
-
-        // 5) Іноді “вкладення” без disposition але з filename
         if (StringUtils.hasText(fileName) && !bp.isMimeType("text/*")) return true;
 
         return false;
@@ -428,10 +468,8 @@ public class ChatService {
         Object c = part.getContent();
         if (c == null) return null;
 
-        // JavaMail може повернути String або InputStream залежно від декодування
         if (c instanceof String s) return s;
 
-        // Якщо раптом повернув stream — читаємо обережно
         if (c instanceof java.io.InputStream is) {
             return new String(is.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
         }
@@ -447,5 +485,37 @@ public class ChatService {
                 .sizeBytes(attachment.getSizeBytes())
                 .mimeType(attachment.getContentType())
                 .build();
+    }
+
+    private String rewriteInlineCid(String html, Long messageId) {
+        if (!StringUtils.hasText(html) || messageId == null) {
+            return html != null ? html : "";
+        }
+        Document document = Jsoup.parse(html);
+        document.select("img[src^=cid:], img[src^=CID:]").forEach(img -> {
+            String src = img.attr("src");
+            String cid = src.length() > 4 ? src.substring(4) : "";
+            String url = "/api/mail/messages/" + messageId + "/inline/" + UriUtils.encodePath(cid, StandardCharsets.UTF_8);
+            img.attr("src", url);
+        });
+        return document.body().html();
+    }
+
+    private String toSimpleHtml(String text) {
+        return HtmlUtils.htmlEscape(text).replace("\n", "<br/>");
+    }
+
+    private String normalizeContentId(String contentId) {
+        if (contentId == null) {
+            return null;
+        }
+        String cleaned = contentId.trim();
+        if (cleaned.startsWith("<") && cleaned.endsWith(">")) {
+            cleaned = cleaned.substring(1, cleaned.length() - 1);
+        }
+        if (cleaned.startsWith("cid:")) {
+            cleaned = cleaned.substring(4);
+        }
+        return cleaned;
     }
 }

--- a/src/main/java/com/esvar/dekanat/mail/ConversationView.java
+++ b/src/main/java/com/esvar/dekanat/mail/ConversationView.java
@@ -2,7 +2,6 @@ package com.esvar.dekanat.mail;
 
 import com.esvar.dekanat.mail.dto.ChatListItemDto;
 import com.esvar.dekanat.mail.dto.ChatMessageDetailDto;
-import com.esvar.dekanat.mail.dto.ChatMessageHeaderDto;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
@@ -15,10 +14,6 @@ import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import jakarta.mail.MessagingException;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.util.CollectionUtils;
 
 import java.time.LocalDate;
@@ -40,13 +35,12 @@ public class ConversationView extends VerticalLayout {
     private final ComboBox<ChatStatus> statusComboBox = new ComboBox<>("Статус");
     private final Button markProcessedButton = new Button("Позначити опрацьованим");
     private final Button closeButton = new Button("Закрити");
-    private final Button loadMoreButton = new Button("Завантажити попередні");
     private final Span metaInfo = new Span();
     private final Div messagesContainer = new Div();
+    private final H3 title = new H3("Діалог");
 
     private ChatListItemDto currentChat;
-    private int currentPage = 0;
-    private final List<ChatMessageHeaderDto> loadedMessages = new ArrayList<>();
+    private final List<ChatMessageDetailDto> loadedMessages = new ArrayList<>();
     private Consumer<ChatListItemDto> chatUpdateListener;
 
     private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm")
@@ -58,7 +52,7 @@ public class ConversationView extends VerticalLayout {
         setSizeFull();
         setPadding(false);
         setSpacing(false);
-        add(buildHeader(), buildMessagesArea(), buildLoadMore());
+        add(buildHeader(), buildMessagesArea());
     }
 
     public void setChatUpdateListener(Consumer<ChatListItemDto> chatUpdateListener) {
@@ -67,29 +61,17 @@ public class ConversationView extends VerticalLayout {
 
     public void showChat(ChatListItemDto chat) {
         this.currentChat = chat;
-        this.currentPage = 0;
         this.loadedMessages.clear();
         updateHeaderState();
-        loadPage(true);
+        loadMessages();
     }
 
     private Component buildHeader() {
-        H3 title = new H3("Діалог");
-        title.addClassName("conversation-title");
-
         statusComboBox.setItems(ChatStatus.values());
         statusComboBox.addValueChangeListener(e -> {
             if (currentChat != null && e.getValue() != null && e.isFromClient()) {
                 chatService.updateStatus(currentChat.getId(), e.getValue());
-                currentChat = ChatListItemDto.builder()
-                        .id(currentChat.getId())
-                        .displayName(currentChat.getDisplayName())
-                        .peerEmail(currentChat.getPeerEmail())
-                        .orgUnit(currentChat.getOrgUnit())
-                        .status(e.getValue())
-                        .hasUnprocessed(false)
-                        .lastMessageAt(currentChat.getLastMessageAt())
-                        .build();
+                currentChat = rebuildChat(currentChat, e.getValue(), false, currentChat.getUnreadCount());
                 notifyChatUpdated();
                 updateHeaderState();
             }
@@ -103,15 +85,7 @@ public class ConversationView extends VerticalLayout {
             chatService.markProcessed(currentChat.getId());
             ChatStatus newStatus = currentChat.getStatus() == ChatStatus.NEW ? ChatStatus.IN_PROGRESS : currentChat.getStatus();
             chatService.updateStatus(currentChat.getId(), newStatus);
-            currentChat = ChatListItemDto.builder()
-                    .id(currentChat.getId())
-                    .displayName(currentChat.getDisplayName())
-                    .peerEmail(currentChat.getPeerEmail())
-                    .orgUnit(currentChat.getOrgUnit())
-                    .status(newStatus)
-                    .hasUnprocessed(false)
-                    .lastMessageAt(currentChat.getLastMessageAt())
-                    .build();
+            currentChat = rebuildChat(currentChat, newStatus, false, 0);
             notifyChatUpdated();
             updateHeaderState();
         });
@@ -122,20 +96,13 @@ public class ConversationView extends VerticalLayout {
                 return;
             }
             chatService.updateStatus(currentChat.getId(), ChatStatus.CLOSED);
-            currentChat = ChatListItemDto.builder()
-                    .id(currentChat.getId())
-                    .displayName(currentChat.getDisplayName())
-                    .peerEmail(currentChat.getPeerEmail())
-                    .orgUnit(currentChat.getOrgUnit())
-                    .status(ChatStatus.CLOSED)
-                    .hasUnprocessed(false)
-                    .lastMessageAt(currentChat.getLastMessageAt())
-                    .build();
+            currentChat = rebuildChat(currentChat, ChatStatus.CLOSED, false, currentChat.getUnreadCount());
             notifyChatUpdated();
             updateHeaderState();
         });
 
         metaInfo.addClassName("conversation-meta");
+        title.addClassName("conversation-title");
 
         HorizontalLayout left = new HorizontalLayout(title, statusComboBox, markProcessedButton, closeButton);
         left.setDefaultVerticalComponentAlignment(FlexComponent.Alignment.CENTER);
@@ -158,29 +125,20 @@ public class ConversationView extends VerticalLayout {
         return messagesContainer;
     }
 
-    private Component buildLoadMore() {
-        loadMoreButton.setWidthFull();
-        loadMoreButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
-        loadMoreButton.addClickListener(e -> loadPage(false));
-        loadMoreButton.setVisible(false);
-        Div wrapper = new Div(loadMoreButton);
-        wrapper.addClassName("conversation-load-more");
-        return wrapper;
-    }
-
     private void updateHeaderState() {
         boolean hasChat = currentChat != null;
         statusComboBox.setEnabled(hasChat);
         markProcessedButton.setEnabled(hasChat);
         closeButton.setEnabled(hasChat);
-        loadMoreButton.setEnabled(hasChat);
         if (!hasChat) {
             messagesContainer.removeAll();
             messagesContainer.add(new Span("Оберіть діалог"));
             metaInfo.setText("");
+            title.setText("Діалог");
             return;
         }
         statusComboBox.setValue(currentChat.getStatus());
+        title.setText(currentChat.getTitle());
         metaInfo.setText(buildMetaText());
     }
 
@@ -188,39 +146,39 @@ public class ConversationView extends VerticalLayout {
         if (CollectionUtils.isEmpty(loadedMessages)) {
             return "";
         }
-        ChatMessageHeaderDto last = loadedMessages.get(loadedMessages.size() - 1);
+        ChatMessageDetailDto last = loadedMessages.get(loadedMessages.size() - 1);
         String lastTime = last.getSentAt() != null ? dateTimeFormatter.format(last.getSentAt()) : "";
         return String.format("Останнє повідомлення: %s • %d повідомлень", lastTime, loadedMessages.size());
     }
 
-    private void loadPage(boolean initial) {
+    private void loadMessages() {
         if (currentChat == null) {
             return;
         }
-        Pageable pageable = PageRequest.of(currentPage, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "sentAt"));
-        Page<ChatMessageHeaderDto> page = chatService.findMessageHeaders(currentChat.getId(), pageable);
-        List<ChatMessageHeaderDto> batch = new ArrayList<>(page.getContent());
-        batch.sort(Comparator.comparing(ChatMessageHeaderDto::getSentAt, Comparator.nullsLast(Comparator.naturalOrder())));
-
-        loadedMessages.addAll(batch);
-        loadedMessages.sort(Comparator.comparing(ChatMessageHeaderDto::getSentAt, Comparator.nullsLast(Comparator.naturalOrder())));
-
-        renderMessages(initial);
-
-        loadMoreButton.setVisible(page.hasNext());
-        if (page.hasNext()) {
-            currentPage++;
-        }
-        metaInfo.setText(buildMetaText());
-        if (initial) {
+        messagesContainer.removeAll();
+        messagesContainer.add(new Span("Завантаження..."));
+        try {
+            List<ChatMessageDetailDto> batch = chatService.findThreadMessages(currentChat.getThreadKey(), PAGE_SIZE, null);
+            loadedMessages.clear();
+            loadedMessages.addAll(batch);
+            loadedMessages.sort(Comparator.comparing(ChatMessageDetailDto::getSentAt, Comparator.nullsLast(Comparator.naturalOrder())));
+            renderMessages();
+            metaInfo.setText(buildMetaText());
             messagesContainer.getElement().executeJs("this.scrollTop = this.scrollHeight;");
+        } catch (MessagingException e) {
+            messagesContainer.removeAll();
+            messagesContainer.add(new Span("Не вдалося завантажити тему."));
         }
     }
 
-    private void renderMessages(boolean initial) {
+    private void renderMessages() {
         messagesContainer.removeAll();
+        if (loadedMessages.isEmpty()) {
+            messagesContainer.add(new Span("Немає повідомлень у темі"));
+            return;
+        }
         LocalDate lastDate = null;
-        for (ChatMessageHeaderDto message : loadedMessages) {
+        for (ChatMessageDetailDto message : loadedMessages) {
             LocalDate date = Optional.ofNullable(message.getSentAt())
                     .map(instant -> instant.atZone(ZoneId.systemDefault()).toLocalDate())
                     .orElse(null);
@@ -228,19 +186,28 @@ public class ConversationView extends VerticalLayout {
                 messagesContainer.add(new MessageDateDivider(date != null ? dateFormatter.format(date) : ""));
                 lastDate = date;
             }
-            messagesContainer.add(new MessageBubble(message, this::loadMessageDetails));
-        }
-        if (!initial) {
-            messagesContainer.getElement().executeJs("this.scrollTop = this.scrollHeight;");
+            messagesContainer.add(new MessageBubble(message));
         }
     }
 
-    private ChatMessageDetailDto loadMessageDetails(Long messageId) {
-        try {
-            return chatService.getMessageDetails(messageId);
-        } catch (MessagingException e) {
-            throw new IllegalStateException("Не вдалося завантажити повідомлення", e);
+    private ChatListItemDto rebuildChat(ChatListItemDto chat, ChatStatus status, boolean hasUnprocessed, int unreadCount) {
+        if (chat == null) {
+            return null;
         }
+        return ChatListItemDto.builder()
+                .id(chat.getId())
+                .threadKey(chat.getThreadKey())
+                .title(chat.getTitle())
+                .displayName(chat.getDisplayName())
+                .peerEmail(chat.getPeerEmail())
+                .orgUnit(chat.getOrgUnit())
+                .status(status)
+                .hasUnprocessed(hasUnprocessed)
+                .unreadCount(unreadCount)
+                .lastMessageAt(chat.getLastMessageAt())
+                .lastSnippet(chat.getLastSnippet())
+                .hasAttachments(chat.isHasAttachments())
+                .build();
     }
 
     private void notifyChatUpdated() {

--- a/src/main/java/com/esvar/dekanat/mail/MailAttachmentMetaEntity.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailAttachmentMetaEntity.java
@@ -35,4 +35,10 @@ public class MailAttachmentMetaEntity {
 
     @Column(name = "size_bytes")
     private Long sizeBytes;
+
+    @Column(name = "content_id", length = 255)
+    private String contentId;
+
+    @Column(name = "inline_attachment", nullable = false)
+    private boolean inline;
 }

--- a/src/main/java/com/esvar/dekanat/mail/MailAttachmentMetaRepository.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailAttachmentMetaRepository.java
@@ -11,4 +11,6 @@ public interface MailAttachmentMetaRepository extends JpaRepository<MailAttachme
     List<MailAttachmentMetaEntity> findByMessageId(Long messageId);
 
     MailAttachmentMetaEntity findByMessage_MessageIdAndPartId(String messageId, String partId);
+
+    MailAttachmentMetaEntity findByMessage_IdAndContentId(Long messageId, String contentId);
 }

--- a/src/main/java/com/esvar/dekanat/mail/MailController.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailController.java
@@ -3,7 +3,6 @@ package com.esvar.dekanat.mail;
 import com.esvar.dekanat.mail.dto.ChatFilter;
 import com.esvar.dekanat.mail.dto.ChatListItemDto;
 import com.esvar.dekanat.mail.dto.ChatMessageDetailDto;
-import com.esvar.dekanat.mail.dto.ChatMessageHeaderDto;
 import com.esvar.dekanat.mail.dto.ReplyRequest;
 import jakarta.mail.MessagingException;
 import org.springframework.data.domain.Page;
@@ -17,10 +16,11 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.InputStream;
+import java.time.Instant;
+import java.util.List;
 
 @RestController
-@RequestMapping("/mail")
+@RequestMapping("/api/mail")
 @RolesAllowed({"ROLE_ADMIN", "ROLE_DEKANAT"})
 public class MailController {
 
@@ -30,7 +30,7 @@ public class MailController {
         this.chatService = chatService;
     }
 
-    @GetMapping("/chats")
+    @GetMapping("/threads")
     public Page<ChatListItemDto> getChats(@RequestParam(name = "q", required = false) String query,
                                           @RequestParam(name = "page", defaultValue = "0") int page,
                                           @RequestParam(name = "size", defaultValue = "20") int size) {
@@ -40,12 +40,11 @@ public class MailController {
         return chatService.findChats(filter, pageable);
     }
 
-    @GetMapping("/chats/{chatId}/messages")
-    public Page<ChatMessageHeaderDto> getMessages(@PathVariable Long chatId,
-                                                  @RequestParam(name = "page", defaultValue = "0") int page,
-                                                  @RequestParam(name = "size", defaultValue = "50") int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "sentAt"));
-        return chatService.findMessageHeaders(chatId, pageable);
+    @GetMapping("/threads/{threadKey}/messages")
+    public List<ChatMessageDetailDto> getThreadMessages(@PathVariable String threadKey,
+                                                        @RequestParam(name = "limit", defaultValue = "30") int limit,
+                                                        @RequestParam(name = "before", required = false) Instant before) throws MessagingException {
+        return chatService.findThreadMessages(threadKey, limit, before);
     }
 
     @GetMapping("/messages/{messageId}")
@@ -53,38 +52,51 @@ public class MailController {
         return chatService.getMessageDetails(messageId);
     }
 
-    @PostMapping("/chats/{chatId}/status")
+    @PostMapping("/threads/{chatId}/status")
     public void updateStatus(@PathVariable Long chatId, @RequestParam ChatStatus status) {
         chatService.updateStatus(chatId, status);
     }
 
-    @PostMapping("/chats/{chatId}/processed")
+    @PostMapping("/threads/{chatId}/processed")
     public void markProcessed(@PathVariable Long chatId) {
         chatService.markProcessed(chatId);
     }
 
-    @PostMapping("/chats/{chatId}/reply")
+    @PostMapping("/threads/{chatId}/reply")
     public void reply(@PathVariable Long chatId, @RequestBody ReplyRequest request) {
         chatService.replyToChat(chatId, request.getBody(), request.getSubject());
     }
 
     @GetMapping("/attachments/{attachmentId}")
     public ResponseEntity<InputStreamResource> downloadAttachment(@PathVariable Long attachmentId) throws MessagingException {
-        InputStream stream = chatService.loadAttachment(attachmentId);
-        return buildAttachmentResponse(stream);
+        ChatService.AttachmentContent content = chatService.loadAttachment(attachmentId);
+        return buildAttachmentResponse(content);
     }
 
     @GetMapping("/messages/{messageId}/attachments/{attachmentId}")
     public ResponseEntity<InputStreamResource> downloadAttachment(@PathVariable String messageId,
                                                                   @PathVariable String attachmentId) throws MessagingException {
-        InputStream stream = chatService.loadAttachment(messageId, attachmentId);
-        return buildAttachmentResponse(stream);
+        ChatService.AttachmentContent content = chatService.loadAttachment(messageId, attachmentId);
+        return buildAttachmentResponse(content);
     }
 
-    private ResponseEntity<InputStreamResource> buildAttachmentResponse(InputStream stream) {
+    @GetMapping("/messages/{messageId}/inline/{cid}")
+    public ResponseEntity<InputStreamResource> loadInline(@PathVariable Long messageId,
+                                                          @PathVariable String cid) throws MessagingException {
+        ChatService.AttachmentContent content = chatService.loadInline(messageId, cid);
         return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment")
-                .contentType(MediaType.APPLICATION_OCTET_STREAM)
-                .body(new InputStreamResource(stream));
+                .contentType(MediaType.parseMediaType(content.contentType()))
+                .body(new InputStreamResource(content.stream()));
+    }
+
+    private ResponseEntity<InputStreamResource> buildAttachmentResponse(ChatService.AttachmentContent content) {
+        String disposition = "attachment";
+        if (content.filename() != null) {
+            disposition += "; filename=\"" + content.filename() + "\"";
+        }
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, disposition)
+                .contentType(MediaType.parseMediaType(content.contentType() != null ? content.contentType() : MediaType.APPLICATION_OCTET_STREAM_VALUE))
+                .body(new InputStreamResource(content.stream()));
     }
 }

--- a/src/main/java/com/esvar/dekanat/mail/MailInboxView.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailInboxView.java
@@ -6,8 +6,13 @@ import com.esvar.dekanat.view.MainLayout;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.dependency.CssImport;
+import com.vaadin.flow.component.grid.ColumnTextAlign;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
@@ -55,7 +60,7 @@ public class MailInboxView extends VerticalLayout {
     }
 
     private HorizontalLayout buildToolbar() {
-        searchField.setPlaceholder("Email або ПІБ");
+        searchField.setPlaceholder("Тема або email");
         searchField.setClearButtonVisible(true);
         searchField.addValueChangeListener(e -> chatGrid.getDataProvider().refreshAll());
 
@@ -88,21 +93,60 @@ public class MailInboxView extends VerticalLayout {
         CallbackDataProvider<ChatListItemDto, Void> dataProvider = new CallbackDataProvider<>(
                 this::fetchChats, this::countChats);
         chatGrid.setDataProvider(dataProvider);
-        chatGrid.addThemeVariants(GridVariant.LUMO_ROW_STRIPES);
+        chatGrid.addThemeVariants(GridVariant.LUMO_NO_BORDER, GridVariant.LUMO_NO_ROW_BORDERS);
         chatGrid.setHeightFull();
 
-        chatGrid.addColumn(ChatListItemDto::getDisplayName).setHeader("ПІБ").setFlexGrow(1);
-        chatGrid.addColumn(ChatListItemDto::getPeerEmail).setHeader("Email").setFlexGrow(1);
-        chatGrid.addColumn(ChatListItemDto::getOrgUnit).setHeader("Факультет/Кафедра").setFlexGrow(1);
-        chatGrid.addColumn(item -> item.getStatus().name()).setHeader("Статус").setWidth("140px");
-        chatGrid.addColumn(item -> item.isHasUnprocessed() ? "1" : "0").setHeader("Неопрацьовано").setWidth("140px");
+        chatGrid.addComponentColumn(this::buildThreadPreview)
+                .setHeader("Темы")
+                .setFlexGrow(1);
         chatGrid.addColumn(item -> item.getLastMessageAt() != null ? dateTimeFormatter.format(item.getLastMessageAt()) : "")
-                .setHeader("Останнє").setWidth("180px");
+                .setHeader("Останнє")
+                .setWidth("180px")
+                .setTextAlign(ColumnTextAlign.END);
+        chatGrid.addColumn(item -> item.getStatus().name()).setHeader("Статус").setWidth("140px");
 
         chatGrid.asSingleSelect().addValueChangeListener(event -> {
             selectedChat = event.getValue();
             conversationView.showChat(selectedChat);
         });
+    }
+
+    private Div buildThreadPreview(ChatListItemDto item) {
+        Div wrapper = new Div();
+        wrapper.addClassName("thread-preview");
+
+        Span title = new Span(item.getTitle());
+        title.addClassName("thread-title");
+
+        Span counterparty = new Span((item.getDisplayName() != null ? item.getDisplayName() : "") + " • " + item.getPeerEmail());
+        counterparty.addClassName("thread-counterparty");
+
+        Span snippet = new Span(item.getLastSnippet() != null ? item.getLastSnippet() : "");
+        snippet.addClassName("thread-snippet");
+
+        HorizontalLayout badges = new HorizontalLayout();
+        badges.setSpacing(true);
+        badges.setPadding(false);
+        badges.setDefaultVerticalComponentAlignment(FlexComponent.Alignment.CENTER);
+
+        if (item.getUnreadCount() > 0 || item.isHasUnprocessed()) {
+            Span unread = new Span(item.getUnreadCount() > 0 ? item.getUnreadCount() + " нових" : "нове");
+            unread.addClassName("thread-unread");
+            badges.add(unread);
+        }
+
+        if (item.isHasAttachments()) {
+            Icon clip = VaadinIcon.PAPERCLIP.create();
+            clip.addClassName("thread-attachment");
+            badges.add(clip);
+        }
+
+        Span status = new Span(item.getStatus().name());
+        status.addClassName("thread-status");
+        badges.add(status);
+
+        wrapper.add(title, counterparty, snippet, badges);
+        return wrapper;
     }
 
     private java.util.stream.Stream<ChatListItemDto> fetchChats(Query<ChatListItemDto, Void> query) {

--- a/src/main/java/com/esvar/dekanat/mail/MailMessageEntity.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailMessageEntity.java
@@ -14,7 +14,8 @@ import java.util.List;
 @Entity
 @Table(name = "mail_message", indexes = {
         @Index(name = "idx_mail_message_peer_email_date", columnList = "peer_email, sent_at"),
-        @Index(name = "idx_mail_message_folder_uid", columnList = "folder, uid")
+        @Index(name = "idx_mail_message_folder_uid", columnList = "folder, uid"),
+        @Index(name = "idx_mail_message_thread_key_date", columnList = "thread_key, sent_at")
 })
 @Getter
 @Setter
@@ -33,6 +34,12 @@ public class MailMessageEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_id", nullable = false)
     private ChatEntity chat;
+
+    @Column(name = "thread_key", nullable = false, length = 700)
+    private String threadKey;
+
+    @Column(name = "normalized_subject", length = 500)
+    private String normalizedSubject;
 
     @Column(name = "peer_email", nullable = false, length = 320)
     private String peerEmail;

--- a/src/main/java/com/esvar/dekanat/mail/MailMessageRepository.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailMessageRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.time.Instant;
 import java.util.Optional;
 
 @Repository
@@ -16,4 +16,10 @@ public interface MailMessageRepository extends JpaRepository<MailMessageEntity, 
     Page<MailMessageEntity> findByChatId(Long chatId, Pageable pageable);
 
     Optional<MailMessageEntity> findTop1ByChatIdOrderBySentAtDesc(Long chatId);
+
+    Page<MailMessageEntity> findByThreadKey(String threadKey, Pageable pageable);
+
+    Page<MailMessageEntity> findByThreadKeyAndSentAtBefore(String threadKey, Instant before, Pageable pageable);
+
+    Optional<MailMessageEntity> findTop1ByThreadKeyOrderBySentAtDesc(String threadKey);
 }

--- a/src/main/java/com/esvar/dekanat/mail/MailQuotedStripper.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailQuotedStripper.java
@@ -1,0 +1,81 @@
+package com.esvar.dekanat.mail;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Utility methods for removing quoted history from emails.
+ */
+public final class MailQuotedStripper {
+
+    private static final Pattern QUOTE_HEADER = Pattern.compile(
+            "(?im)^\\s*(" +
+                    "On\\s.+wrote:|" +
+                    ".+\\sпише:|" +
+                    ".+\\sписав\\(ла\\):|" +
+                    "-----\\s*Original Message\\s*-----|" +
+                    "-----\\s*Forwarded message\\s*-----|" +
+                    "From:|" +
+                    "Від:|" +
+                    "От:|" +
+                    "Sent:|" +
+                    "Дата:|" +
+                    "To:|" +
+                    "Кому:|" +
+                    "Subject:|" +
+                    "Тема:" +
+                    ")\\s*$"
+    );
+
+    private static final Set<String> HTML_QUOTE_SELECTORS = new HashSet<>(Arrays.asList(
+            "blockquote",
+            ".gmail_quote",
+            ".gmail_extra",
+            ".yahoo_quoted",
+            ".moz-cite-prefix",
+            "[class*=moz-cite-prefix]"
+    ));
+
+    private MailQuotedStripper() {
+    }
+
+    public static String stripQuotedPlain(String text) {
+        if (!StringUtils.hasText(text)) {
+            return "";
+        }
+        String normalized = text.replace("\r\n", "\n").replace("\r", "\n");
+        String[] lines = normalized.split("\n", -1);
+        StringBuilder result = new StringBuilder();
+        for (String line : lines) {
+            String trimmed = line.stripLeading();
+            if (trimmed.startsWith(">")) {
+                break;
+            }
+            if (trimmed.startsWith("-- ")) {
+                break;
+            }
+            if (QUOTE_HEADER.matcher(trimmed).find()) {
+                break;
+            }
+            result.append(line).append("\n");
+        }
+        return result.toString().replaceFirst("(?s)\\n+$", "").trim();
+    }
+
+    public static String stripQuotedHtml(String html) {
+        if (!StringUtils.hasText(html)) {
+            return "";
+        }
+        Document document = Jsoup.parse(html);
+        String selectors = HTML_QUOTE_SELECTORS.stream().collect(Collectors.joining(","));
+        document.select(selectors).remove();
+        return MailTextExtractor.sanitizeHtml(document.body().html());
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailSyncService.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailSyncService.java
@@ -10,7 +10,6 @@ import jakarta.mail.internet.InternetAddress;
 import org.eclipse.angus.mail.imap.IMAPFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.domain.Sort;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,7 +18,6 @@ import org.springframework.util.StringUtils;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Date;
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -101,12 +99,21 @@ public class MailSyncService {
             return;
         }
 
-        ChatEntity chat = chatRepository.findByPeerEmail(peerEmail)
-                .orElseGet(() -> createChat(peerEmail));
+        String normalizedSubject = MailThreadUtils.normalizeSubject(message.getSubject());
+        String threadKey = MailThreadUtils.buildThreadKey(peerEmail, message.getSubject());
+        String title = MailThreadUtils.stripPrefixes(message.getSubject());
+
+        ChatEntity chat = chatRepository.findByThreadKey(threadKey)
+                .orElseGet(() -> createChat(peerEmail, threadKey, title, normalizedSubject));
+
+        String cleanPlain = MailQuotedStripper.stripQuotedPlain(MailpartExtractor.extractPlainText(message));
+        String snippet = MailTextExtractor.sanitizeSnippet(StringUtils.hasText(cleanPlain) ? cleanPlain : title, 500);
 
         MailMessageEntity entity = MailMessageEntity.builder()
                 .messageId(messageId)
                 .chat(chat)
+                .threadKey(threadKey)
+                .normalizedSubject(normalizedSubject)
                 .peerEmail(peerEmail)
                 .folder(folder.getFullName())
                 .uid(folder.getUID(message))
@@ -115,14 +122,22 @@ public class MailSyncService {
                 .toEmail(extractAddress(message.getRecipients(Message.RecipientType.TO)))
                 .subject(message.getSubject())
                 .hasAttachments(hasAttachments(message))
+                .snippet(snippet)
                 .direction(direction)
                 .build();
 
         mailMessageRepository.save(entity);
 
+        chat.setThreadKey(threadKey);
+        chat.setTitle(title);
+        chat.setNormalizedSubject(normalizedSubject);
+        chat.setPeerEmail(peerEmail);
         chat.setLastMessageAt(entity.getSentAt());
+        chat.setLastSnippet(entity.getSnippet());
+        chat.setHasAttachments(chat.isHasAttachments() || entity.isHasAttachments());
         if (direction == MessageDirection.IN) {
             chat.setHasUnprocessed(true);
+            chat.setUnreadCount(chat.getUnreadCount() + 1);
         }
         chatRepository.save(chat);
     }
@@ -162,14 +177,20 @@ public class MailSyncService {
         return address.toString();
     }
 
-    private ChatEntity createChat(String peerEmail) {
+    private ChatEntity createChat(String peerEmail, String threadKey, String title, String normalizedSubject) {
         ChatProfileResolver.ResolvedProfile profile = profileResolver.resolve(peerEmail);
         return chatRepository.save(ChatEntity.builder()
+                .threadKey(threadKey)
                 .peerEmail(peerEmail)
+                .title(title)
+                .normalizedSubject(normalizedSubject)
                 .displayName(profile.displayName())
                 .orgUnit(profile.orgUnit())
                 .status(ChatStatus.NEW)
                 .hasUnprocessed(false)
+                .unreadCount(0)
+                .hasAttachments(false)
+                .lastSnippet(null)
                 .lastMessageAt(null)
                 .build());
     }

--- a/src/main/java/com/esvar/dekanat/mail/MailThreadUtils.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailThreadUtils.java
@@ -1,0 +1,43 @@
+package com.esvar.dekanat.mail;
+
+import org.springframework.util.StringUtils;
+
+import java.text.Normalizer;
+
+public final class MailThreadUtils {
+
+    private MailThreadUtils() {
+    }
+
+    public static String normalizeSubject(String subject) {
+        String base = stripPrefixes(subject);
+        String normalized = Normalizer.normalize(base, Normalizer.Form.NFKC)
+                .replaceAll("\\s+", " ")
+                .trim()
+                .toLowerCase();
+        return StringUtils.hasText(normalized) ? normalized : "(no subject)";
+    }
+
+    public static String stripPrefixes(String subject) {
+        if (!StringUtils.hasText(subject)) {
+            return "Без теми";
+        }
+        String result = subject;
+        boolean changed;
+        do {
+            changed = false;
+            String trimmed = result.stripLeading();
+            if (trimmed.matches("(?i)^(re|fw|fwd|aw|пере?д|відповідь)\\s*[:\\]\\)\\-]*\\s*.*")) {
+                result = trimmed.replaceFirst("(?i)^(re|fw|fwd|aw|пере?д|відповідь)\\s*[:\\]\\)\\-]*\\s*", "");
+                changed = true;
+            }
+        } while (changed);
+        return result.strip();
+    }
+
+    public static String buildThreadKey(String peerEmail, String subject) {
+        String peer = StringUtils.hasText(peerEmail) ? peerEmail.trim().toLowerCase() : "(unknown)";
+        String normalizedSubject = normalizeSubject(subject);
+        return peer + "|" + normalizedSubject;
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mail/MailpartExtractor.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailpartExtractor.java
@@ -42,6 +42,26 @@ public final class MailpartExtractor {
         return new BodyContent(collector.html, collector.plain);
     }
 
+    public static InlineContent extractInlineContent(Message message, String contentId) {
+        try {
+            Part part = findInlinePart(message, normalizeContentId(contentId), "");
+            if (part == null) {
+                return null;
+            }
+            return new InlineContent(part.getInputStream(), part.getContentType());
+        } catch (Exception e) {
+            throw new IllegalStateException("Cannot load inline resource: " + e.getMessage(), e);
+        }
+    }
+
+    public static String extractContentId(Part part) throws MessagingException {
+        String[] ids = part.getHeader("Content-ID");
+        if (ids == null || ids.length == 0) {
+            return null;
+        }
+        return normalizeContentId(ids[0]);
+    }
+
     private static Optional<Part> findAttachment(Part part, String targetPartId, String currentPartId) throws MessagingException, IOException {
         if (part.isMimeType("multipart/*")) {
             Multipart multipart = (Multipart) part.getContent();
@@ -61,6 +81,26 @@ public final class MailpartExtractor {
             }
         }
         return Optional.empty();
+    }
+
+    private static Part findInlinePart(Part part, String targetContentId, String currentPartId) throws MessagingException, IOException {
+        if (part.isMimeType("multipart/*")) {
+            Multipart multipart = (Multipart) part.getContent();
+            for (int i = 0; i < multipart.getCount(); i++) {
+                BodyPart bodyPart = multipart.getBodyPart(i);
+                String childPartId = currentPartId.isEmpty() ? String.valueOf(i + 1) : currentPartId + "." + (i + 1);
+                Part match = findInlinePart(bodyPart, targetContentId, childPartId);
+                if (match != null) {
+                    return match;
+                }
+            }
+            return null;
+        }
+        String contentId = extractContentId(part);
+        if (StringUtils.hasText(targetContentId) && targetContentId.equalsIgnoreCase(contentId)) {
+            return part;
+        }
+        return null;
     }
 
     private static String extractText(Part part, String partId) throws MessagingException, IOException {
@@ -126,5 +166,22 @@ public final class MailpartExtractor {
     }
 
     public record BodyContent(String html, String plain) {
+    }
+
+    public record InlineContent(InputStream stream, String contentType) {
+    }
+
+    private static String normalizeContentId(String contentId) {
+        if (contentId == null) {
+            return null;
+        }
+        String cleaned = contentId.trim();
+        if (cleaned.startsWith("<") && cleaned.endsWith(">")) {
+            cleaned = cleaned.substring(1, cleaned.length() - 1);
+        }
+        if (cleaned.startsWith("cid:")) {
+            cleaned = cleaned.substring(4);
+        }
+        return cleaned;
     }
 }

--- a/src/main/java/com/esvar/dekanat/mail/MessageBubble.java
+++ b/src/main/java/com/esvar/dekanat/mail/MessageBubble.java
@@ -2,7 +2,6 @@ package com.esvar.dekanat.mail;
 
 import com.esvar.dekanat.mail.dto.AttachmentDto;
 import com.esvar.dekanat.mail.dto.ChatMessageDetailDto;
-import com.esvar.dekanat.mail.dto.ChatMessageHeaderDto;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
@@ -23,16 +22,12 @@ public class MessageBubble extends Div {
 
     private final Div bodyWrapper = new Div();
     private final Div attachmentsWrapper = new Div();
-    private final MessageDetailLoader detailLoader;
+    private final ChatMessageDetailDto detail;
 
-    private ChatMessageHeaderDto header;
-    private ChatMessageDetailDto detail;
-
-    public MessageBubble(ChatMessageHeaderDto header, MessageDetailLoader detailLoader) {
-        this.header = header;
-        this.detailLoader = detailLoader;
+    public MessageBubble(ChatMessageDetailDto detail) {
+        this.detail = detail;
         addClassName("message-bubble");
-        addClassName(header.getDirection() == MessageDirection.IN ? "incoming" : "outgoing");
+        addClassName(detail.getDirection() == MessageDirection.IN ? "incoming" : "outgoing");
 
         bodyWrapper.addClassName("bubble-body");
         attachmentsWrapper.addClassName("bubble-attachments");
@@ -40,23 +35,17 @@ public class MessageBubble extends Div {
         add(buildHeader(), bodyWrapper, attachmentsWrapper);
         renderBody();
         renderAttachments();
-
-        addClickListener(e -> {
-            if (detail == null) {
-                loadDetails();
-            }
-        });
     }
 
     private Component buildHeader() {
-        Span directionBadge = new Span(header.getDirection() == MessageDirection.IN ? "Вхідне" : "Вихідне");
+        Span directionBadge = new Span(detail.getDirection() == MessageDirection.IN ? "Вхідне" : "Вихідне");
         directionBadge.addClassName("direction-badge");
-        directionBadge.addClassName(header.getDirection() == MessageDirection.IN ? "incoming-badge" : "outgoing-badge");
+        directionBadge.addClassName(detail.getDirection() == MessageDirection.IN ? "incoming-badge" : "outgoing-badge");
 
         Span addresses = new Span(shortAddress());
         addresses.addClassName("bubble-address");
 
-        Span time = new Span(header.getSentAt() != null ? timeFormatter.format(header.getSentAt()) : "");
+        Span time = new Span(detail.getSentAt() != null ? timeFormatter.format(detail.getSentAt()) : "");
         time.addClassName("message-time");
 
         HorizontalLayout header = new HorizontalLayout(directionBadge, addresses, time);
@@ -69,39 +58,22 @@ public class MessageBubble extends Div {
 
     private void renderBody() {
         bodyWrapper.removeAll();
-        if (detail == null) {
-            String previewText = toSafeHtml(Optional.ofNullable(header.getSnippet()).orElse("Натисніть, щоб завантажити"));
-            Span preview = new Span();
-            preview.addClassName("message-body-html");
-            preview.getElement().setProperty("innerHTML", previewText);
-            bodyWrapper.add(preview);
-            return;
-        }
-
-        QuoteCollapsePanel.QuoteExtraction extraction = QuoteCollapsePanel.extract(detail.getBodyText());
-        boolean hasQuote = extraction.hasQuote();
-        String mainHtml;
-        if (!hasQuote && StringUtils.hasText(detail.getBodyHtml())) {
+        String mainHtml = detail.getBodyHtmlClean();
+        if (!StringUtils.hasText(mainHtml)) {
             mainHtml = detail.getBodyHtml();
-        } else {
-            mainHtml = toSafeHtml(extraction.main());
+        }
+        if (!StringUtils.hasText(mainHtml)) {
+            mainHtml = toSafeHtml(Optional.ofNullable(detail.getBodyTextClean()).orElse(detail.getBodyText()));
         }
 
         Span body = new Span();
         body.addClassName("message-body-html");
         body.getElement().setProperty("innerHTML", mainHtml);
         bodyWrapper.add(body);
-
-        if (hasQuote) {
-            bodyWrapper.add(new QuoteCollapsePanel(toSafeHtml(extraction.quote())));
-        }
     }
 
     private void renderAttachments() {
         attachmentsWrapper.removeAll();
-        if (detail == null) {
-            return;
-        }
         List<AttachmentDto> attachments = detail.getAttachments();
         if (attachments != null && !attachments.isEmpty()) {
             attachmentsWrapper.add(new AttachmentList(attachments));
@@ -109,10 +81,10 @@ public class MessageBubble extends Div {
     }
 
     private String shortAddress() {
-        if (header.getDirection() == MessageDirection.IN) {
-            return "Від: " + Optional.ofNullable(header.getFrom()).orElse("");
+        if (detail.getDirection() == MessageDirection.IN) {
+            return "Від: " + Optional.ofNullable(detail.getFrom()).orElse("");
         }
-        return "Кому: " + Optional.ofNullable(header.getTo()).orElse("");
+        return "Кому: " + Optional.ofNullable(detail.getTo()).orElse("");
     }
 
     private String toSafeHtml(String text) {
@@ -120,22 +92,5 @@ public class MessageBubble extends Div {
             return "";
         }
         return HtmlUtils.htmlEscape(text).replace("\n", "<br/>");
-    }
-
-    private void loadDetails() {
-        if (detailLoader == null) {
-            return;
-        }
-        ChatMessageDetailDto loaded = detailLoader.load(header.getId());
-        if (loaded != null) {
-            this.detail = loaded;
-            renderBody();
-            renderAttachments();
-        }
-    }
-
-    @FunctionalInterface
-    public interface MessageDetailLoader {
-        ChatMessageDetailDto load(Long messageId);
     }
 }

--- a/src/main/java/com/esvar/dekanat/mail/dto/ChatListItemDto.java
+++ b/src/main/java/com/esvar/dekanat/mail/dto/ChatListItemDto.java
@@ -10,10 +10,15 @@ import java.time.Instant;
 @Builder
 public class ChatListItemDto {
     Long id;
+    String threadKey;
+    String title;
     String displayName;
     String peerEmail;
     String orgUnit;
     ChatStatus status;
     boolean hasUnprocessed;
+    int unreadCount;
     Instant lastMessageAt;
+    String lastSnippet;
+    boolean hasAttachments;
 }

--- a/src/main/java/com/esvar/dekanat/mail/dto/ChatMessageDetailDto.java
+++ b/src/main/java/com/esvar/dekanat/mail/dto/ChatMessageDetailDto.java
@@ -16,7 +16,9 @@ public class ChatMessageDetailDto {
     String to;
     String subject;
     String bodyHtml;
+    String bodyHtmlClean;
     String bodyText;
+    String bodyTextClean;
     String quotedText;
     String quotedHtml;
     String snippet;


### PR DESCRIPTION
## Summary
- group emails into lightweight threads using normalized subjects and counterparty addresses, persisting snippets without quoted history and inline-aware attachment metadata
- expose new /api/mail thread/message endpoints, inline content streaming, and quoted/HTML cleaning for message bodies
- refresh the Vaadin inbox to show thread previews and a chat-style view of the latest messages with loading states and cleaned content

## Testing
- ./mvnw test *(fails: cannot download Maven wrapper artifacts in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947ccf67e9c8326b4d7812cdecd5e74)