### PR TITLE
Fix zalik student initials handling

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/dto/ZalikSheetDto.java
+++ b/src/main/java/com/esvar/dekanat/generate/dto/ZalikSheetDto.java
@@ -8,6 +8,8 @@ import java.util.List;
  */
 public record ZalikSheetDto(
         String spec,
+        String courseNumber,
+        String groupName,
         String studyYear,
         String sheetNumber,
         LocalDate sheetDate,

--- a/src/main/java/com/esvar/dekanat/generate/pdf/ZalikSheetPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/ZalikSheetPdfGenerator.java
@@ -149,7 +149,7 @@ public final class ZalikSheetPdfGenerator implements PdfGenerator {
                         .setFontSize(11))
                 .setBorder(Border.NO_BORDER));
         groupTable.addCell(new Cell().setPadding(0)
-                .add(new Paragraph(Objects.toString(data.groupName(), ""))
+                .add(new Paragraph(Objects.toString(dto.groupName(), ""))
                         .setFont(regular)
                         .setFontSize(11)
                         .setTextAlignment(TextAlignment.CENTER))
@@ -160,7 +160,7 @@ public final class ZalikSheetPdfGenerator implements PdfGenerator {
 
         document.add(groupTable);
 
-        document.add(new Paragraph(Objects.toString(data.studyYear(), "") + " навчальний рік")
+        document.add(new Paragraph(Objects.toString(dto.studyYear(), "") + " навчальний рік")
                 .setFont(regular)
                 .setFontSize(11)
                 .setTextAlignment(TextAlignment.CENTER));
@@ -451,6 +451,20 @@ public final class ZalikSheetPdfGenerator implements PdfGenerator {
         return date.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"));
     }
 
+    private static LocalDate parseSheetDate(String day, String month, String year) {
+        try {
+            if (day == null || month == null || year == null) {
+                return null;
+            }
+            int d = Integer.parseInt(day);
+            int m = Integer.parseInt(month);
+            int y = Integer.parseInt(year);
+            return LocalDate.of(y, m, d);
+        } catch (RuntimeException ex) {
+            return null;
+        }
+    }
+
     /**
      * Compute study year in format "YY-(YY+1)" using current calendar year.
      */
@@ -475,10 +489,18 @@ public final class ZalikSheetPdfGenerator implements PdfGenerator {
                 .map(student -> toRow(student, data))
                 .toList();
 
+        String studyYear = safe(data.studyYear());
+        if (studyYear.isBlank()) {
+            studyYear = computeStudyYear(LocalDate.now());
+        }
+
         return new ZalikSheetDto(
-                computeStudyYear(LocalDate.now()),
+                safe(data.specialityName()),
+                safe(data.courseNumber()),
+                safe(data.groupName()),
+                studyYear,
                 safe(data.order()),
-                null,
+                parseSheetDate(data.day(), data.month(), data.year()),
                 safe(data.day()),
                 safe(data.month()),
                 safe(data.year()),

--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -75,6 +75,7 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @PageTitle("Введення оцінок | Деканат")
 @Route(value = "marks", layout = MainLayout.class)
@@ -878,6 +879,11 @@ public class EnterMarksView extends Div {
         if (plansEntity.getGroups() != null && !plansEntity.getGroups().isEmpty()) {
             return plansEntity.getGroups().iterator().next();
         }
+        return getLegacyPlanGroup();
+    }
+
+    @SuppressWarnings("deprecation")
+    private StudentGroupEntity getLegacyPlanGroup() {
         return plansEntity.getGroup();
     }
 
@@ -1550,9 +1556,8 @@ public class EnterMarksView extends Div {
             if (mark == null) {
                 mark = "";
             }
-            String patronymic = Optional.ofNullable(student.getPatronymic()).orElse("");
             students.add(new StudentModelToDocumentGenerate(index,
-                    student.getSurname() + " " + student.getName().charAt(0) + ". " + patronymic.charAt(0) + ".",
+                    buildStudentNameWithInitials(student),
                     student.getRecordBookNumber() != null ? student.getRecordBookNumber() : "",
                     mark));
             index++;
@@ -1569,6 +1574,29 @@ public class EnterMarksView extends Div {
                 .map(String::toUpperCase)
                 .orElse("");
         return (firstName + " " + surname).trim();
+    }
+
+    private String buildStudentNameWithInitials(StudentEntity student) {
+        String surname = Optional.ofNullable(student.getSurname()).orElse("").trim();
+        String nameInitial = extractInitial(student.getName());
+        String patronymicInitial = extractInitial(student.getPatronymic());
+
+        return Stream.of(surname, nameInitial, patronymicInitial)
+                .filter(part -> !part.isEmpty())
+                .collect(Collectors.joining(" "));
+    }
+
+    private String extractInitial(String value) {
+        if (value == null) {
+            return "";
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            return "";
+        }
+        int firstCodePoint = trimmed.codePointAt(0);
+        String initial = new String(Character.toChars(Character.toUpperCase(firstCodePoint)));
+        return initial + ".";
     }
 
     private void showAdditionalReportDialog() {


### PR DESCRIPTION
## Summary
- avoid crashes when generating zalik documents by safely building student initials
- align zalik sheet DTO mapping with generator fields, including course/group data and parsed sheet dates
- fall back to legacy plan group with explicit suppression instead of deprecated getter usage

## Testing
- ⚠️ `./mvnw -q -DskipTests compile` *(failed: unable to download Maven distribution from repo.maven.apache.org in sandbox)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69483c046d848326a00e939f4cd08d34)