### PR TITLE
Use configured sender address for outgoing mail messages

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/service/MessageService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/MessageService.java
@@ -35,6 +35,7 @@ public class MessageService {
 
     @Transactional
     public MailMessageEntity saveOutgoing(MailThreadEntity thread,
+                                          String fromEmail,
                                           String subject,
                                           String bodyHtml,
                                           String bodyText,
@@ -42,7 +43,7 @@ public class MessageService {
         MailMessageEntity entity = MailMessageEntity.builder()
                 .thread(thread)
                 .direction(MailMessageEntity.Direction.OUT)
-                .fromEmail(thread.getContact().getEmail())
+                .fromEmail(fromEmail)
                 .toEmail(toEmail)
                 .subject(subject)
                 .sentAt(Instant.now())

--- a/src/main/java/com/esvar/dekanat/mail/v2/service/SendMailService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/SendMailService.java
@@ -8,11 +8,13 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.Nullable;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -31,12 +33,25 @@ public class SendMailService {
     private final MailAttachmentRepository attachmentRepository;
     private final MessageService messageService;
 
+    @Value("${mail.default-from:}")
+    private String defaultFrom;
+
+    @Value("${spring.mail.username:}")
+    private String mailUsername;
+
     @Transactional
     public MailMessageEntity send(MailThreadEntity thread,
                                   String text,
                                   String subject,
                                   List<MultipartFile> files) {
-        MailMessageEntity saved = messageService.saveOutgoing(thread, subject, null, text, thread.getContact().getEmail());
+        String senderEmail = resolveSenderEmail(thread);
+        MailMessageEntity saved = messageService.saveOutgoing(
+                thread,
+                senderEmail,
+                subject,
+                null,
+                text,
+                thread.getContact().getEmail());
         List<MailAttachmentEntity> attachments = persistAttachments(saved, files);
         saved.setHasAttachments(!attachments.isEmpty());
         try {
@@ -55,7 +70,7 @@ public class SendMailService {
         helper.setTo(thread.getContact().getEmail());
         helper.setSubject(message.getSubject());
         helper.setText(message.getBodyText(), false);
-        helper.setFrom(message.getFromEmail() != null ? message.getFromEmail() : thread.getContact().getEmail());
+        helper.setFrom(StringUtils.hasText(message.getFromEmail()) ? message.getFromEmail() : resolveSenderEmail(thread));
         for (MailAttachmentEntity attachment : attachments) {
             Path path = Paths.get(attachment.getStorageKey());
 
@@ -67,6 +82,16 @@ public class SendMailService {
 
         }
         mailSender.send(mimeMessage);
+    }
+
+    private String resolveSenderEmail(MailThreadEntity thread) {
+        if (StringUtils.hasText(defaultFrom)) {
+            return defaultFrom;
+        }
+        if (StringUtils.hasText(mailUsername)) {
+            return mailUsername;
+        }
+        return thread.getContact().getEmail();
     }
 
     private List<MailAttachmentEntity> persistAttachments(MailMessageEntity message, @Nullable List<MultipartFile> files) {


### PR DESCRIPTION
## Summary
- store the configured sender address when persisting outgoing mail entries instead of copying the contact email
- send mail using the configured sender (mail.default-from or spring mail username) so conversation metadata matches the real sender

## Testing
- `./mvnw -q -DskipTests compile` *(fails: unable to download Maven wrapper distribution in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b0871c2088326b36cb8290fc9dd93)