### PR TITLE
Normalize reply subjects in mail inbox

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/service/ImapMailIngestService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/ImapMailIngestService.java
@@ -582,7 +582,13 @@ public class ImapMailIngestService implements MailIngestService {
                 Pattern.compile("(?i)^sent:.*"),
                 Pattern.compile("(?iu)^.*пише:?$"),
                 Pattern.compile("(?iu)^.*написав:?$"),
-                Pattern.compile("(?iu)^.*написала:?$")
+                Pattern.compile("(?iu)^.*написала:?$"),
+                Pattern.compile("(?iu)^[-_\\s]*forwarded message[-_\\s]*$"),
+                Pattern.compile("(?iu)^[-_\\s]*original message[-_\\s]*$"),
+                Pattern.compile("(?iu)^[-_\\s]*forwarded:?[-_\\s]*$"),
+                Pattern.compile("(?iu)^[-_\\s]*переслане повідомлення[-_\\s]*$"),
+                Pattern.compile("(?iu)^[-_\\s]*оригінальне повідомлення[-_\\s]*$"),
+                Pattern.compile("(?iu)^[-_\\s]*початкове повідомлення[-_\\s]*$")
         );
         return patterns.stream().anyMatch(pattern -> pattern.matcher(trimmed).find());
     }

--- a/src/main/java/com/esvar/dekanat/mail/v2/service/SubjectNormalizer.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/SubjectNormalizer.java
@@ -1,0 +1,30 @@
+package com.esvar.dekanat.mail.v2.service;
+
+import org.springframework.util.StringUtils;
+
+import java.util.regex.Pattern;
+
+public final class SubjectNormalizer {
+
+    private static final Pattern RE_PREFIX = Pattern.compile("(?i)^(?:re(\\[[0-9]+])?:\\s*)+");
+    private static final Pattern FWD_PREFIX = Pattern.compile("(?i)^(?:fwd?:\\s*)+");
+
+    private SubjectNormalizer() {
+    }
+
+    public static String normalize(String subject) {
+        if (!StringUtils.hasText(subject)) {
+            return subject;
+        }
+        String cleaned = subject.trim();
+        cleaned = RE_PREFIX.matcher(cleaned).replaceFirst("");
+        cleaned = FWD_PREFIX.matcher(cleaned).replaceFirst("");
+        return cleaned.trim();
+    }
+
+    public static String buildReplySubject(String subject) {
+        String normalized = normalize(subject);
+        String base = StringUtils.hasText(normalized) ? normalized : " ";
+        return "Re: " + base;
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mail/v2/service/ThreadService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/ThreadService.java
@@ -83,7 +83,11 @@ public class ThreadService {
     private ThreadListItemDto toDto(MailThreadEntity thread) {
         MailContactEntity contact = thread.getContact();
         List<MailMessageEntity> latestMessage = messageRepository.findPaged(thread.getId(), PageRequest.of(0, 1, Sort.by(Sort.Direction.DESC, "sentAt")));
-        String lastSubject = latestMessage.stream().findFirst().map(MailMessageEntity::getSubject).orElse(null);
+        String lastSubject = latestMessage.stream()
+                .findFirst()
+                .map(MailMessageEntity::getSubject)
+                .map(SubjectNormalizer::normalize)
+                .orElse(null);
         return ThreadListItemDto.builder()
                 .threadId(thread.getId())
                 .contactId(contact.getId())

--- a/src/main/java/com/esvar/dekanat/mail/v2/view/MailInboxView.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/view/MailInboxView.java
@@ -4,6 +4,7 @@ import com.esvar.dekanat.mail.v2.dto.MessageDto;
 import com.esvar.dekanat.mail.v2.dto.ThreadListItemDto;
 import com.esvar.dekanat.mail.v2.entity.MailThreadEntity;
 import com.esvar.dekanat.mail.v2.service.MessageService;
+import com.esvar.dekanat.mail.v2.service.SubjectNormalizer;
 import com.esvar.dekanat.mail.v2.service.SendMailService;
 import com.esvar.dekanat.mail.v2.service.ThreadService;
 import com.esvar.dekanat.mail.v2.view.component.ChatHeader;
@@ -328,7 +329,7 @@ public class MailInboxView extends VerticalLayout {
         }
         sendMailService.send(threadService.findById(selectedThread.getThreadId()).orElseThrow(),
                 text,
-                "Re: " + (StringUtils.hasText(selectedThread.getLastSubject()) ? selectedThread.getLastSubject() : " "),
+                SubjectNormalizer.buildReplySubject(selectedThread.getLastSubject()),
                 attachments);
         replyInput.reset();
         Notification.show("Відправлено");


### PR DESCRIPTION
## Summary
- add SubjectNormalizer utility to strip repeated reply/forward prefixes
- normalize thread subjects before showing them in the inbox list
- build reply subjects with normalization to avoid stacking prefixes
- trim forwarded/original message separators so stored message bodies keep only the main text

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b0ffe55b0832696f6b1f8306e7490)