### PR TITLE
Widen mail attachment storage column

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/entity/MailAttachmentEntity.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/entity/MailAttachmentEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
@@ -63,7 +64,8 @@ public class MailAttachmentEntity {
     @Column(name = "storage_type", nullable = false, length = 8)
     private StorageType storageType;
 
-    @Column(name = "storage_key", columnDefinition = "TEXT")
+    @Lob
+    @Column(name = "storage_key", columnDefinition = "LONGTEXT")
     private String storageKey;
 
     @Column(name = "created_at", nullable = false)


### PR DESCRIPTION
## Summary
- mark the mail attachment storage key as a LOB and map it to LONGTEXT to handle large values without truncation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694afa1c03d48326b3eab2a69ecbb4dc)