### PR TITLE
Set fixed teacher names for module control reports

### DIFF
--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -86,6 +86,8 @@ public class EnterMarksView extends Div {
     private static final String CONTROL_TYPE_CONTROL_WORK = "Контрольна робота";
     private static final String SYSTEM_USER_DISPLAY_NAME = "Система";
     private static final String DATE_TIME_PATTERN = "dd.MM.yyyy HH:mm";
+    private static final String EXAMINER_NAME = "Павло ГОНЧАР";
+    private static final String FINAL_GRADE_TEACHER_NAME = "Гончар Павло Олександрович";
 
     private final FacultyService facultyService;
     private final DepartmentService departmentService;
@@ -1022,8 +1024,8 @@ public class EnterMarksView extends Div {
         String controlTypeName = selectControlType.getValue();
         String hours = String.valueOf(plansEntity.getHours());
         // Приклад з фіксованими значеннями для викладачів
-        String firstTeacher = getCurrentUserFullNameSurnameFirst();
-        String gradeTeacher = getCurrentUserFullName();
+        String firstTeacher = EXAMINER_NAME;
+        String gradeTeacher = FINAL_GRADE_TEACHER_NAME;
 
         // Формуємо список студентів для друку
         List<StudentModelToDocumentGenerate> students = new ArrayList<>();
@@ -1155,8 +1157,8 @@ public class EnterMarksView extends Div {
         String semesterNumber = String.valueOf(plansEntity.getSemester());
         String controlTypeName = selectControlType.getValue();
         String hours = String.valueOf(plansEntity.getHours());
-        String firstTeacher = getCurrentUserFullNameSurnameFirst();
-        String gradeTeacher = getCurrentUserFullName();
+        String firstTeacher = EXAMINER_NAME;
+        String gradeTeacher = FINAL_GRADE_TEACHER_NAME;
         String qualityTrue = "Якість1";
         String qualityFalse = "Якість2";
 


### PR DESCRIPTION
## Summary
- add constants for the examiner and final-grade teacher names
- use the fixed teacher names in first- and second-module report generation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694817bcc69c83269f4a18068154d7f8)