### PR TITLE
Harden image upload handling for mail attachments

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/controller/SendMailController.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/controller/SendMailController.java
@@ -1,15 +1,18 @@
 package com.esvar.dekanat.mail.v2.controller;
 
 import com.esvar.dekanat.mail.v2.entity.MailThreadEntity;
+import com.esvar.dekanat.mail.v2.service.AttachmentUploadException;
 import com.esvar.dekanat.mail.v2.service.SendMailService;
 import com.esvar.dekanat.mail.v2.service.ThreadService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -26,7 +29,11 @@ public class SendMailController {
                      @RequestParam(name = "text", required = false) String text,
                      @RequestParam(name = "subject", required = false) String subject,
                      @RequestParam(name = "files", required = false) List<MultipartFile> files) {
-        MailThreadEntity thread = threadService.findById(threadId).orElseThrow();
-        sendMailService.send(thread, text, subject, files);
+        try {
+            MailThreadEntity thread = threadService.findById(threadId).orElseThrow();
+            sendMailService.send(thread, text, subject, files);
+        } catch (AttachmentUploadException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/com/esvar/dekanat/mail/v2/service/AttachmentStorageService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/AttachmentStorageService.java
@@ -1,0 +1,147 @@
+package com.esvar.dekanat.mail.v2.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class AttachmentStorageService {
+
+    private static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
+            "image/png",
+            "image/jpeg",
+            "image/jpg",
+            "image/gif",
+            "image/webp"
+    );
+
+    private static final DateTimeFormatter FILENAME_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    @Value("${mail.attachments.dir:uploads/mail}")
+    private String attachmentsDir;
+
+    @Value("${mail.attachments.max-size-bytes:5242880}")
+    private long maxSizeBytes;
+
+    public StoredAttachment storeImage(MultipartFile file) {
+        validateImage(file);
+        Path targetDir = prepareDirectory();
+        String originalFilename = safeFilename(file.getOriginalFilename());
+        String extension = StringUtils.getFilenameExtension(originalFilename);
+        String generatedName = buildGeneratedName(extension);
+        Path destination = targetDir.resolve(generatedName);
+        try (InputStream inputStream = file.getInputStream()) {
+            Files.copy(inputStream, destination, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new AttachmentUploadException("Не вдалося зберегти зображення на диск", e);
+        }
+        String contentType = detectContentType(file);
+        long size = file.getSize();
+        return new StoredAttachment(originalFilename, contentType, destination.toString(), size);
+    }
+
+    private void validateImage(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new AttachmentUploadException("Файл зображення відсутній або порожній");
+        }
+        if (file.getSize() <= 0) {
+            throw new AttachmentUploadException("Розмір зображення дорівнює нулю");
+        }
+        if (file.getSize() > maxSizeBytes) {
+            throw new AttachmentUploadException("Зображення перевищує максимальний розмір " + humanReadable(maxSizeBytes));
+        }
+        String contentType = detectContentType(file);
+        if (!ALLOWED_IMAGE_TYPES.contains(contentType)) {
+            throw new AttachmentUploadException("Підтримуються лише зображення PNG, JPEG, GIF або WEBP");
+        }
+        ensureImageDecodable(file);
+    }
+
+    private void ensureImageDecodable(MultipartFile file) {
+        try (InputStream inputStream = file.getInputStream()) {
+            if (ImageIO.read(inputStream) == null) {
+                throw new AttachmentUploadException("Файл не схожий на справжнє зображення");
+            }
+        } catch (IOException e) {
+            throw new AttachmentUploadException("Не вдалося перевірити вміст зображення", e);
+        }
+    }
+
+    private Path prepareDirectory() {
+        Path dir = Paths.get(attachmentsDir).toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(dir);
+        } catch (IOException e) {
+            throw new AttachmentUploadException("Не вдалося підготувати каталог для збереження зображення", e);
+        }
+        return dir;
+    }
+
+    private String detectContentType(MultipartFile file) {
+        String declared = file.getContentType();
+        if (StringUtils.hasText(declared) && ALLOWED_IMAGE_TYPES.contains(declared.toLowerCase(Locale.ROOT))) {
+            return declared.toLowerCase(Locale.ROOT);
+        }
+        try (InputStream inputStream = file.getInputStream()) {
+            String probed = URLConnection.guessContentTypeFromStream(inputStream);
+            if (StringUtils.hasText(probed)) {
+                return probed.toLowerCase(Locale.ROOT);
+            }
+        } catch (IOException ignored) {
+        }
+        if (StringUtils.hasText(declared)) {
+            return declared.toLowerCase(Locale.ROOT);
+        }
+        return "application/octet-stream";
+    }
+
+    private String safeFilename(String filename) {
+        String cleaned = StringUtils.cleanPath(StringUtils.hasText(filename) ? filename : "image");
+        String onlyName = StringUtils.getFilename(cleaned);
+        if (!StringUtils.hasText(onlyName)) {
+            return "image";
+        }
+        return onlyName;
+    }
+
+    private String buildGeneratedName(String extension) {
+        String timestamp = LocalDateTime.now().format(FILENAME_DATE_FORMATTER);
+        String randomPart = UUID.randomUUID().toString().replace("-", "");
+        if (StringUtils.hasText(extension)) {
+            return timestamp + "-" + randomPart + "." + extension;
+        }
+        return timestamp + "-" + randomPart;
+    }
+
+    private String humanReadable(long bytes) {
+        double value = (double) bytes;
+        String[] units = {"Б", "КБ", "МБ", "ГБ"};
+        int unitIndex = 0;
+        while (value >= 1024 && unitIndex < units.length - 1) {
+            value /= 1024;
+            unitIndex++;
+        }
+        return String.format(Locale.ROOT, "%.1f %s", value, units[unitIndex]);
+    }
+
+    public record StoredAttachment(String originalFilename,
+                                   String contentType,
+                                   String storagePath,
+                                   long size) {
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mail/v2/service/AttachmentUploadException.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/AttachmentUploadException.java
@@ -1,0 +1,11 @@
+package com.esvar.dekanat.mail.v2.service;
+
+public class AttachmentUploadException extends RuntimeException {
+    public AttachmentUploadException(String message) {
+        super(message);
+    }
+
+    public AttachmentUploadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/esvar/dekanat/mail/v2/service/SendMailService.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/service/SendMailService.java
@@ -22,10 +22,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 
 @Service
@@ -36,6 +34,7 @@ public class SendMailService {
     private final MailAttachmentRepository attachmentRepository;
     private final MailThreadRepository threadRepository;
     private final MessageService messageService;
+    private final AttachmentStorageService attachmentStorageService;
 
     @Value("${mail.default-from:}")
     private String defaultFrom;
@@ -114,9 +113,9 @@ public class SendMailService {
             return new byte[0];
         }
         try {
-            return Base64.getDecoder().decode(storageKey);
+            return java.util.Base64.getDecoder().decode(storageKey);
         } catch (IllegalArgumentException ignored) {
-            return storageKey.getBytes(StandardCharsets.UTF_8);
+            return storageKey.getBytes(java.nio.charset.StandardCharsets.UTF_8);
         }
     }
 
@@ -126,21 +125,18 @@ public class SendMailService {
         }
         List<MailAttachmentEntity> entities = new ArrayList<>();
         for (MultipartFile file : files) {
-            try {
-                String storageKey = Base64.getEncoder().encodeToString(file.getBytes());
-                MailAttachmentEntity entity = MailAttachmentEntity.builder()
-                        .message(message)
-                        .filename(file.getOriginalFilename())
-                        .contentType(file.getContentType())
-                        .size(file.getSize())
-                        .inline(false)
-                        .storageType(MailAttachmentEntity.StorageType.DB)
-                        .storageKey(storageKey)
-                        .createdAt(Instant.now())
-                        .build();
-                entities.add(entity);
-            } catch (IOException ignored) {
-            }
+            AttachmentStorageService.StoredAttachment storedAttachment = attachmentStorageService.storeImage(file);
+            MailAttachmentEntity entity = MailAttachmentEntity.builder()
+                    .message(message)
+                    .filename(storedAttachment.originalFilename())
+                    .contentType(storedAttachment.contentType())
+                    .size(storedAttachment.size())
+                    .inline(false)
+                    .storageType(MailAttachmentEntity.StorageType.FS)
+                    .storageKey(storedAttachment.storagePath())
+                    .createdAt(Instant.now())
+                    .build();
+            entities.add(entity);
         }
         return attachmentRepository.saveAll(entities);
     }

--- a/src/main/java/com/esvar/dekanat/mail/v2/view/MailInboxView.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/view/MailInboxView.java
@@ -3,6 +3,7 @@ package com.esvar.dekanat.mail.v2.view;
 import com.esvar.dekanat.mail.v2.dto.MessageDto;
 import com.esvar.dekanat.mail.v2.dto.ThreadListItemDto;
 import com.esvar.dekanat.mail.v2.entity.MailThreadEntity;
+import com.esvar.dekanat.mail.v2.service.AttachmentUploadException;
 import com.esvar.dekanat.mail.v2.service.MessageService;
 import com.esvar.dekanat.mail.v2.service.SubjectNormalizer;
 import com.esvar.dekanat.mail.v2.service.SendMailService;
@@ -327,10 +328,15 @@ public class MailInboxView extends VerticalLayout {
         if (!StringUtils.hasText(text) && attachments.isEmpty()) {
             return;
         }
-        sendMailService.send(threadService.findById(selectedThread.getThreadId()).orElseThrow(),
-                text,
-                SubjectNormalizer.buildReplySubject(selectedThread.getLastSubject()),
-                attachments);
+        try {
+            sendMailService.send(threadService.findById(selectedThread.getThreadId()).orElseThrow(),
+                    text,
+                    SubjectNormalizer.buildReplySubject(selectedThread.getLastSubject()),
+                    attachments);
+        } catch (AttachmentUploadException ex) {
+            Notification.show(ex.getMessage());
+            return;
+        }
         replyInput.reset();
         Notification.show("Відправлено");
         List<MessageDto> latest = messageService.loadMessages(selectedThread.getThreadId(), null, 1);

--- a/src/main/java/com/esvar/dekanat/mail/v2/view/component/ReplyInput.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/view/component/ReplyInput.java
@@ -29,6 +29,15 @@ import java.util.List;
 
 public class ReplyInput extends Div {
 
+    private static final int MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
+    private static final String[] ACCEPTED_IMAGE_TYPES = new String[]{
+            "image/png",
+            "image/jpeg",
+            "image/jpg",
+            "image/gif",
+            "image/webp"
+    };
+
     private TextArea textArea = new TextArea();
     private MultiFileMemoryBuffer buffer = new MultiFileMemoryBuffer();
     private final Upload upload = new Upload(buffer);
@@ -53,10 +62,12 @@ public class ReplyInput extends Div {
         upload.setDropAllowed(true);
         upload.setMaxFiles(8);
         upload.setAutoUpload(true);
+        upload.setMaxFileSize(MAX_IMAGE_SIZE_BYTES);
+        upload.setAcceptedFileTypes(ACCEPTED_IMAGE_TYPES);
         upload.getElement().setAttribute("title", "Додати вкладення або перетягнути файли");
         upload.addClassName("reply-upload");
         upload.setUploadButton(createUploadButton());
-        upload.setDropLabel(new Span("Перетягніть файли або оберіть їх"));
+        upload.setDropLabel(new Span("Перетягніть зображення (PNG/JPG/GIF/WEBP) " + readableMaxSize()));
 
         send.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
         send.addClickListener(e -> emitSend());
@@ -103,7 +114,13 @@ public class ReplyInput extends Div {
 
         upload.addSucceededListener(e -> updateSendEnabled());
         upload.addFileRemovedListener(e -> updateSendEnabled());
-        upload.addFileRejectedListener(e -> Notification.show(e.getErrorMessage()));
+        upload.addFileRejectedListener(e -> {
+            String error = e.getErrorMessage();
+            if (!StringUtils.hasText(error)) {
+                error = "Невдале завантаження зображення. Перевірте формат та розмір (" + readableMaxSize() + ")";
+            }
+            Notification.show(error);
+        });
     }
 
 
@@ -156,6 +173,17 @@ public class ReplyInput extends Div {
 
     public Registration addSendListener(ComponentEventListener<SendEvent> listener) {
         return addListener(SendEvent.class, listener);
+    }
+
+    private String readableMaxSize() {
+        double value = MAX_IMAGE_SIZE_BYTES;
+        String[] units = {"Б", "КБ", "МБ"};
+        int unit = 0;
+        while (value >= 1024 && unit < units.length - 1) {
+            value /= 1024;
+            unit++;
+        }
+        return String.format("%.0f %s", value, units[unit]);
     }
 
     private void attachAutoGrow() {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,6 +57,10 @@ mail:
   sync:
     interval-ms: ${MAIL_SYNC_INTERVAL_MS:60000}
 
+  attachments:
+    dir: ${MAIL_ATTACHMENTS_DIR:uploads/mail}
+    max-size-bytes: ${MAIL_ATTACHMENTS_MAX_SIZE:5242880}
+
 # Якщо треба довіряти заголовкам проксі (nginx/cloudflare)
 #server:
 #  port: ${SERVER_PORT:8080}


### PR DESCRIPTION
## Summary
- add a dedicated attachment storage service that validates images and stores outgoing mail uploads on disk
- enforce image-only uploads with size hints in the mail reply UI and surface upload validation errors in the view and API
- expose attachment directory and size limits through configuration for predictable storage

## Testing
- `./mvnw -q -DskipTests compile` *(fails: Maven wrapper could not download Maven due to network restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b42c93970832690d2cb692381455e)