### PR TITLE
Retry IMAP sync when folder closes

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/service/ImapMailIngestService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/ImapMailIngestService.java
@@ -101,6 +101,24 @@ public class ImapMailIngestService implements MailIngestService {
     }
 
     private void syncFolder(Store store, String folderName) throws MessagingException {
+        syncFolder(store, folderName, 0);
+    }
+
+    private void syncFolder(Store store, String folderName, int attempt) throws MessagingException {
+        try {
+            syncFolderInternal(store, folderName);
+        } catch (FolderClosedException e) {
+            if (attempt < 1) {
+                log.warn("Folder {} connection lost, retrying sync", folderName, e);
+                syncFolder(store, folderName, attempt + 1);
+            } else {
+                log.error("Folder {} connection lost after retry, aborting sync", folderName, e);
+                throw e;
+            }
+        }
+    }
+
+    private void syncFolderInternal(Store store, String folderName) throws MessagingException {
         Folder folder = store.getFolder(folderName);
         if (!(folder instanceof IMAPFolder imapFolder)) {
             log.warn("Folder {} is not IMAP compatible", folderName);


### PR DESCRIPTION
## Summary
- add retry logic to rerun IMAP folder sync when the folder connection closes unexpectedly
- log retry attempts and abort after a second failure to avoid endless loops

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b0682e8548326aecf664b3e5dfca5)