### PR TITLE
Add pagination for mail conversation messages

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/ChatService.java
+++ b/src/main/java/com/esvar/dekanat/mail/ChatService.java
@@ -39,6 +39,8 @@ import java.util.stream.Collectors;
 @Service
 public class ChatService {
 
+    private static final int DEFAULT_MESSAGE_PAGE_SIZE = 20;
+
     private final ChatRepository chatRepository;
     private final MailMessageRepository mailMessageRepository;
     private final MailAttachmentMetaRepository attachmentRepository;
@@ -80,22 +82,33 @@ public class ChatService {
         return page.map(this::toDto);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public List<ChatMessageDetailDto> findChatMessages(Long chatId, Instant before) throws MessagingException {
+        return findChatMessages(chatId, before, DEFAULT_MESSAGE_PAGE_SIZE);
+    }
+
+    @Transactional
+    public List<ChatMessageDetailDto> findChatMessages(Long chatId, Instant before, int pageSize) throws MessagingException {
         if (chatId == null) {
             return List.of();
         }
-        List<MailMessageEntity> messages = before != null
-                ? mailMessageRepository.findByChatIdAndSentAtBeforeOrderBySentAtDesc(chatId, before)
-                : mailMessageRepository.findByChatIdOrderBySentAtDesc(chatId);
+
+        int effectivePageSize = Math.max(Math.min(pageSize, 100), 1);
+        Pageable pageable = PageRequest.of(0, effectivePageSize, Sort.by(Sort.Direction.DESC, "sentAt"));
+
+        Page<MailMessageEntity> messagePage = before != null
+                ? mailMessageRepository.findByChatIdAndSentAtBefore(chatId, before, pageable)
+                : mailMessageRepository.findByChatId(chatId, pageable);
+        List<MailMessageEntity> messages = messagePage.getContent();
 
         if (messages.isEmpty()) {
             Optional<ChatEntity> chat = chatRepository.findById(chatId);
             if (chat.isPresent() && StringUtils.hasText(chat.get().getContactEmail())) {
                 String normalized = chat.get().getContactEmail().trim().toLowerCase();
-                messages = before != null
-                        ? mailMessageRepository.findByContactEmailAndSentAtBeforeOrderBySentAtDesc(normalized, before)
-                        : mailMessageRepository.findByContactEmailOrderBySentAtDesc(normalized);
+                Page<MailMessageEntity> contactMessages = before != null
+                        ? mailMessageRepository.findByContactEmailAndSentAtBefore(normalized, before, pageable)
+                        : mailMessageRepository.findByContactEmail(normalized, pageable);
+                messages = contactMessages.getContent();
             }
         }
         List<ChatMessageDetailDto> details = new ArrayList<>();

--- a/src/main/java/com/esvar/dekanat/mail/ConversationView.java
+++ b/src/main/java/com/esvar/dekanat/mail/ConversationView.java
@@ -17,6 +17,7 @@ import jakarta.mail.MessagingException;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -33,13 +34,17 @@ public class ConversationView extends VerticalLayout {
     private final ComboBox<ChatStatus> statusComboBox = new ComboBox<>("Статус");
     private final Button markProcessedButton = new Button("Позначити опрацьованим");
     private final Button closeButton = new Button("Закрити");
+    private final Button loadMoreButton = new Button("Показати більше");
     private final Span metaInfo = new Span();
     private final Div messagesContainer = new Div();
     private final H3 title = new H3("Діалог");
 
     private ChatListItemDto currentChat;
     private final List<ChatMessageDetailDto> loadedMessages = new ArrayList<>();
+    private Instant nextPageBefore;
+    private boolean loadingMessages = false;
     private Consumer<ChatListItemDto> chatUpdateListener;
+    private static final int PAGE_SIZE = 20;
 
     private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm")
             .withZone(ZoneId.systemDefault());
@@ -102,6 +107,10 @@ public class ConversationView extends VerticalLayout {
         metaInfo.addClassName("conversation-meta");
         title.addClassName("conversation-title");
 
+        loadMoreButton.addClickListener(e -> loadNextPage());
+        loadMoreButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        loadMoreButton.setVisible(false);
+
         HorizontalLayout left = new HorizontalLayout(title, statusComboBox, markProcessedButton, closeButton);
         left.setDefaultVerticalComponentAlignment(FlexComponent.Alignment.CENTER);
         left.setSpacing(true);
@@ -153,21 +162,55 @@ public class ConversationView extends VerticalLayout {
         if (currentChat == null) {
             return;
         }
-        messagesContainer.removeAll();
-        messagesContainer.add(new Span("Завантаження..."));
+        nextPageBefore = null;
+        loadedMessages.clear();
+        renderLoadingState();
+        loadPage(true);
+    }
+
+    private void loadNextPage() {
+        loadPage(false);
+    }
+
+    private void loadPage(boolean initial) {
+        if (currentChat == null || loadingMessages) {
+            return;
+        }
+        loadingMessages = true;
+        loadMoreButton.setEnabled(false);
         try {
-            List<ChatMessageDetailDto> batch = chatService.findChatMessages(currentChat.getId(), null);
-            loadedMessages.clear();
+            List<ChatMessageDetailDto> batch = chatService.findChatMessages(currentChat.getId(), nextPageBefore, PAGE_SIZE);
+            if (initial) {
+                loadedMessages.clear();
+            }
             loadedMessages.addAll(batch);
-            renderMessages();
+            nextPageBefore = calculateNextBefore(batch);
+            boolean hasMore = batch.size() == PAGE_SIZE && nextPageBefore != null;
+            renderMessages(hasMore);
             metaInfo.setText(buildMetaText());
         } catch (MessagingException e) {
             messagesContainer.removeAll();
             messagesContainer.add(new Span("Не вдалося завантажити тему."));
+        } finally {
+            loadingMessages = false;
+            loadMoreButton.setEnabled(true);
         }
     }
 
-    private void renderMessages() {
+    private Instant calculateNextBefore(List<ChatMessageDetailDto> batch) {
+        if (batch == null || batch.isEmpty()) {
+            return null;
+        }
+        ChatMessageDetailDto last = batch.get(batch.size() - 1);
+        return last.getSentAt() != null ? last.getSentAt().minusMillis(1) : null;
+    }
+
+    private void renderLoadingState() {
+        messagesContainer.removeAll();
+        messagesContainer.add(new Span("Завантаження..."));
+    }
+
+    private void renderMessages(boolean hasMore) {
         messagesContainer.removeAll();
         if (loadedMessages.isEmpty()) {
             messagesContainer.add(new Span("Немає повідомлень у темі"));
@@ -183,6 +226,10 @@ public class ConversationView extends VerticalLayout {
                 lastDate = date;
             }
             messagesContainer.add(new MessageBubble(message));
+        }
+        loadMoreButton.setVisible(hasMore);
+        if (hasMore) {
+            messagesContainer.add(loadMoreButton);
         }
     }
 

--- a/src/main/java/com/esvar/dekanat/mail/MailController.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailController.java
@@ -42,8 +42,9 @@ public class MailController {
 
     @GetMapping("/chats/{chatId}/messages")
     public List<ChatMessageDetailDto> getChatMessages(@PathVariable Long chatId,
-                                                      @RequestParam(name = "before", required = false) Instant before) throws MessagingException {
-        return chatService.findChatMessages(chatId, before);
+                                                      @RequestParam(name = "before", required = false) Instant before,
+                                                      @RequestParam(name = "size", defaultValue = "20") int size) throws MessagingException {
+        return chatService.findChatMessages(chatId, before, size);
     }
 
     @GetMapping("/messages/{messageId}")

--- a/src/main/java/com/esvar/dekanat/mail/MailMessageRepository.java
+++ b/src/main/java/com/esvar/dekanat/mail/MailMessageRepository.java
@@ -16,6 +16,8 @@ public interface MailMessageRepository extends JpaRepository<MailMessageEntity, 
 
     Page<MailMessageEntity> findByChatId(Long chatId, Pageable pageable);
 
+    Page<MailMessageEntity> findByChatIdAndSentAtBefore(Long chatId, Instant before, Pageable pageable);
+
     Optional<MailMessageEntity> findTop1ByChatIdOrderBySentAtDesc(Long chatId);
 
     Page<MailMessageEntity> findByThreadKey(String threadKey, Pageable pageable);
@@ -28,7 +30,7 @@ public interface MailMessageRepository extends JpaRepository<MailMessageEntity, 
 
     List<MailMessageEntity> findByChatIdAndSentAtBeforeOrderBySentAtDesc(Long chatId, Instant before);
 
-    List<MailMessageEntity> findByContactEmailOrderBySentAtDesc(String contactEmail);
+    Page<MailMessageEntity> findByContactEmail(String contactEmail, Pageable pageable);
 
-    List<MailMessageEntity> findByContactEmailAndSentAtBeforeOrderBySentAtDesc(String contactEmail, Instant before);
+    Page<MailMessageEntity> findByContactEmailAndSentAtBefore(String contactEmail, Instant before, Pageable pageable);
 }


### PR DESCRIPTION
## Summary
- add pageable chat message loading with optional size parameter and before cursor
- enable caching while fetching message content to avoid repeated IMAP downloads
- update Vaadin conversation view with paged loading and "Показати більше" control to avoid loading entire threads at once

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948293068208326a99783ed1379fc2d)