### PR TITLE
Refactor mail chats to be contact-based

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/ChatEntity.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatEntity.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 @Entity
 @Table(name = "mail_chat", indexes = {
         @Index(name = "idx_mail_chat_peer_email", columnList = "peer_email"),
+        @Index(name = "idx_mail_chat_contact_email", columnList = "contact_email"),
         @Index(name = "idx_mail_chat_thread_key", columnList = "thread_key", unique = true),
         @Index(name = "idx_mail_chat_last_message_at", columnList = "last_message_at")
 })
@@ -38,6 +39,9 @@ public class ChatEntity {
 
     @Column(name = "peer_email", nullable = false, length = 320)
     private String peerEmail;
+
+    @Column(name = "contact_email", nullable = false, length = 320)
+    private String contactEmail;
 
     @Column(name = "display_name", length = 255)
     private String displayName;

--- a/src/main/java/com/esvar/dekanat/mail/ChatRepository.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatRepository.java
@@ -14,12 +14,14 @@ public interface ChatRepository extends JpaRepository<ChatEntity, Long> {
 
     Optional<ChatEntity> findByPeerEmail(String peerEmail);
 
+    Optional<ChatEntity> findByContactEmail(String contactEmail);
+
     Optional<ChatEntity> findByThreadKey(String threadKey);
 
     @Query("""
             select c from ChatEntity c
             where (:statusesEmpty = true or c.status in :statuses)
-              and (lower(c.peerEmail) like lower(concat('%', :query, '%'))
+              and (lower(c.contactEmail) like lower(concat('%', :query, '%'))
                 or lower(coalesce(c.displayName,'')) like lower(concat('%', :query, '%'))
                 or lower(coalesce(c.title,'')) like lower(concat('%', :query, '%')))
             """)

--- a/src/main/java/com/esvar/dekanat/mail/ChatService.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatService.java
@@ -32,7 +32,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -82,14 +81,11 @@ public class ChatService {
     }
 
     @Transactional(readOnly = true)
-    public List<ChatMessageDetailDto> findThreadMessages(String threadKey, int limit, Instant before) throws MessagingException {
-        Pageable pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "sentAt"));
-        Page<MailMessageEntity> page = before != null
-                ? mailMessageRepository.findByThreadKeyAndSentAtBefore(threadKey, before, pageable)
-                : mailMessageRepository.findByThreadKey(threadKey, pageable);
-        List<MailMessageEntity> messages = new ArrayList<>(page.getContent());
-        messages.sort(Comparator.comparing(MailMessageEntity::getSentAt, Comparator.nullsLast(Comparator.naturalOrder())));
-
+    public List<ChatMessageDetailDto> findChatMessages(String contactEmail, Instant before) throws MessagingException {
+        String normalizedContact = StringUtils.hasText(contactEmail) ? contactEmail.trim().toLowerCase() : contactEmail;
+        List<MailMessageEntity> messages = before != null
+                ? mailMessageRepository.findByContactEmailAndSentAtBeforeOrderBySentAtDesc(normalizedContact, before)
+                : mailMessageRepository.findByContactEmailOrderBySentAtDesc(normalizedContact);
         List<ChatMessageDetailDto> details = new ArrayList<>();
         for (MailMessageEntity message : messages) {
             details.add(toDetailDto(message));
@@ -112,24 +108,8 @@ public class ChatService {
         });
     }
 
-    public void updateStatus(String threadKey, ChatStatus status) {
-        chatRepository.findByThreadKey(threadKey).ifPresent(chat -> {
-            chat.setStatus(status);
-            chat.setHasUnprocessed(false);
-            chatRepository.save(chat);
-        });
-    }
-
     public void markProcessed(Long chatId) {
         chatRepository.findById(chatId).ifPresent(chat -> {
-            chat.setHasUnprocessed(false);
-            chat.setUnreadCount(0);
-            chatRepository.save(chat);
-        });
-    }
-
-    public void markProcessed(String threadKey) {
-        chatRepository.findByThreadKey(threadKey).ifPresent(chat -> {
             chat.setHasUnprocessed(false);
             chat.setUnreadCount(0);
             chatRepository.save(chat);
@@ -188,7 +168,7 @@ public class ChatService {
 
     public void replyToChat(Long chatId, String body, String subjectOverride) {
         ChatEntity chat = chatRepository.findById(chatId).orElseThrow();
-        String to = chat.getPeerEmail();
+        String to = chat.getContactEmail();
         Optional<MailMessageEntity> lastMessage = mailMessageRepository.findTop1ByChatIdOrderBySentAtDesc(chatId);
 
         MimeMessage mimeMessage = mailSender.createMimeMessage();
@@ -227,14 +207,12 @@ public class ChatService {
     }
 
     private ChatListItemDto toDto(ChatEntity chat) {
-        String resolvedTitle = StringUtils.hasText(chat.getTitle()) ? chat.getTitle() : MailThreadUtils.stripPrefixes(chat.getNormalizedSubject());
+        String contact = StringUtils.hasText(chat.getContactEmail()) ? chat.getContactEmail() : chat.getPeerEmail();
+        String display = StringUtils.hasText(chat.getDisplayName()) ? chat.getDisplayName() : contact;
         return ChatListItemDto.builder()
                 .id(chat.getId())
-                .threadKey(chat.getThreadKey())
-                .title(resolvedTitle)
-                .displayName(StringUtils.hasText(chat.getDisplayName()) ? chat.getDisplayName() : chat.getPeerEmail())
-                .peerEmail(chat.getPeerEmail())
-                .orgUnit(chat.getOrgUnit())
+                .contactEmail(contact)
+                .displayName(display)
                 .status(chat.getStatus())
                 .hasUnprocessed(chat.isHasUnprocessed())
                 .unreadCount(chat.getUnreadCount())

--- a/src/main/java/com/esvar/dekanat/mail/ConversationView.java
+++ b/src/main/java/com/esvar/dekanat/mail/ConversationView.java
@@ -15,12 +15,12 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import jakarta.mail.MessagingException;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -28,8 +28,6 @@ import java.util.function.Consumer;
 
 @CssImport("./styles/conversation-view.css")
 public class ConversationView extends VerticalLayout {
-
-    private static final int PAGE_SIZE = 30;
 
     private final ChatService chatService;
     private final ComboBox<ChatStatus> statusComboBox = new ComboBox<>("Статус");
@@ -138,7 +136,7 @@ public class ConversationView extends VerticalLayout {
             return;
         }
         statusComboBox.setValue(currentChat.getStatus());
-        title.setText(currentChat.getTitle());
+        title.setText(StringUtils.hasText(currentChat.getDisplayName()) ? currentChat.getDisplayName() : currentChat.getContactEmail());
         metaInfo.setText(buildMetaText());
     }
 
@@ -146,7 +144,7 @@ public class ConversationView extends VerticalLayout {
         if (CollectionUtils.isEmpty(loadedMessages)) {
             return "";
         }
-        ChatMessageDetailDto last = loadedMessages.get(loadedMessages.size() - 1);
+        ChatMessageDetailDto last = loadedMessages.get(0);
         String lastTime = last.getSentAt() != null ? dateTimeFormatter.format(last.getSentAt()) : "";
         return String.format("Останнє повідомлення: %s • %d повідомлень", lastTime, loadedMessages.size());
     }
@@ -158,13 +156,11 @@ public class ConversationView extends VerticalLayout {
         messagesContainer.removeAll();
         messagesContainer.add(new Span("Завантаження..."));
         try {
-            List<ChatMessageDetailDto> batch = chatService.findThreadMessages(currentChat.getThreadKey(), PAGE_SIZE, null);
+            List<ChatMessageDetailDto> batch = chatService.findChatMessages(currentChat.getContactEmail(), null);
             loadedMessages.clear();
             loadedMessages.addAll(batch);
-            loadedMessages.sort(Comparator.comparing(ChatMessageDetailDto::getSentAt, Comparator.nullsLast(Comparator.naturalOrder())));
             renderMessages();
             metaInfo.setText(buildMetaText());
-            messagesContainer.getElement().executeJs("this.scrollTop = this.scrollHeight;");
         } catch (MessagingException e) {
             messagesContainer.removeAll();
             messagesContainer.add(new Span("Не вдалося завантажити тему."));
@@ -196,11 +192,8 @@ public class ConversationView extends VerticalLayout {
         }
         return ChatListItemDto.builder()
                 .id(chat.getId())
-                .threadKey(chat.getThreadKey())
-                .title(chat.getTitle())
+                .contactEmail(chat.getContactEmail())
                 .displayName(chat.getDisplayName())
-                .peerEmail(chat.getPeerEmail())
-                .orgUnit(chat.getOrgUnit())
                 .status(status)
                 .hasUnprocessed(hasUnprocessed)
                 .unreadCount(unreadCount)

--- a/src/main/java/com/esvar/dekanat/mail/MailController.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailController.java
@@ -30,7 +30,7 @@ public class MailController {
         this.chatService = chatService;
     }
 
-    @GetMapping("/threads")
+    @GetMapping("/chats")
     public Page<ChatListItemDto> getChats(@RequestParam(name = "q", required = false) String query,
                                           @RequestParam(name = "page", defaultValue = "0") int page,
                                           @RequestParam(name = "size", defaultValue = "20") int size) {
@@ -40,11 +40,10 @@ public class MailController {
         return chatService.findChats(filter, pageable);
     }
 
-    @GetMapping("/threads/{threadKey}/messages")
-    public List<ChatMessageDetailDto> getThreadMessages(@PathVariable String threadKey,
-                                                        @RequestParam(name = "limit", defaultValue = "30") int limit,
+    @GetMapping("/chats/{contactEmail}/messages")
+    public List<ChatMessageDetailDto> getChatMessages(@PathVariable String contactEmail,
                                                         @RequestParam(name = "before", required = false) Instant before) throws MessagingException {
-        return chatService.findThreadMessages(threadKey, limit, before);
+        return chatService.findChatMessages(contactEmail, before);
     }
 
     @GetMapping("/messages/{messageId}")

--- a/src/main/java/com/esvar/dekanat/mail/MailInboxView.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailInboxView.java
@@ -60,7 +60,7 @@ public class MailInboxView extends VerticalLayout {
     }
 
     private HorizontalLayout buildToolbar() {
-        searchField.setPlaceholder("Тема або email");
+        searchField.setPlaceholder("Email або ім'я");
         searchField.setClearButtonVisible(true);
         searchField.addValueChangeListener(e -> chatGrid.getDataProvider().refreshAll());
 
@@ -97,7 +97,7 @@ public class MailInboxView extends VerticalLayout {
         chatGrid.setHeightFull();
 
         chatGrid.addComponentColumn(this::buildThreadPreview)
-                .setHeader("Темы")
+                .setHeader("Чати")
                 .setFlexGrow(1);
         chatGrid.addColumn(item -> item.getLastMessageAt() != null ? dateTimeFormatter.format(item.getLastMessageAt()) : "")
                 .setHeader("Останнє")
@@ -115,10 +115,10 @@ public class MailInboxView extends VerticalLayout {
         Div wrapper = new Div();
         wrapper.addClassName("thread-preview");
 
-        Span title = new Span(item.getTitle());
+        Span title = new Span(item.getDisplayName() != null ? item.getDisplayName() : item.getContactEmail());
         title.addClassName("thread-title");
 
-        Span counterparty = new Span((item.getDisplayName() != null ? item.getDisplayName() : "") + " • " + item.getPeerEmail());
+        Span counterparty = new Span(item.getContactEmail());
         counterparty.addClassName("thread-counterparty");
 
         Span snippet = new Span(item.getLastSnippet() != null ? item.getLastSnippet() : "");

--- a/src/main/java/com/esvar/dekanat/mail/MailMessageEntity.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailMessageEntity.java
@@ -14,6 +14,7 @@ import java.util.List;
 @Entity
 @Table(name = "mail_message", indexes = {
         @Index(name = "idx_mail_message_peer_email_date", columnList = "peer_email, sent_at"),
+        @Index(name = "idx_mail_message_contact_email_date", columnList = "contact_email, sent_at"),
         @Index(name = "idx_mail_message_folder_uid", columnList = "folder, uid"),
         @Index(name = "idx_mail_message_thread_key_date", columnList = "thread_key, sent_at")
 })
@@ -43,6 +44,9 @@ public class MailMessageEntity {
 
     @Column(name = "peer_email", nullable = false, length = 320)
     private String peerEmail;
+
+    @Column(name = "contact_email", nullable = false, length = 320)
+    private String contactEmail;
 
     @Column(name = "folder", nullable = false, length = 64)
     private String folder;

--- a/src/main/java/com/esvar/dekanat/mail/MailMessageRepository.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailMessageRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -22,4 +23,8 @@ public interface MailMessageRepository extends JpaRepository<MailMessageEntity, 
     Page<MailMessageEntity> findByThreadKeyAndSentAtBefore(String threadKey, Instant before, Pageable pageable);
 
     Optional<MailMessageEntity> findTop1ByThreadKeyOrderBySentAtDesc(String threadKey);
+
+    List<MailMessageEntity> findByContactEmailOrderBySentAtDesc(String contactEmail);
+
+    List<MailMessageEntity> findByContactEmailAndSentAtBeforeOrderBySentAtDesc(String contactEmail, Instant before);
 }

--- a/src/main/java/com/esvar/dekanat/mail/MailSyncService.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailSyncService.java
@@ -17,8 +17,12 @@ import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 public class MailSyncService {
@@ -31,19 +35,22 @@ public class MailSyncService {
     private final MailMessageRepository mailMessageRepository;
     private final MailSyncStateRepository syncStateRepository;
     private final ChatProfileResolver profileResolver;
+    private final org.springframework.boot.autoconfigure.mail.MailProperties mailProperties;
 
     public MailSyncService(MailImapClient mailImapClient,
                            MailSyncProperties properties,
                            ChatRepository chatRepository,
                            MailMessageRepository mailMessageRepository,
                            MailSyncStateRepository syncStateRepository,
-                           ChatProfileResolver profileResolver) {
+                           ChatProfileResolver profileResolver,
+                           org.springframework.boot.autoconfigure.mail.MailProperties mailProperties) {
         this.mailImapClient = mailImapClient;
         this.properties = properties;
         this.chatRepository = chatRepository;
         this.mailMessageRepository = mailMessageRepository;
         this.syncStateRepository = syncStateRepository;
         this.profileResolver = profileResolver;
+        this.mailProperties = mailProperties;
     }
 
     @Scheduled(fixedDelayString = "${mail.sync.interval-ms:60000}")
@@ -93,18 +100,19 @@ public class MailSyncService {
             return;
         }
 
-        String peerEmail = resolvePeerEmail(message, direction);
-        if (!StringUtils.hasText(peerEmail)) {
-            LOGGER.debug("Skipping message {} without peer email", messageId);
+        String contactEmail = resolveContactEmail(message, direction);
+        if (!StringUtils.hasText(contactEmail)) {
+            LOGGER.debug("Skipping message {} without contact email", messageId);
             return;
         }
 
         String normalizedSubject = MailThreadUtils.normalizeSubject(message.getSubject());
-        String threadKey = MailThreadUtils.buildThreadKey(peerEmail, message.getSubject());
+        String threadKey = MailThreadUtils.buildThreadKey(contactEmail, message.getSubject());
         String title = MailThreadUtils.stripPrefixes(message.getSubject());
 
-        ChatEntity chat = chatRepository.findByThreadKey(threadKey)
-                .orElseGet(() -> createChat(peerEmail, threadKey, title, normalizedSubject));
+        ChatEntity chat = chatRepository.findByContactEmail(contactEmail)
+                .or(() -> chatRepository.findByPeerEmail(contactEmail))
+                .orElseGet(() -> createChat(contactEmail, title, normalizedSubject));
 
         String cleanPlain = MailQuotedStripper.stripQuotedPlain(MailpartExtractor.extractPlainText(message));
         String snippet = MailTextExtractor.sanitizeSnippet(StringUtils.hasText(cleanPlain) ? cleanPlain : title, 500);
@@ -114,7 +122,8 @@ public class MailSyncService {
                 .chat(chat)
                 .threadKey(threadKey)
                 .normalizedSubject(normalizedSubject)
-                .peerEmail(peerEmail)
+                .peerEmail(contactEmail)
+                .contactEmail(contactEmail)
                 .folder(folder.getFullName())
                 .uid(folder.getUID(message))
                 .sentAt(resolveSentAt(message))
@@ -131,7 +140,8 @@ public class MailSyncService {
         chat.setThreadKey(threadKey);
         chat.setTitle(title);
         chat.setNormalizedSubject(normalizedSubject);
-        chat.setPeerEmail(peerEmail);
+        chat.setPeerEmail(contactEmail);
+        chat.setContactEmail(contactEmail);
         chat.setLastMessageAt(entity.getSentAt());
         chat.setLastSnippet(entity.getSnippet());
         chat.setHasAttachments(chat.isHasAttachments() || entity.isHasAttachments());
@@ -159,11 +169,16 @@ public class MailSyncService {
         return Part.ATTACHMENT.equalsIgnoreCase(part.getDisposition()) || StringUtils.hasText(part.getFileName());
     }
 
-    private String resolvePeerEmail(Message message, MessageDirection direction) throws MessagingException {
+    private String resolveContactEmail(Message message, MessageDirection direction) throws MessagingException {
         if (direction == MessageDirection.IN) {
-            return extractAddress(message.getFrom());
+            return normalizeEmail(extractAddress(message.getFrom()));
         }
-        return extractAddress(message.getRecipients(Message.RecipientType.TO));
+        List<String> recipients = extractAddresses(message.getRecipients(Message.RecipientType.TO));
+        if (recipients.isEmpty()) {
+            return null;
+        }
+        String external = findExternalRecipient(recipients);
+        return normalizeEmail(StringUtils.hasText(external) ? external : recipients.get(0));
     }
 
     private String extractAddress(Address[] addresses) {
@@ -177,11 +192,59 @@ public class MailSyncService {
         return address.toString();
     }
 
-    private ChatEntity createChat(String peerEmail, String threadKey, String title, String normalizedSubject) {
-        ChatProfileResolver.ResolvedProfile profile = profileResolver.resolve(peerEmail);
+    private List<String> extractAddresses(Address[] addresses) {
+        if (addresses == null || addresses.length == 0) {
+            return List.of();
+        }
+        List<String> result = new ArrayList<>();
+        for (Address address : addresses) {
+            if (address instanceof InternetAddress internetAddress) {
+                result.add(internetAddress.getAddress());
+            } else {
+                result.add(address.toString());
+            }
+        }
+        return result;
+    }
+
+    private String findExternalRecipient(List<String> recipients) {
+        Set<String> localAddresses = localAddresses();
+        for (String recipient : recipients) {
+            if (recipient == null) {
+                continue;
+            }
+            String normalized = recipient.trim().toLowerCase();
+            if (!localAddresses.contains(normalized)) {
+                return recipient;
+            }
+        }
+        return null;
+    }
+
+    private Set<String> localAddresses() {
+        Set<String> addresses = new HashSet<>();
+        if (StringUtils.hasText(properties.getImap().getUsername())) {
+            addresses.add(properties.getImap().getUsername().trim().toLowerCase());
+        }
+        if (mailProperties != null && StringUtils.hasText(mailProperties.getUsername())) {
+            addresses.add(mailProperties.getUsername().trim().toLowerCase());
+        }
+        return addresses;
+    }
+
+    private String normalizeEmail(String email) {
+        if (!StringUtils.hasText(email)) {
+            return null;
+        }
+        return email.trim().toLowerCase();
+    }
+
+    private ChatEntity createChat(String contactEmail, String title, String normalizedSubject) {
+        ChatProfileResolver.ResolvedProfile profile = profileResolver.resolve(contactEmail);
         return chatRepository.save(ChatEntity.builder()
-                .threadKey(threadKey)
-                .peerEmail(peerEmail)
+                .threadKey(contactEmail)
+                .peerEmail(contactEmail)
+                .contactEmail(contactEmail)
                 .title(title)
                 .normalizedSubject(normalizedSubject)
                 .displayName(profile.displayName())

--- a/src/main/java/com/esvar/dekanat/mail/dto/ChatListItemDto.java
+++ b/src/main/java/com/esvar/dekanat/mail/dto/ChatListItemDto.java
@@ -10,11 +10,8 @@ import java.time.Instant;
 @Builder
 public class ChatListItemDto {
     Long id;
-    String threadKey;
-    String title;
+    String contactEmail;
     String displayName;
-    String peerEmail;
-    String orgUnit;
     ChatStatus status;
     boolean hasUnprocessed;
     int unreadCount;


### PR DESCRIPTION
## Summary
- group mail chats and messages by contact email, storing the value and indexing for faster lookups
- derive contact addresses during IMAP sync and expose contact-based chat endpoints and message retrieval
- refresh the Vaadin inbox to display contact chats with newest messages first

## Testing
- ./mvnw -q -DskipTests compile *(fails: unable to download Maven distribution in sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481711dfe083269303217a57127d31)