### PR TITLE
Normalize CID inline images in message bubbles

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/view/component/MessageBubble.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/view/component/MessageBubble.java
@@ -133,8 +133,16 @@ public class MessageBubble extends Div {
                     .filter(attachment -> StringUtils.hasText(attachment.getContentId()))
                     .collect(Collectors.toMap(attachment -> attachment.getContentId().toLowerCase(Locale.ROOT), Function.identity(), (first, duplicate) -> first));
 
-            for (Element imageElement : document.select("img[src^=cid:]")) {
-                String cid = imageElement.attr("src").substring(4).trim();
+            for (Element imageElement : document.select("img[src]")) {
+                String originalSrc = imageElement.attr("src");
+                if (!StringUtils.hasText(originalSrc)) {
+                    continue;
+                }
+                String normalizedSrc = originalSrc.trim();
+                if (!normalizedSrc.toLowerCase(Locale.ROOT).startsWith("cid:")) {
+                    continue;
+                }
+                String cid = normalizedSrc.substring(4).trim();
                 MessageDto.MessageAttachmentDto attachment = inlineByContentId.get(cid.toLowerCase(Locale.ROOT));
                 if (attachment != null) {
                     imageElement.attr("src", "/api/mail/v2/attachments/" + attachment.getId() + "/inline");


### PR DESCRIPTION
## Summary
- normalize cid-based image sources when replacing inline mail attachments so images render correctly
- keep sanitized message bodies while tracking which inline attachments were resolved

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b0f3df56483269ff0f5fdfbd71304)