### PR TITLE
Improve mail inbox loading and reply UI

### DIFF
--- a/src/main/frontend/styles/mail-inbox.css
+++ b/src/main/frontend/styles/mail-inbox.css
@@ -275,12 +275,13 @@
 }
 
 .reply-upload {
-    width: 44px;
-    --lumo-size-s: 34px;
+    min-width: 200px;
+    flex-shrink: 0;
 }
 
 .reply-upload::part(drop-label) {
-    display: none;
+    color: var(--lumo-secondary-text-color);
+    font-size: 12px;
 }
 
 .reply-textarea {

--- a/src/main/java/com/esvar/dekanat/mail/v2/service/ThreadService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/ThreadService.java
@@ -34,9 +34,19 @@ public class ThreadService {
                                                MailThreadEntity.ThreadStatus status,
                                                int offset,
                                                int limit) {
-        Pageable pageable = PageRequest.of(offset / limit, limit, Sort.by(Sort.Direction.DESC, "lastIncomingAt"));
+        int page = Math.floorDiv(offset, limit);
+        Pageable pageable = PageRequest.of(page, limit, Sort.by(Sort.Direction.DESC, "lastIncomingAt"));
         Page<MailThreadEntity> page = threadRepository.search(trimToNull(nameQuery), trimToNull(emailQuery), trimToNull(orgQuery), status, pageable);
         return page.map(this::toDto);
+    }
+
+    public long countThreads(String nameQuery,
+                             String emailQuery,
+                             String orgQuery,
+                             MailThreadEntity.ThreadStatus status) {
+        Pageable pageable = PageRequest.of(0, 1, Sort.by(Sort.Direction.DESC, "lastIncomingAt"));
+        return threadRepository.search(trimToNull(nameQuery), trimToNull(emailQuery), trimToNull(orgQuery), status, pageable)
+                .getTotalElements();
     }
 
     public Optional<MailThreadEntity> findById(Long id) {

--- a/src/main/java/com/esvar/dekanat/mail/v2/view/MailInboxView.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/view/MailInboxView.java
@@ -237,15 +237,11 @@ public class MailInboxView extends VerticalLayout {
     }
 
     private int countThreads(Query<ThreadListItemDto, Void> query) {
-        int limit = query.getLimit() > 0 ? query.getLimit() : pageSize;
-        return (int) threadService.findThreads(
-                        nameFilter.getValue(),
-                        emailFilter.getValue(),
-                        orgFilter.getValue(),
-                        statusFilter.getValue(),
-                        0,
-                        limit)
-                .getTotalElements();
+        return (int) threadService.countThreads(
+                nameFilter.getValue(),
+                emailFilter.getValue(),
+                orgFilter.getValue(),
+                statusFilter.getValue());
     }
 
     private Component renderThread(ThreadListItemDto thread) {

--- a/src/main/java/com/esvar/dekanat/mail/v2/view/component/MessageBubble.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/view/component/MessageBubble.java
@@ -35,6 +35,10 @@ public class MessageBubble extends Div {
             body.getElement().setProperty("innerHTML", safeHtml);
         } else if (StringUtils.hasText(message.getBodyText())) {
             body.setText(message.getBodyText());
+        } else if (StringUtils.hasText(message.getSnippet())) {
+            body.setText(message.getSnippet());
+        } else {
+            body.setText("Без вмісту");
         }
 
         add(meta, body);

--- a/src/main/java/com/esvar/dekanat/mail/v2/view/component/ReplyInput.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/view/component/ReplyInput.java
@@ -7,6 +7,7 @@ import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.notification.Notification;
@@ -54,6 +55,8 @@ public class ReplyInput extends Div {
         upload.setAutoUpload(true);
         upload.getElement().setAttribute("title", "Додати вкладення або перетягнути файли");
         upload.addClassName("reply-upload");
+        upload.setUploadButton(createUploadButton());
+        upload.setDropLabel(new Span("Перетягніть файли або оберіть їх"));
 
         send.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
         send.addClickListener(e -> emitSend());
@@ -63,8 +66,8 @@ public class ReplyInput extends Div {
 
         FlexLayout layout = new FlexLayout();
         layout.setWidthFull();
-        layout.setAlignItems(FlexLayout.Alignment.END);
-        layout.setJustifyContentMode(FlexLayout.JustifyContentMode.BETWEEN);
+        layout.setAlignItems(FlexLayout.Alignment.CENTER);
+        layout.setJustifyContentMode(FlexLayout.JustifyContentMode.START);
         layout.add(upload, textArea, send);
         layout.addClassName("reply-row");
         layout.setFlexGrow(1, textArea);
@@ -72,6 +75,13 @@ public class ReplyInput extends Div {
 
         add(layout);
         attachAutoGrow();
+    }
+
+    private Button createUploadButton() {
+        Button button = new Button("Додати файл", new Icon(VaadinIcon.PAPERCLIP));
+        button.addThemeVariants(ButtonVariant.LUMO_TERTIARY, ButtonVariant.LUMO_SMALL);
+        button.setWidthFull();
+        return button;
     }
 
     private void configureInteractions() {


### PR DESCRIPTION
## Summary
- ensure mail inbox list uses a dedicated count query for accurate paging of threads
- show message content fallbacks so opened threads always render text
- widen the attachment control with a descriptive button and drop label

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694af9fcb170832684bd2902c98a51cc)