### PR TITLE
Show download links for inline attachments

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/view/component/MessageBubble.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/view/component/MessageBubble.java
@@ -45,6 +45,7 @@ public class MessageBubble extends Div {
                 .toList();
 
         InlineBody inlineBody = sanitizeBodyHtml(message.getBodyHtml(), inlineAttachments);
+        Set<Long> resolvedInlineIds = inlineBody.resolvedInlineIds();
 
         if (StringUtils.hasText(inlineBody.html())) {
             body.getElement().setProperty("innerHTML", inlineBody.html());
@@ -56,12 +57,13 @@ public class MessageBubble extends Div {
             body.setText("Без вмісту");
         }
 
-        appendInlineImages(body, inlineAttachments, inlineBody.resolvedInlineIds());
+        appendInlineImages(body, inlineAttachments, resolvedInlineIds);
 
         add(meta, body);
 
         List<MessageDto.MessageAttachmentDto> downloadableAttachments = attachments.stream()
-                .filter(attachment -> !attachment.isInline())
+                .filter(attachment -> attachment.getId() != null)
+                .filter(attachment -> !attachment.isInline() || !resolvedInlineIds.contains(attachment.getId()))
                 .toList();
         if (!downloadableAttachments.isEmpty()) {
             Div attachmentBlock = new Div();


### PR DESCRIPTION
## Summary
- include inline attachments with ids that were not rendered into the message body in the attachment list
- skip download links for attachments missing identifiers to avoid broken links

## Testing
- not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b0d8aa1c48326bbbe8f8af1e9f3cb)