### PR TITLE
Handle null attachments in mail message bubble

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/view/component/MessageBubble.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/view/component/MessageBubble.java
@@ -15,6 +15,7 @@ import org.springframework.util.StringUtils;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Objects;
 
 public class MessageBubble extends Div {
 
@@ -43,7 +44,7 @@ public class MessageBubble extends Div {
 
         add(meta, body);
 
-        List<MessageDto.MessageAttachmentDto> attachments = message.getAttachments();
+        List<MessageDto.MessageAttachmentDto> attachments = Objects.requireNonNullElseGet(message.getAttachments(), List::of);
         if (!attachments.isEmpty()) {
             Div attachmentBlock = new Div();
             attachmentBlock.addClassName("attachments");


### PR DESCRIPTION
## Summary
- prevent message bubble rendering from crashing when a message has null attachments by defaulting to an empty list

## Testing
- `./mvnw -q -DskipTests compile` *(fails: unable to download Maven distribution from repo.maven.apache.org in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694afc05f5d88326a76a22d6219efc06)