### PR TITLE
Set fixed teacher names for module control reports

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/pdf/FirstModulePdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/FirstModulePdfGenerator.java
@@ -418,19 +418,29 @@ public class FirstModulePdfGenerator implements PdfGenerator {
 
     private String resolveSignatureName(DataModelForMC1 data) {
         if (!isBlank(data.secondTeacher())) {
-            return data.secondTeacher();
+            return formatExaminerName(data.secondTeacher());
         }
         if (!isBlank(data.gradeTeacher())) {
-            return data.gradeTeacher();
+            return formatExaminerName(data.gradeTeacher());
         }
         if (!isBlank(data.firstTeacher())) {
-            return data.firstTeacher();
+            return formatExaminerName(data.firstTeacher());
         }
         return "";
     }
 
     private boolean isBlank(String value) {
         return value == null || value.isBlank();
+    }
+
+    private String formatExaminerName(String fullName) {
+        String[] parts = Objects.toString(fullName, "").trim().split("\\s+");
+        if (parts.length >= 2) {
+            String surname = parts[0].toUpperCase();
+            String firstName = parts[1];
+            return firstName + " " + surname;
+        }
+        return Objects.toString(fullName, "");
     }
 
     private Cell createHeaderCell(String text, PdfFont font) {

--- a/src/main/java/com/esvar/dekanat/generate/pdf/SecondModulePdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/SecondModulePdfGenerator.java
@@ -440,19 +440,29 @@ public class SecondModulePdfGenerator implements PdfGenerator {
 
     private String resolveSignatureName(DataModelForMC2 data) {
         if (!isBlank(data.secondTeacher())) {
-            return data.secondTeacher();
+            return formatExaminerName(data.secondTeacher());
         }
         if (!isBlank(data.gradeTeacher())) {
-            return data.gradeTeacher();
+            return formatExaminerName(data.gradeTeacher());
         }
         if (!isBlank(data.firstTeacher())) {
-            return data.firstTeacher();
+            return formatExaminerName(data.firstTeacher());
         }
         return "";
     }
 
     private boolean isBlank(String value) {
         return value == null || value.isBlank();
+    }
+
+    private String formatExaminerName(String fullName) {
+        String[] parts = Objects.toString(fullName, "").trim().split("\\s+");
+        if (parts.length >= 2) {
+            String surname = parts[0].toUpperCase();
+            String firstName = parts[1];
+            return firstName + " " + surname;
+        }
+        return Objects.toString(fullName, "");
     }
 
     private SummaryCounts calculateSummaryCounts(List<StudentModelToDocumentGenerate> students) {

--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -86,6 +86,7 @@ public class EnterMarksView extends Div {
     private static final String CONTROL_TYPE_CONTROL_WORK = "Контрольна робота";
     private static final String SYSTEM_USER_DISPLAY_NAME = "Система";
     private static final String DATE_TIME_PATTERN = "dd.MM.yyyy HH:mm";
+    private static final String MODULE_CONTROL_TEACHER_FULL_NAME = "Гончар Павло Олександрович";
 
     private final FacultyService facultyService;
     private final DepartmentService departmentService;
@@ -1022,8 +1023,8 @@ public class EnterMarksView extends Div {
         String controlTypeName = selectControlType.getValue();
         String hours = String.valueOf(plansEntity.getHours());
         // Приклад з фіксованими значеннями для викладачів
-        String firstTeacher = getCurrentUserFullNameSurnameFirst();
-        String gradeTeacher = getCurrentUserFullName();
+        String firstTeacher = MODULE_CONTROL_TEACHER_FULL_NAME;
+        String gradeTeacher = MODULE_CONTROL_TEACHER_FULL_NAME;
 
         // Формуємо список студентів для друку
         List<StudentModelToDocumentGenerate> students = new ArrayList<>();
@@ -1155,8 +1156,8 @@ public class EnterMarksView extends Div {
         String semesterNumber = String.valueOf(plansEntity.getSemester());
         String controlTypeName = selectControlType.getValue();
         String hours = String.valueOf(plansEntity.getHours());
-        String firstTeacher = getCurrentUserFullNameSurnameFirst();
-        String gradeTeacher = getCurrentUserFullName();
+        String firstTeacher = MODULE_CONTROL_TEACHER_FULL_NAME;
+        String gradeTeacher = MODULE_CONTROL_TEACHER_FULL_NAME;
         String qualityTrue = "Якість1";
         String qualityFalse = "Якість2";
 


### PR DESCRIPTION
## Summary
- set module control teacher values to full name for first and second teacher fields
- format examiner signature to the required "Ім'я ПРІЗВИЩЕ" layout in module control PDFs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694817bcc69c83269f4a18068154d7f8)