### PR TITLE
Implement IMAP inbox synchronization

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/repository/MailMessageRepository.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/repository/MailMessageRepository.java
@@ -20,4 +20,6 @@ public interface MailMessageRepository extends JpaRepository<MailMessageEntity, 
 
     @Query("select m from MailMessageEntity m where m.thread.id = :threadId order by m.sentAt desc")
     List<MailMessageEntity> findPaged(@Param("threadId") Long threadId, Pageable pageable);
+
+    Optional<MailMessageEntity> findByExternalId(String externalId);
 }

--- a/src/main/java/com/esvar/dekanat/mail/v2/repository/MailThreadRepository.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/repository/MailThreadRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface MailThreadRepository extends JpaRepository<MailThreadEntity, Long> {
 
     @Query("""
@@ -25,4 +27,6 @@ public interface MailThreadRepository extends JpaRepository<MailThreadEntity, Lo
                                   @Param("org") String org,
                                   @Param("status") ThreadStatus status,
                                   Pageable pageable);
+
+    Optional<MailThreadEntity> findByContactId(Long contactId);
 }

--- a/src/main/java/com/esvar/dekanat/mail/v2/service/ImapMailIngestService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/ImapMailIngestService.java
@@ -1,11 +1,46 @@
 package com.esvar.dekanat.mail.v2.service;
 
 import com.esvar.dekanat.mail.v2.repository.FolderStateRepository;
+import com.esvar.dekanat.mail.v2.repository.MailAttachmentRepository;
+import com.esvar.dekanat.mail.v2.repository.MailContactRepository;
+import com.esvar.dekanat.mail.v2.repository.MailMessageRepository;
+import com.esvar.dekanat.mail.v2.repository.MailThreadRepository;
+import com.esvar.dekanat.mail.v2.entity.FolderStateEntity;
+import com.esvar.dekanat.mail.v2.entity.MailAttachmentEntity;
+import com.esvar.dekanat.mail.v2.entity.MailContactEntity;
+import com.esvar.dekanat.mail.v2.entity.MailMessageEntity;
+import com.esvar.dekanat.mail.v2.entity.MailThreadEntity;
+import jakarta.mail.Address;
+import jakarta.mail.BodyPart;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Part;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
+import jakarta.mail.UIDFolder;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeUtility;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.sun.mail.imap.IMAPFolder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
 
 @Service
 @RequiredArgsConstructor
@@ -13,20 +48,372 @@ import org.springframework.stereotype.Service;
 public class ImapMailIngestService implements MailIngestService {
 
     private final FolderStateRepository folderStateRepository;
+    private final MailContactRepository contactRepository;
+    private final MailThreadRepository threadRepository;
+    private final MailMessageRepository messageRepository;
+    private final MailAttachmentRepository attachmentRepository;
 
     @Value("${mail.sync.enabled:true}")
     private boolean syncEnabled;
+
+    @Value("${mail.imap.host}")
+    private String host;
+
+    @Value("${mail.imap.port:993}")
+    private int port;
+
+    @Value("${mail.imap.username}")
+    private String username;
+
+    @Value("${mail.imap.password}")
+    private String password;
+
+    @Value("${mail.imap.inbox-folder:INBOX}")
+    private String inboxFolder;
+
+    @Value("${mail.imap.use-ssl:true}")
+    private boolean useSsl;
+
+    @Value("${mail.default-from:}")
+    private String defaultFrom;
 
     @Override
     public void syncInbox() {
         if (!syncEnabled) {
             return;
         }
-        log.debug("IMAP sync placeholder executed");
+        Properties props = new Properties();
+        props.put("mail.store.protocol", useSsl ? "imaps" : "imap");
+        props.put("mail.imap.ssl.enable", String.valueOf(useSsl));
+        props.put("mail.imap.port", String.valueOf(port));
+        Session session = Session.getInstance(props);
+        try (Store store = session.getStore()) {
+            store.connect(host, port, username, password);
+            Folder folder = store.getFolder(inboxFolder);
+            if (!(folder instanceof IMAPFolder imapFolder)) {
+                log.warn("Folder {} is not IMAP compatible", inboxFolder);
+                return;
+            }
+            try {
+                imapFolder.open(Folder.READ_ONLY);
+                FolderStateEntity state = folderStateRepository.findByFolderName(inboxFolder)
+                        .orElseGet(() -> FolderStateEntity.builder()
+                                .folderName(inboxFolder)
+                                .build());
+                long uidValidity = imapFolder.getUIDValidity();
+                if (state.getUidValidity() != null && !state.getUidValidity().equals(uidValidity)) {
+                    log.info("UIDVALIDITY changed for {}, resetting sync cursor", inboxFolder);
+                    state.setLastSeenUid(null);
+                }
+                state.setUidValidity(uidValidity);
+
+                long startUid = state.getLastSeenUid() != null ? state.getLastSeenUid() + 1 : 1;
+                Message[] messages = imapFolder.getMessagesByUID(startUid, UIDFolder.LASTUID);
+                Arrays.sort(messages, Comparator.comparingLong(imapFolder::getUID));
+                long maxUid = state.getLastSeenUid() != null ? state.getLastSeenUid() : 0;
+                for (Message message : messages) {
+                    long uid = imapFolder.getUID(message);
+                    if (uid <= 0) {
+                        continue;
+                    }
+                    try {
+                        ingestMessage(message, uid);
+                        maxUid = Math.max(maxUid, uid);
+                    } catch (Exception e) {
+                        log.warn("Failed to ingest message UID {}: {}", uid, e.getMessage(), e);
+                    }
+                }
+                state.setLastSeenUid(maxUid);
+                state.setUpdatedAt(Instant.now());
+                folderStateRepository.save(state);
+            } finally {
+                if (imapFolder.isOpen()) {
+                    imapFolder.close(false);
+                }
+            }
+        } catch (Exception e) {
+            log.error("IMAP sync failed: {}", e.getMessage(), e);
+        }
     }
 
     @Scheduled(fixedDelayString = "${mail.sync.interval-ms:60000}")
     public void scheduledSync() {
         syncInbox();
+    }
+
+    private void ingestMessage(Message message, long uid) throws MessagingException, IOException {
+        String messageId = message.getHeader("Message-ID", null);
+        String externalId = StringUtils.hasText(messageId) ? messageId : inboxFolder + ":" + uid;
+        if (messageRepository.findByExternalId(externalId).isPresent()) {
+            return;
+        }
+
+        EmailAddress from = extractAddress(message.getFrom());
+        EmailAddress to = extractAddress(message.getRecipients(Message.RecipientType.TO));
+        MailMessageEntity.Direction direction = resolveDirection(from.email());
+        Instant sentAt = message.getSentDate() != null ? message.getSentDate().toInstant() : Instant.now();
+        MessageContent content = extractContent(message);
+        MailContactEntity contact = resolveContact(direction, from, to);
+        MailThreadEntity thread = resolveThread(contact);
+
+        MailMessageEntity saved = messageRepository.save(MailMessageEntity.builder()
+                .thread(thread)
+                .direction(direction)
+                .fromEmail(from.email())
+                .toEmail(to.email())
+                .subject(message.getSubject())
+                .sentAt(sentAt)
+                .bodyHtml(content.bodyHtml())
+                .bodyText(content.bodyText())
+                .snippet(buildSnippet(content))
+                .externalId(externalId)
+                .hasAttachments(!content.attachments().isEmpty())
+                .build());
+
+        persistAttachments(saved, content.attachments());
+        updateThreadMetadata(thread, direction, sentAt);
+    }
+
+    private MailThreadEntity resolveThread(MailContactEntity contact) {
+        return threadRepository.findByContactId(contact.getId())
+                .orElseGet(() -> threadRepository.save(MailThreadEntity.builder()
+                        .contact(contact)
+                        .status(MailThreadEntity.ThreadStatus.NEW)
+                        .unreadIncomingCount(0)
+                        .build()));
+    }
+
+    private void updateThreadMetadata(MailThreadEntity thread, MailMessageEntity.Direction direction, Instant sentAt) {
+        boolean changed = false;
+        if (direction == MailMessageEntity.Direction.IN) {
+            if (thread.getLastIncomingAt() == null || sentAt.isAfter(thread.getLastIncomingAt())) {
+                thread.setLastIncomingAt(sentAt);
+            }
+            thread.setUnreadIncomingCount(thread.getUnreadIncomingCount() + 1);
+            changed = true;
+        }
+        if (thread.getLastActivityAt() == null || sentAt.isAfter(thread.getLastActivityAt())) {
+            thread.setLastActivityAt(sentAt);
+            changed = true;
+        }
+        if (changed) {
+            threadRepository.save(thread);
+        }
+    }
+
+    private MailContactEntity resolveContact(MailMessageEntity.Direction direction, EmailAddress from, EmailAddress to) throws MessagingException {
+        EmailAddress peer = direction == MailMessageEntity.Direction.IN ? from : preferredRecipient(to, from);
+        String email = peer.email();
+        if (!StringUtils.hasText(email)) {
+            email = direction == MailMessageEntity.Direction.IN ? to.email() : from.email();
+        }
+        if (!StringUtils.hasText(email)) {
+            throw new MessagingException("Cannot resolve contact email for message");
+        }
+        MailContactEntity contact = contactRepository.findNormalized(email)
+                .orElseGet(() -> contactRepository.save(MailContactEntity.builder()
+                        .type(MailContactEntity.ContactType.EXTERNAL)
+                        .email(email)
+                        .displayName(peer.displayName())
+                        .createdAt(Instant.now())
+                        .updatedAt(Instant.now())
+                        .build()));
+        if (!StringUtils.hasText(contact.getDisplayName()) && StringUtils.hasText(peer.displayName())) {
+            contact.setDisplayName(peer.displayName());
+            contact.setUpdatedAt(Instant.now());
+            contact = contactRepository.save(contact);
+        }
+        return contact;
+    }
+
+    private EmailAddress preferredRecipient(EmailAddress primary, EmailAddress fallback) {
+        if (primary != null && StringUtils.hasText(primary.email())) {
+            return primary;
+        }
+        return fallback;
+    }
+
+    private MessageContent extractContent(Part part) throws MessagingException, IOException {
+        MessageContentBuilder builder = new MessageContentBuilder();
+        parsePart(part, builder);
+        return builder.build();
+    }
+
+    private void parsePart(Part part, MessageContentBuilder builder) throws MessagingException, IOException {
+        if (part.isMimeType("multipart/alternative")) {
+            Multipart mp = (Multipart) part.getContent();
+            for (int i = 0; i < mp.getCount(); i++) {
+                BodyPart bp = mp.getBodyPart(i);
+                if (bp.isMimeType("text/html")) {
+                    builder.setBodyHtml(readAsString(bp));
+                } else if (bp.isMimeType("text/plain") && !builder.hasText()) {
+                    builder.setBodyText(readAsString(bp));
+                }
+            }
+        } else if (part.isMimeType("multipart/*")) {
+            Multipart mp = (Multipart) part.getContent();
+            for (int i = 0; i < mp.getCount(); i++) {
+                parsePart(mp.getBodyPart(i), builder);
+            }
+        } else if (Part.ATTACHMENT.equalsIgnoreCase(part.getDisposition()) || Part.INLINE.equalsIgnoreCase(part.getDisposition()) || StringUtils.hasText(part.getFileName())) {
+            builder.addAttachment(buildAttachment(part));
+        } else if (part.isMimeType("text/html")) {
+            builder.setBodyHtml(readAsString(part));
+        } else if (part.isMimeType("text/plain")) {
+            builder.setBodyText(readAsString(part));
+        }
+    }
+
+    private AttachmentData buildAttachment(Part part) throws MessagingException, IOException {
+        String filename = MimeUtility.decodeText(part.getFileName() != null ? part.getFileName() : "attachment");
+        String contentType = part.getContentType();
+        String contentId = Optional.ofNullable(part.getHeader("Content-ID", null))
+                .map(id -> id.replaceAll("[<>]", ""))
+                .orElse(null);
+        boolean inline = Part.INLINE.equalsIgnoreCase(part.getDisposition()) || StringUtils.hasText(contentId);
+        byte[] contentBytes = readBytes(part);
+        return new AttachmentData(
+                filename,
+                contentType,
+                (long) contentBytes.length,
+                inline,
+                contentId,
+                new String(contentBytes, StandardCharsets.UTF_8)
+        );
+    }
+
+    private void persistAttachments(MailMessageEntity message, List<AttachmentData> attachments) {
+        if (attachments.isEmpty()) {
+            return;
+        }
+        List<MailAttachmentEntity> entities = new ArrayList<>();
+        for (AttachmentData attachment : attachments) {
+            entities.add(MailAttachmentEntity.builder()
+                    .message(message)
+                    .filename(attachment.filename())
+                    .contentType(attachment.contentType())
+                    .size(attachment.size())
+                    .inline(attachment.inline())
+                    .contentId(attachment.contentId())
+                    .storageType(MailAttachmentEntity.StorageType.DB)
+                    .storageKey(attachment.storageKey())
+                    .createdAt(Instant.now())
+                    .build());
+        }
+        attachmentRepository.saveAll(entities);
+    }
+
+    private MailMessageEntity.Direction resolveDirection(String fromEmail) {
+        if (StringUtils.hasText(fromEmail)) {
+            if (StringUtils.hasText(defaultFrom) && defaultFrom.equalsIgnoreCase(fromEmail)) {
+                return MailMessageEntity.Direction.OUT;
+            }
+            if (StringUtils.hasText(username) && username.equalsIgnoreCase(fromEmail)) {
+                return MailMessageEntity.Direction.OUT;
+            }
+        }
+        return MailMessageEntity.Direction.IN;
+    }
+
+    private String buildSnippet(MessageContent content) {
+        String source = StringUtils.hasText(content.bodyText()) ? content.bodyText() : content.bodyHtml();
+        if (!StringUtils.hasText(source)) {
+            return null;
+        }
+        String cleaned = source.replaceAll("<[^>]*>", " ").replaceAll("\\s+", " ").trim();
+        if (cleaned.length() > 200) {
+            return cleaned.substring(0, 200);
+        }
+        return cleaned;
+    }
+
+    private EmailAddress extractAddress(Address[] addresses) {
+        if (addresses == null || addresses.length == 0) {
+            return new EmailAddress(null, null);
+        }
+        Address address = addresses[0];
+        if (address instanceof InternetAddress internetAddress) {
+            return new EmailAddress(internetAddress.getAddress(), internetAddress.getPersonal());
+        }
+        return new EmailAddress(address.toString(), null);
+    }
+
+    private String readAsString(Part part) throws IOException, MessagingException {
+        Object content = part.getContent();
+        if (content instanceof String) {
+            return (String) content;
+        }
+        return new String(readBytes(part), StandardCharsets.UTF_8);
+    }
+
+    private byte[] readBytes(Part part) throws IOException, MessagingException {
+        try (InputStream inputStream = part.getInputStream()) {
+            return inputStream.readAllBytes();
+        }
+    }
+
+    private record EmailAddress(String email, String displayName) {
+    }
+
+    private record AttachmentData(String filename,
+                                  String contentType,
+                                  Long size,
+                                  boolean inline,
+                                  String contentId,
+                                  String storageKey) {
+    }
+
+    private static class MessageContent {
+        private final String bodyText;
+        private final String bodyHtml;
+        private final List<AttachmentData> attachments;
+
+        MessageContent(String bodyText, String bodyHtml, List<AttachmentData> attachments) {
+            this.bodyText = bodyText;
+            this.bodyHtml = bodyHtml;
+            this.attachments = attachments;
+        }
+
+        public String bodyText() {
+            return bodyText;
+        }
+
+        public String bodyHtml() {
+            return bodyHtml;
+        }
+
+        public List<AttachmentData> attachments() {
+            return attachments;
+        }
+    }
+
+    private static class MessageContentBuilder {
+        private String bodyText;
+        private String bodyHtml;
+        private final List<AttachmentData> attachments = new ArrayList<>();
+
+        public void setBodyText(String bodyText) {
+            if (!StringUtils.hasText(this.bodyText)) {
+                this.bodyText = bodyText;
+            }
+        }
+
+        public void setBodyHtml(String bodyHtml) {
+            if (!StringUtils.hasText(this.bodyHtml)) {
+                this.bodyHtml = bodyHtml;
+            }
+        }
+
+        public void addAttachment(AttachmentData attachment) {
+            attachments.add(attachment);
+        }
+
+        public boolean hasText() {
+            return StringUtils.hasText(bodyText) || StringUtils.hasText(bodyHtml);
+        }
+
+        public MessageContent build() {
+            return new MessageContent(bodyText, bodyHtml, attachments);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement IMAP inbox synchronization that connects via configured credentials, tracks folder state, and ingests messages with attachments
- resolve contacts/threads from message addresses while updating activity/unread metadata and deduplicating by external id
- add repository helpers for external ids and thread lookup by contact to support ingestion

## Testing
- ./mvnw -q -DskipTests compile *(fails: repository download blocked in sandbox network)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694af22e1b148326adccfbac2f882934)