### PR TITLE
Adjust module control teacher name formatting

### DIFF
--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -1059,9 +1059,7 @@ public class EnterMarksView extends Div {
 
     private String getCurrentUserFullNameSurnameFirst() {
         return securityService.getCurrentUserModel()
-                .map(u -> capitalize(u.getLastname()) + " "
-                        + capitalize(u.getFirstname()) + " "
-                        + capitalize(u.getPatronymic()))
+                .map(u -> capitalize(u.getFirstname()) + " " + u.getLastname().toUpperCase())
                 .orElse("");
     }
 


### PR DESCRIPTION
## Summary
- format the current teacher name used in module control documents as "First LAST" instead of including patronymic

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947ed8439c08326922ce66d54e5cc0a)