### PR TITLE
Render inline mail attachments in message body

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/view/component/MessageBubble.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/view/component/MessageBubble.java
@@ -7,6 +7,9 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.html.Span;
 
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.owasp.html.HtmlSanitizer;
 import org.owasp.html.PolicyFactory;
 import org.owasp.html.Sanitizers;
@@ -14,8 +17,13 @@ import org.springframework.util.StringUtils;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class MessageBubble extends Div {
 
@@ -31,9 +39,15 @@ public class MessageBubble extends Div {
 
         Div body = new Div();
         body.addClassName("message-body");
-        if (StringUtils.hasText(message.getBodyHtml())) {
-            String safeHtml = MAIL_HTML_POLICY.sanitize(message.getBodyHtml());
-            body.getElement().setProperty("innerHTML", safeHtml);
+        List<MessageDto.MessageAttachmentDto> attachments = Objects.requireNonNullElseGet(message.getAttachments(), List::of);
+        List<MessageDto.MessageAttachmentDto> inlineAttachments = attachments.stream()
+                .filter(MessageDto.MessageAttachmentDto::isInline)
+                .toList();
+
+        InlineBody inlineBody = sanitizeBodyHtml(message.getBodyHtml(), inlineAttachments);
+
+        if (StringUtils.hasText(inlineBody.html())) {
+            body.getElement().setProperty("innerHTML", inlineBody.html());
         } else if (StringUtils.hasText(message.getBodyText())) {
             body.setText(message.getBodyText());
         } else if (StringUtils.hasText(message.getSnippet())) {
@@ -42,29 +56,27 @@ public class MessageBubble extends Div {
             body.setText("Без вмісту");
         }
 
+        appendInlineImages(body, inlineAttachments, inlineBody.resolvedInlineIds());
+
         add(meta, body);
 
-        List<MessageDto.MessageAttachmentDto> attachments = Objects.requireNonNullElseGet(message.getAttachments(), List::of);
-        if (!attachments.isEmpty()) {
+        List<MessageDto.MessageAttachmentDto> downloadableAttachments = attachments.stream()
+                .filter(attachment -> !attachment.isInline())
+                .toList();
+        if (!downloadableAttachments.isEmpty()) {
             Div attachmentBlock = new Div();
             attachmentBlock.addClassName("attachments");
-            for (MessageDto.MessageAttachmentDto attachment : attachments) {
-                if (attachment.isInline()) {
-                    Image image = new Image("/api/mail/v2/attachments/" + attachment.getId() + "/inline", attachment.getFilename());
-                    image.addClassName("inline-image");
-                    attachmentBlock.add(image);
-                } else {
-                    String size = humanReadableSize(attachment.getSize());
-                    String label = attachment.getFilename();
-                    if (StringUtils.hasText(size)) {
-                        label = label + " · " + size;
-                    }
-                    Anchor link = new Anchor("/api/mail/v2/attachments/" + attachment.getId() + "/download", label);
-                    link.setTarget("_blank");
-                    link.getElement().setAttribute("download", true);
-                    link.addClassName("attachment-link");
-                    attachmentBlock.add(link);
+            for (MessageDto.MessageAttachmentDto attachment : downloadableAttachments) {
+                String size = humanReadableSize(attachment.getSize());
+                String label = attachment.getFilename();
+                if (StringUtils.hasText(size)) {
+                    label = label + " · " + size;
                 }
+                Anchor link = new Anchor("/api/mail/v2/attachments/" + attachment.getId() + "/download", label);
+                link.setTarget("_blank");
+                link.getElement().setAttribute("download", true);
+                link.addClassName("attachment-link");
+                attachmentBlock.add(link);
             }
             add(attachmentBlock);
         }
@@ -104,5 +116,47 @@ public class MessageBubble extends Div {
                     .and(Sanitizers.LINKS)
                     .and(Sanitizers.IMAGES)
                     .and(Sanitizers.STYLES);
+
+    private InlineBody sanitizeBodyHtml(String bodyHtml, List<MessageDto.MessageAttachmentDto> inlineAttachments) {
+        if (!StringUtils.hasText(bodyHtml)) {
+            return new InlineBody(null, Set.of());
+        }
+
+        Document document = Jsoup.parse(bodyHtml);
+        Set<Long> resolvedInlineIds = new HashSet<>();
+
+        if (!inlineAttachments.isEmpty()) {
+            var inlineByContentId = inlineAttachments.stream()
+                    .filter(attachment -> attachment.getId() != null)
+                    .filter(attachment -> StringUtils.hasText(attachment.getContentId()))
+                    .collect(Collectors.toMap(attachment -> attachment.getContentId().toLowerCase(Locale.ROOT), Function.identity(), (first, duplicate) -> first));
+
+            for (Element imageElement : document.select("img[src^=cid:]")) {
+                String cid = imageElement.attr("src").substring(4).trim();
+                MessageDto.MessageAttachmentDto attachment = inlineByContentId.get(cid.toLowerCase(Locale.ROOT));
+                if (attachment != null) {
+                    imageElement.attr("src", "/api/mail/v2/attachments/" + attachment.getId() + "/inline");
+                    resolvedInlineIds.add(attachment.getId());
+                }
+            }
+        }
+
+        String sanitized = MAIL_HTML_POLICY.sanitize(document.body().html());
+        return new InlineBody(sanitized, resolvedInlineIds);
+    }
+
+    private void appendInlineImages(Div body, List<MessageDto.MessageAttachmentDto> inlineAttachments, Set<Long> alreadyInlined) {
+        for (MessageDto.MessageAttachmentDto attachment : inlineAttachments) {
+            if (attachment.getId() == null || alreadyInlined.contains(attachment.getId())) {
+                continue;
+            }
+            Image image = new Image("/api/mail/v2/attachments/" + attachment.getId() + "/inline", attachment.getFilename());
+            image.addClassName("inline-image");
+            body.add(image);
+        }
+    }
+
+    private record InlineBody(String html, Set<Long> resolvedInlineIds) {
+    }
 
 }


### PR DESCRIPTION
## Summary
- sanitize message HTML and rewrite cid image sources to served inline attachments
- embed inline images into the message body while keeping other attachments as downloads

## Testing
- `./mvnw -q -DskipTests package` *(fails: wget could not fetch apache-maven-3.9.9-bin.zip from repo.maven.apache.org)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b06ceafec8326b4ba34e83edf83d2)