### PR TITLE
Fix inline mail attachments decoding

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/service/AttachmentService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/AttachmentService.java
@@ -4,11 +4,16 @@ import com.esvar.dekanat.mail.v2.entity.MailAttachmentEntity;
 import com.esvar.dekanat.mail.v2.repository.MailAttachmentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
+import java.util.Base64;
 
 @Service
 @RequiredArgsConstructor
@@ -17,25 +22,42 @@ public class AttachmentService {
     private final MailAttachmentRepository attachmentRepository;
 
     public Optional<AttachmentContent> loadAttachment(Long id) {
-        return attachmentRepository.findById(id).map(entity -> new AttachmentContent(
-                entity.getFilename(),
-                entity.getContentType(),
-                toResource(entity.getStorageKey())
-        ));
+        return attachmentRepository.findById(id)
+                .map(this::toAttachmentContent);
     }
 
     public Optional<AttachmentContent> loadInline(Long id) {
-        return attachmentRepository.findByIdAndInlineTrue(id).map(entity -> new AttachmentContent(
-                entity.getFilename(),
-                entity.getContentType(),
-                toResource(entity.getStorageKey())
-        ));
+        return attachmentRepository.findByIdAndInlineTrue(id)
+                .map(this::toAttachmentContent);
     }
 
-    private Resource toResource(String storageKey) {
-        // Placeholder storage implementation uses in-memory content for demo purposes.
-        byte[] bytes = storageKey != null ? storageKey.getBytes(StandardCharsets.UTF_8) : new byte[0];
+    private AttachmentContent toAttachmentContent(MailAttachmentEntity entity) {
+        return new AttachmentContent(
+                entity.getFilename(),
+                entity.getContentType(),
+                toResource(entity)
+        );
+    }
+
+    private Resource toResource(MailAttachmentEntity entity) {
+        if (entity.getStorageType() == MailAttachmentEntity.StorageType.FS
+                && StringUtils.hasText(entity.getStorageKey())) {
+            Path path = Paths.get(entity.getStorageKey());
+            return new FileSystemResource(path);
+        }
+        byte[] bytes = decodeStorageKey(entity.getStorageKey());
         return new ByteArrayResource(bytes);
+    }
+
+    byte[] decodeStorageKey(String storageKey) {
+        if (!StringUtils.hasText(storageKey)) {
+            return new byte[0];
+        }
+        try {
+            return Base64.getDecoder().decode(storageKey);
+        } catch (IllegalArgumentException ignored) {
+            return storageKey.getBytes(StandardCharsets.UTF_8);
+        }
     }
 
     public record AttachmentContent(String filename, String contentType, Resource resource) {

--- a/src/main/java/com/esvar/dekanat/mail/v2/service/ImapMailIngestService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/ImapMailIngestService.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -385,7 +386,7 @@ public class ImapMailIngestService implements MailIngestService {
                 (long) contentBytes.length,
                 inline,
                 contentId,
-                new String(contentBytes, StandardCharsets.UTF_8)
+                Base64.getEncoder().encodeToString(contentBytes)
         );
     }
 

--- a/src/main/java/com/esvar/dekanat/mail/v2/service/SendMailService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/SendMailService.java
@@ -9,6 +9,9 @@ import jakarta.mail.internet.MimeMessage;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
 import org.springframework.lang.Nullable;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -18,11 +21,10 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 @Service
@@ -72,14 +74,14 @@ public class SendMailService {
         helper.setText(message.getBodyText(), false);
         helper.setFrom(StringUtils.hasText(message.getFromEmail()) ? message.getFromEmail() : resolveSenderEmail(thread));
         for (MailAttachmentEntity attachment : attachments) {
-            Path path = Paths.get(attachment.getStorageKey());
-
-            helper.addAttachment(
-                    attachment.getFilename(),
-                    () -> Files.newInputStream(path),
-                    attachment.getContentType()
-            );
-
+            Resource resource = resolveAttachmentResource(attachment);
+            if (resource != null) {
+                helper.addAttachment(
+                        attachment.getFilename(),
+                        resource,
+                        attachment.getContentType()
+                );
+            }
         }
         mailSender.send(mimeMessage);
     }
@@ -94,6 +96,26 @@ public class SendMailService {
         return thread.getContact().getEmail();
     }
 
+    private Resource resolveAttachmentResource(MailAttachmentEntity attachment) {
+        if (attachment.getStorageType() == MailAttachmentEntity.StorageType.FS
+                && StringUtils.hasText(attachment.getStorageKey())) {
+            return new FileSystemResource(attachment.getStorageKey());
+        }
+        byte[] bytes = decodeStorageKey(attachment.getStorageKey());
+        return new ByteArrayResource(bytes);
+    }
+
+    private byte[] decodeStorageKey(String storageKey) {
+        if (!StringUtils.hasText(storageKey)) {
+            return new byte[0];
+        }
+        try {
+            return Base64.getDecoder().decode(storageKey);
+        } catch (IllegalArgumentException ignored) {
+            return storageKey.getBytes(StandardCharsets.UTF_8);
+        }
+    }
+
     private List<MailAttachmentEntity> persistAttachments(MailMessageEntity message, @Nullable List<MultipartFile> files) {
         if (CollectionUtils.isEmpty(files)) {
             return List.of();
@@ -101,6 +123,7 @@ public class SendMailService {
         List<MailAttachmentEntity> entities = new ArrayList<>();
         for (MultipartFile file : files) {
             try {
+                String storageKey = Base64.getEncoder().encodeToString(file.getBytes());
                 MailAttachmentEntity entity = MailAttachmentEntity.builder()
                         .message(message)
                         .filename(file.getOriginalFilename())
@@ -108,7 +131,7 @@ public class SendMailService {
                         .size(file.getSize())
                         .inline(false)
                         .storageType(MailAttachmentEntity.StorageType.DB)
-                        .storageKey(new String(file.getBytes()))
+                        .storageKey(storageKey)
                         .createdAt(Instant.now())
                         .build();
                 entities.add(entity);


### PR DESCRIPTION
## Summary
- encode attachments as Base64 when ingesting and sending to preserve binary payloads for inline display
- decode stored attachment content when serving downloads or sending email, with support for filesystem-backed storage keys

## Testing
- ./mvnw -q -DskipTests compile *(fails: unable to download Maven binaries in sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b0c194ff08326962f0729ded1fe7a)