### PR TITLE
Fix inline mail attachments rendering

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/service/AttachmentService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/AttachmentService.java
@@ -28,12 +28,16 @@ public class AttachmentService {
 
     public Optional<AttachmentContent> loadAttachment(Long id) {
         return attachmentRepository.findById(id)
-                .map(this::toAttachmentContent);
+                .map(this::toAttachmentContent)
+                .flatMap(this::filterExistingResource);
     }
 
     public Optional<AttachmentContent> loadInline(Long id) {
         return attachmentRepository.findByIdAndInlineTrue(id)
-                .map(this::toAttachmentContent);
+                .or(() -> attachmentRepository.findById(id)
+                        .filter(attachment -> StringUtils.hasText(attachment.getContentId())))
+                .map(this::toAttachmentContent)
+                .flatMap(this::filterExistingResource);
     }
 
     public MediaType resolveMediaType(AttachmentContent content) {
@@ -67,6 +71,20 @@ public class AttachmentService {
             }
         }
         return new ByteArrayResource(bytes);
+    }
+
+    private Optional<AttachmentContent> filterExistingResource(AttachmentContent content) {
+        Resource resource = content.resource();
+        if (resource == null) {
+            return Optional.empty();
+        }
+        try {
+            if (resource.exists() && resource.contentLength() > 0) {
+                return Optional.of(content);
+            }
+        } catch (IOException ignored) {
+        }
+        return Optional.empty();
     }
 
     byte[] decodeStorageKey(String storageKey) {
@@ -110,17 +128,6 @@ public class AttachmentService {
         } catch (IOException ignored) {
         }
         return null;
-    }
-
-    private MediaType parseMediaType(String contentType) {
-        if (!StringUtils.hasText(contentType)) {
-            return null;
-        }
-        try {
-            return MediaType.parseMediaType(contentType);
-        } catch (InvalidMediaTypeException ignored) {
-            return null;
-        }
     }
 
     public record AttachmentContent(String filename, String contentType, Resource resource) {

--- a/src/main/java/com/esvar/dekanat/mail/v2/service/ThreadService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/ThreadService.java
@@ -34,10 +34,10 @@ public class ThreadService {
                                                MailThreadEntity.ThreadStatus status,
                                                int offset,
                                                int limit) {
-        int page = Math.floorDiv(offset, limit);
-        Pageable pageable = PageRequest.of(page, limit, Sort.by(Sort.Direction.DESC, "lastIncomingAt"));
-        Page<MailThreadEntity> page = threadRepository.search(trimToNull(nameQuery), trimToNull(emailQuery), trimToNull(orgQuery), status, pageable);
-        return page.map(this::toDto);
+        int pageIndex = Math.floorDiv(offset, limit);
+        Pageable pageable = PageRequest.of(pageIndex, limit, Sort.by(Sort.Direction.DESC, "lastIncomingAt"));
+        Page<MailThreadEntity> threadsPage = threadRepository.search(trimToNull(nameQuery), trimToNull(emailQuery), trimToNull(orgQuery), status, pageable);
+        return threadsPage.map(this::toDto);
     }
 
     public long countThreads(String nameQuery,

--- a/src/main/java/com/esvar/dekanat/mail/v2/view/component/MessageBubble.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/view/component/MessageBubble.java
@@ -41,7 +41,7 @@ public class MessageBubble extends Div {
         body.addClassName("message-body");
         List<MessageDto.MessageAttachmentDto> attachments = Objects.requireNonNullElseGet(message.getAttachments(), List::of);
         List<MessageDto.MessageAttachmentDto> inlineAttachments = attachments.stream()
-                .filter(MessageDto.MessageAttachmentDto::isInline)
+                .filter(attachment -> StringUtils.hasText(attachment.getContentId()))
                 .toList();
 
         InlineBody inlineBody = sanitizeBodyHtml(message.getBodyHtml(), inlineAttachments);
@@ -63,7 +63,7 @@ public class MessageBubble extends Div {
 
         List<MessageDto.MessageAttachmentDto> downloadableAttachments = attachments.stream()
                 .filter(attachment -> attachment.getId() != null)
-                .filter(attachment -> !attachment.isInline() || !resolvedInlineIds.contains(attachment.getId()))
+                .filter(attachment -> !resolvedInlineIds.contains(attachment.getId()))
                 .toList();
         if (!downloadableAttachments.isEmpty()) {
             Div attachmentBlock = new Div();


### PR DESCRIPTION
## Summary
- allow mail attachments with inline content IDs to be served and skip empty/missing resources instead of returning broken payloads
- render inline images based on content IDs regardless of the inline flag to resolve cid references and avoid duplicate download links
- fix mail thread pagination variable shadowing

## Testing
- `./mvnw -DskipTests compile` *(fails to download Maven distribution in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3f9d8b408326a3deb73f014dd4c2)