### PR TITLE
Fix mail attachments initialization in MessageDto

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/dto/MessageDto.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/dto/MessageDto.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Getter
@@ -26,6 +27,7 @@ public class MessageDto {
     private Instant sentAt;
     private String bodyHtml;
     private String bodyText;
+    @Builder.Default
     private List<MessageAttachmentDto> attachments = new ArrayList<>();
     private String snippet;
 
@@ -44,6 +46,7 @@ public class MessageDto {
     }
 
     public static MessageDto fromEntity(MailMessageEntity entity, List<MailAttachmentEntity> attachments) {
+        List<MailAttachmentEntity> safeAttachments = attachments != null ? attachments : Collections.emptyList();
         MessageDto dto = MessageDto.builder()
                 .id(entity.getId())
                 .direction(entity.getDirection())
@@ -55,7 +58,7 @@ public class MessageDto {
                 .bodyText(entity.getBodyText())
                 .snippet(entity.getSnippet())
                 .build();
-        for (MailAttachmentEntity attachment : attachments) {
+        for (MailAttachmentEntity attachment : safeAttachments) {
             dto.attachments.add(MessageAttachmentDto.builder()
                     .id(attachment.getId())
                     .filename(attachment.getFilename())


### PR DESCRIPTION
## Summary
- ensure MessageDto builder initializes attachments with a default list
- handle null attachment collections when mapping mail messages to DTOs

## Testing
- ❌ `./mvnw -DskipTests compile` *(failed: unable to download Maven distribution from repo.maven.apache.org in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b029c92d4832699532a10cdd25196)