### PR TITLE
Fix inline attachment content type fallback

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/controller/MailAttachmentController.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/controller/MailAttachmentController.java
@@ -21,19 +21,25 @@ public class MailAttachmentController {
     @GetMapping("/{attachmentId}/download")
     public ResponseEntity<Resource> download(@PathVariable Long attachmentId) {
         return attachmentService.loadAttachment(attachmentId)
-                .map(content -> ResponseEntity.ok()
-                        .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + content.filename() + "\"")
-                        .contentType(MediaType.parseMediaType(content.contentType() != null ? content.contentType() : MediaType.APPLICATION_OCTET_STREAM_VALUE))
-                        .body(content.resource()))
+                .map(content -> {
+                    MediaType mediaType = attachmentService.resolveMediaType(content);
+                    return ResponseEntity.ok()
+                            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + content.filename() + "\"")
+                            .contentType(mediaType)
+                            .body(content.resource());
+                })
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/{attachmentId}/inline")
     public ResponseEntity<Resource> inline(@PathVariable Long attachmentId) {
         return attachmentService.loadInline(attachmentId)
-                .map(content -> ResponseEntity.ok()
-                        .contentType(MediaType.parseMediaType(content.contentType() != null ? content.contentType() : MediaType.APPLICATION_OCTET_STREAM_VALUE))
-                        .body(content.resource()))
+                .map(content -> {
+                    MediaType mediaType = attachmentService.resolveMediaType(content);
+                    return ResponseEntity.ok()
+                            .contentType(mediaType)
+                            .body(content.resource());
+                })
                 .orElse(ResponseEntity.notFound().build());
     }
 }

--- a/src/main/java/com/esvar/dekanat/mail/v2/service/AttachmentService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/AttachmentService.java
@@ -6,10 +6,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.InvalidMediaTypeException;
+import org.springframework.http.MediaType;
+import org.springframework.http.MediaTypeFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -31,6 +36,15 @@ public class AttachmentService {
                 .map(this::toAttachmentContent);
     }
 
+    public MediaType resolveMediaType(AttachmentContent content) {
+        MediaType parsed = parseMediaType(content.contentType());
+        if (parsed != null) {
+            return parsed;
+        }
+        return MediaTypeFactory.getMediaType(content.filename())
+                .orElse(MediaType.APPLICATION_OCTET_STREAM);
+    }
+
     private AttachmentContent toAttachmentContent(MailAttachmentEntity entity) {
         return new AttachmentContent(
                 entity.getFilename(),
@@ -46,6 +60,12 @@ public class AttachmentService {
             return new FileSystemResource(path);
         }
         byte[] bytes = decodeStorageKey(entity.getStorageKey());
+        if (bytes.length == 0) {
+            Resource fileResource = fallbackToFileResource(entity.getStorageKey());
+            if (fileResource != null) {
+                return fileResource;
+            }
+        }
         return new ByteArrayResource(bytes);
     }
 
@@ -56,8 +76,40 @@ public class AttachmentService {
         try {
             return Base64.getDecoder().decode(storageKey);
         } catch (IllegalArgumentException ignored) {
-            return storageKey.getBytes(StandardCharsets.UTF_8);
         }
+        try {
+            return Base64.getMimeDecoder().decode(storageKey);
+        } catch (IllegalArgumentException ignored) {
+        }
+        return storageKey.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private MediaType parseMediaType(String contentType) {
+        if (!StringUtils.hasText(contentType)) {
+            return null;
+        }
+        try {
+            return MediaType.parseMediaType(contentType);
+        } catch (InvalidMediaTypeException ignored) {
+            return null;
+        }
+    }
+
+    private Resource fallbackToFileResource(String storageKey) {
+        if (!StringUtils.hasText(storageKey)) {
+            return null;
+        }
+        Path candidate = Paths.get(storageKey);
+        if (!Files.exists(candidate)) {
+            return null;
+        }
+        try {
+            if (Files.isReadable(candidate) && Files.size(candidate) > 0) {
+                return new FileSystemResource(candidate);
+            }
+        } catch (IOException ignored) {
+        }
+        return null;
     }
 
     public record AttachmentContent(String filename, String contentType, Resource resource) {


### PR DESCRIPTION
## Summary
- fallback to a safe media type for stored attachments when the original type is invalid or missing
- reuse the same media type resolution for inline and download responses to avoid broken inline images
- make attachment decoding resilient to MIME-encoded base64 and file-path storage keys so inline images render reliably

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b10b755608326b8ca1d00c9f8e49a)