### PR TITLE
Fix eager loading contact when sending mail replies

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/repository/MailThreadRepository.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/repository/MailThreadRepository.java
@@ -28,5 +28,8 @@ public interface MailThreadRepository extends JpaRepository<MailThreadEntity, Lo
                                   @Param("status") ThreadStatus status,
                                   Pageable pageable);
 
+    @Query("select t from MailThreadEntity t join fetch t.contact where t.id = :id")
+    Optional<MailThreadEntity> findWithContact(@Param("id") Long id);
+
     Optional<MailThreadEntity> findByContactId(Long contactId);
 }

--- a/src/main/java/com/esvar/dekanat/mail/v2/service/SendMailService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/SendMailService.java
@@ -4,6 +4,7 @@ import com.esvar.dekanat.mail.v2.entity.MailAttachmentEntity;
 import com.esvar.dekanat.mail.v2.entity.MailMessageEntity;
 import com.esvar.dekanat.mail.v2.entity.MailThreadEntity;
 import com.esvar.dekanat.mail.v2.repository.MailAttachmentRepository;
+import com.esvar.dekanat.mail.v2.repository.MailThreadRepository;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.transaction.Transactional;
@@ -33,6 +34,7 @@ public class SendMailService {
 
     private final JavaMailSender mailSender;
     private final MailAttachmentRepository attachmentRepository;
+    private final MailThreadRepository threadRepository;
     private final MessageService messageService;
 
     @Value("${mail.default-from:}")
@@ -46,18 +48,20 @@ public class SendMailService {
                                   String text,
                                   String subject,
                                   List<MultipartFile> files) {
-        String senderEmail = resolveSenderEmail(thread);
+        MailThreadEntity managedThread = threadRepository.findWithContact(thread.getId())
+                .orElseThrow(() -> new IllegalArgumentException("Thread not found: " + thread.getId()));
+        String senderEmail = resolveSenderEmail(managedThread);
         MailMessageEntity saved = messageService.saveOutgoing(
-                thread,
+                managedThread,
                 senderEmail,
                 subject,
                 null,
                 text,
-                thread.getContact().getEmail());
+                managedThread.getContact().getEmail());
         List<MailAttachmentEntity> attachments = persistAttachments(saved, files);
         saved.setHasAttachments(!attachments.isEmpty());
         try {
-            dispatchEmail(thread, saved, attachments);
+            dispatchEmail(managedThread, saved, attachments);
         } catch (MessagingException | IOException e) {
             // For demo purposes we skip failing the transaction to keep UI responsive.
         }


### PR DESCRIPTION
## Summary
- add repository method to fetch mail thread with its contact
- re-fetch thread with contact inside SendMailService before sending replies to prevent lazy-loading errors

## Testing
- `./mvnw test` *(fails: Maven wrapper could not download apache-maven-3.9.9 from repo.maven.apache.org in the sandbox environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3f59a7248326bb39d26260851735)