### PR TITLE
Strip quoted reply blocks from ingested HTML

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/service/ImapMailIngestService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/ImapMailIngestService.java
@@ -560,12 +560,18 @@ public class ImapMailIngestService implements MailIngestService {
         if (!StringUtils.hasText(html)) {
             return fallbackText;
         }
-        String plainFromHtml = htmlToText(html);
+        String plainFromHtml = htmlToText(removeQuotedBlocks(html));
         String cleanedPlain = stripQuotedText(plainFromHtml);
         if (!StringUtils.hasText(cleanedPlain)) {
             return fallbackText;
         }
         return textToHtml(cleanedPlain);
+    }
+
+    private String removeQuotedBlocks(String html) {
+        Document document = Jsoup.parse(html);
+        document.select("blockquote, blockquote[type=cite], .gmail_quote, .yahoo_quoted").remove();
+        return document.body().html();
     }
 
     private boolean isQuoteMarker(String line) {


### PR DESCRIPTION
## Summary
- remove quoted email blocks from HTML bodies before rendering
- rely on cleaned plain text to strip historical reply markers

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3ff7702c8326ad1c1e151113af7d)