### PR TITLE
Handle UTF-8 filenames in content disposition headers

### DIFF
--- a/src/main/java/com/esvar/dekanat/mail/v2/controller/MailAttachmentController.java
+++ b/src/main/java/com/esvar/dekanat/mail/v2/controller/MailAttachmentController.java
@@ -1,6 +1,7 @@
 package com.esvar.dekanat.mail.v2.controller;
 
 import com.esvar.dekanat.mail.v2.service.AttachmentService;
+import com.esvar.dekanat.utilites.ContentDispositionUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -24,7 +25,8 @@ public class MailAttachmentController {
                 .map(content -> {
                     MediaType mediaType = attachmentService.resolveMediaType(content);
                     return ResponseEntity.ok()
-                            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + content.filename() + "\"")
+                            .header(HttpHeaders.CONTENT_DISPOSITION,
+                                    ContentDispositionUtils.buildHeaderValue("attachment", content.filename()))
                             .contentType(mediaType)
                             .body(content.resource());
                 })

--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -22,6 +22,7 @@ import com.esvar.dekanat.security.SecurityService;
 import com.esvar.dekanat.service.*;
 import com.esvar.dekanat.service.SummaryReportService.SummaryReportGenerationException;
 import com.esvar.dekanat.service.SummaryReportService.SummaryReportResult;
+import com.esvar.dekanat.utilites.ContentDispositionUtils;
 import com.esvar.dekanat.user.UserModel;
 import com.esvar.dekanat.user.UserRepository;
 import com.esvar.dekanat.view.MainLayout;
@@ -1373,7 +1374,8 @@ public class EnterMarksView extends Div {
         StreamResource resource = new StreamResource(fileName, () -> new ByteArrayInputStream(pdfBytes));
         resource.setContentType("application/pdf");
         resource.setCacheTime(0);
-        resource.setHeader(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + fileName + "\"");
+        resource.setHeader(HttpHeaders.CONTENT_DISPOSITION,
+                ContentDispositionUtils.buildHeaderValue("inline", fileName));
 
         StreamRegistration registration = VaadinSession.getCurrent()
                 .getResourceRegistry()
@@ -1410,7 +1412,8 @@ public class EnterMarksView extends Div {
         });
         resource.setContentType(resolveContentType(fileName));
         resource.setCacheTime(0);
-        resource.setHeader(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + fileName + "\"");
+        resource.setHeader(HttpHeaders.CONTENT_DISPOSITION,
+                ContentDispositionUtils.buildHeaderValue("inline", fileName));
 
         UI ui = UI.getCurrent();
         if (ui == null) {

--- a/src/main/java/com/esvar/dekanat/utilites/ContentDispositionUtils.java
+++ b/src/main/java/com/esvar/dekanat/utilites/ContentDispositionUtils.java
@@ -1,0 +1,25 @@
+package com.esvar.dekanat.utilites;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public final class ContentDispositionUtils {
+
+    private ContentDispositionUtils() {
+    }
+
+    public static String buildHeaderValue(String dispositionType, String fileName) {
+        String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8)
+                .replace("+", "%20");
+        String asciiFallback = fileName.replaceAll("[^\\x20-\\x7E]", "_");
+
+        if (asciiFallback.isBlank()) {
+            asciiFallback = "file";
+        }
+
+        return String.format("%s; filename=\"%s\"; filename*=UTF-8''%s",
+                dispositionType,
+                asciiFallback,
+                encodedFileName);
+    }
+}


### PR DESCRIPTION
## Summary
- add a utility to generate Content-Disposition headers with UTF-8 encoded filenames
- apply encoded headers to mail attachment downloads and generated report streams to avoid non-ASCII rejections

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b60f7246c832691d018012e6a0af9)