### PR TITLE
Fix inline attachment content type fallback

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/controller/MailAttachmentController.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/controller/MailAttachmentController.java
@@ -21,19 +21,25 @@ public class MailAttachmentController {
     @GetMapping("/{attachmentId}/download")
     public ResponseEntity<Resource> download(@PathVariable Long attachmentId) {
         return attachmentService.loadAttachment(attachmentId)
-                .map(content -> ResponseEntity.ok()
-                        .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + content.filename() + "\"")
-                        .contentType(MediaType.parseMediaType(content.contentType() != null ? content.contentType() : MediaType.APPLICATION_OCTET_STREAM_VALUE))
-                        .body(content.resource()))
+                .map(content -> {
+                    MediaType mediaType = attachmentService.resolveMediaType(content);
+                    return ResponseEntity.ok()
+                            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + content.filename() + "\"")
+                            .contentType(mediaType)
+                            .body(content.resource());
+                })
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/{attachmentId}/inline")
     public ResponseEntity<Resource> inline(@PathVariable Long attachmentId) {
         return attachmentService.loadInline(attachmentId)
-                .map(content -> ResponseEntity.ok()
-                        .contentType(MediaType.parseMediaType(content.contentType() != null ? content.contentType() : MediaType.APPLICATION_OCTET_STREAM_VALUE))
-                        .body(content.resource()))
+                .map(content -> {
+                    MediaType mediaType = attachmentService.resolveMediaType(content);
+                    return ResponseEntity.ok()
+                            .contentType(mediaType)
+                            .body(content.resource());
+                })
                 .orElse(ResponseEntity.notFound().build());
     }
 }

--- a/src/main/java/com/esvar/dekanat/mail/v2/service/AttachmentService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/AttachmentService.java
@@ -6,6 +6,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.InvalidMediaTypeException;
+import org.springframework.http.MediaType;
+import org.springframework.http.MediaTypeFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -29,6 +32,15 @@ public class AttachmentService {
     public Optional<AttachmentContent> loadInline(Long id) {
         return attachmentRepository.findByIdAndInlineTrue(id)
                 .map(this::toAttachmentContent);
+    }
+
+    public MediaType resolveMediaType(AttachmentContent content) {
+        MediaType parsed = parseMediaType(content.contentType());
+        if (parsed != null) {
+            return parsed;
+        }
+        return MediaTypeFactory.getMediaType(content.filename())
+                .orElse(MediaType.APPLICATION_OCTET_STREAM);
     }
 
     private AttachmentContent toAttachmentContent(MailAttachmentEntity entity) {
@@ -57,6 +69,17 @@ public class AttachmentService {
             return Base64.getDecoder().decode(storageKey);
         } catch (IllegalArgumentException ignored) {
             return storageKey.getBytes(StandardCharsets.UTF_8);
+        }
+    }
+
+    private MediaType parseMediaType(String contentType) {
+        if (!StringUtils.hasText(contentType)) {
+            return null;
+        }
+        try {
+            return MediaType.parseMediaType(contentType);
+        } catch (InvalidMediaTypeException ignored) {
+            return null;
         }
     }
 


### PR DESCRIPTION
## Summary
- fallback to a safe media type for stored attachments when the original type is invalid or missing
- reuse the same media type resolution for inline and download responses to avoid broken inline images

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b10b755608326b8ca1d00c9f8e49a)