### PR TITLE
Load chat messages by id

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/ChatService.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatService.java
@@ -81,11 +81,13 @@ public class ChatService {
     }
 
     @Transactional(readOnly = true)
-    public List<ChatMessageDetailDto> findChatMessages(String contactEmail, Instant before) throws MessagingException {
-        String normalizedContact = StringUtils.hasText(contactEmail) ? contactEmail.trim().toLowerCase() : contactEmail;
+    public List<ChatMessageDetailDto> findChatMessages(Long chatId, Instant before) throws MessagingException {
+        if (chatId == null) {
+            return List.of();
+        }
         List<MailMessageEntity> messages = before != null
-                ? mailMessageRepository.findByContactEmailAndSentAtBeforeOrderBySentAtDesc(normalizedContact, before)
-                : mailMessageRepository.findByContactEmailOrderBySentAtDesc(normalizedContact);
+                ? mailMessageRepository.findByChatIdAndSentAtBeforeOrderBySentAtDesc(chatId, before)
+                : mailMessageRepository.findByChatIdOrderBySentAtDesc(chatId);
         List<ChatMessageDetailDto> details = new ArrayList<>();
         for (MailMessageEntity message : messages) {
             details.add(toDetailDto(message));

--- a/src/main/java/com/esvar/dekanat/mail/ConversationView.java
+++ b/src/main/java/com/esvar/dekanat/mail/ConversationView.java
@@ -156,7 +156,7 @@ public class ConversationView extends VerticalLayout {
         messagesContainer.removeAll();
         messagesContainer.add(new Span("Завантаження..."));
         try {
-            List<ChatMessageDetailDto> batch = chatService.findChatMessages(currentChat.getContactEmail(), null);
+            List<ChatMessageDetailDto> batch = chatService.findChatMessages(currentChat.getId(), null);
             loadedMessages.clear();
             loadedMessages.addAll(batch);
             renderMessages();

--- a/src/main/java/com/esvar/dekanat/mail/MailController.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailController.java
@@ -40,10 +40,10 @@ public class MailController {
         return chatService.findChats(filter, pageable);
     }
 
-    @GetMapping("/chats/{contactEmail}/messages")
-    public List<ChatMessageDetailDto> getChatMessages(@PathVariable String contactEmail,
-                                                        @RequestParam(name = "before", required = false) Instant before) throws MessagingException {
-        return chatService.findChatMessages(contactEmail, before);
+    @GetMapping("/chats/{chatId}/messages")
+    public List<ChatMessageDetailDto> getChatMessages(@PathVariable Long chatId,
+                                                      @RequestParam(name = "before", required = false) Instant before) throws MessagingException {
+        return chatService.findChatMessages(chatId, before);
     }
 
     @GetMapping("/messages/{messageId}")

--- a/src/main/java/com/esvar/dekanat/mail/MailMessageRepository.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailMessageRepository.java
@@ -24,6 +24,10 @@ public interface MailMessageRepository extends JpaRepository<MailMessageEntity, 
 
     Optional<MailMessageEntity> findTop1ByThreadKeyOrderBySentAtDesc(String threadKey);
 
+    List<MailMessageEntity> findByChatIdOrderBySentAtDesc(Long chatId);
+
+    List<MailMessageEntity> findByChatIdAndSentAtBeforeOrderBySentAtDesc(Long chatId, Instant before);
+
     List<MailMessageEntity> findByContactEmailOrderBySentAtDesc(String contactEmail);
 
     List<MailMessageEntity> findByContactEmailAndSentAtBeforeOrderBySentAtDesc(String contactEmail, Instant before);


### PR DESCRIPTION
## Summary
- fetch conversation messages by chat id to display threads after selecting a chat
- adjust mail API endpoint to return messages for the chosen chat
- add repository helpers for chat-scoped message queries

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481f78a8e08326b58f92418f335a55)