### PR TITLE
Add control type row and repeat headers in statement PDFs

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/pdf/BaseStatementPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/BaseStatementPdfGenerator.java
@@ -116,6 +116,9 @@ public abstract class BaseStatementPdfGenerator implements PdfGenerator {
         document.add(centered(data.formattedDate(), bold, DEFAULT_FONT_SIZE).setUnderline());
 
         document.add(buildDisciplineRow(data, regular));
+        if (!safeText(data.controlTypeName()).isBlank()) {
+            document.add(buildControlTypeRow(data, regular));
+        }
         document.add(buildSemesterRow(data, regular));
         document.add(buildTeacherRow("Викладач", data.teacherFullName(), regular));
         document.add(new Paragraph(" "));
@@ -165,7 +168,6 @@ public abstract class BaseStatementPdfGenerator implements PdfGenerator {
     private Table buildStudentsTable(List<StudentModelToDocumentGenerate> rows, PdfFont regular, PdfFont bold) {
         Table table = new Table(UnitValue.createPercentArray(new float[]{7, 34, 18, 18, 12, 11}))
                 .useAllAvailableWidth();
-//        table.setHeaderRows(2);
 
         table.addHeaderCell(headerCell("№ з/п", bold));
         table.addHeaderCell(headerCell("Прізвище та ініціали студента", bold));
@@ -272,6 +274,15 @@ public abstract class BaseStatementPdfGenerator implements PdfGenerator {
         semControlTable.addCell(underlinedCell(safeText(data.semesterNumber()), regular));
         semControlTable.addCell(noBorderCell("-й навчальний семестр.", regular, TextAlignment.LEFT));
         return semControlTable;
+    }
+
+    private Table buildControlTypeRow(StatementDocumentData data, PdfFont regular) {
+        Table controlTypeTable = new Table(UnitValue.createPercentArray(new float[]{25, 60, 15}))
+                .useAllAvailableWidth();
+        controlTypeTable.addCell(noBorderCell("Тип контролю: ", regular, TextAlignment.LEFT));
+        controlTypeTable.addCell(underlinedCell(safeText(data.controlTypeName()), regular));
+        controlTypeTable.addCell(noBorderCell("", regular, TextAlignment.LEFT));
+        return controlTypeTable;
     }
 
     private Table buildTeacherRow(String label, String value, PdfFont font) {

--- a/src/main/java/com/esvar/dekanat/generate/pdf/StatementDocumentData.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/StatementDocumentData.java
@@ -23,6 +23,7 @@ public record StatementDocumentData(
         String year,
         String disciplineName,
         String semesterNumber,
+        String controlTypeName,
         String teacherFullName,
         String headName,
         List<StudentModelToDocumentGenerate> students
@@ -49,6 +50,7 @@ public record StatementDocumentData(
                     zalik.year(),
                     zalik.disciplineName(),
                     zalik.semesterNumber(),
+                    zalik.controlTypeName(),
                     zalik.firstTeacher(),
                     zalik.dean(),
                     zalik.students()


### PR DESCRIPTION
## Summary
- pass the selected control type through statement PDF data for course project reports
- render a control type row in the statement header when available
- keep student table headers compatible with PDF generation so multi-page statements preserve column context

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69510c2d14f8832695acf2f497b55819)