### PR TITLE
Fix course project PDF header and pagination

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/StudentModelToDocumentGenerate.java
+++ b/src/main/java/com/esvar/dekanat/generate/StudentModelToDocumentGenerate.java
@@ -4,15 +4,23 @@ import java.time.LocalDate;
 
 public record StudentModelToDocumentGenerate(int index, String name, String studentNumber, String nationalMark,
                                              String mark, String ectsMark, LocalDate date,
-                                             String dateText, String teacherSignPlaceholder) {
+                                             String dateText, String teacherSignPlaceholder,
+                                             String markText) {
 
     public StudentModelToDocumentGenerate {
         dateText = dateText == null ? "" : dateText;
         teacherSignPlaceholder = teacherSignPlaceholder == null ? "" : teacherSignPlaceholder;
+        markText = markText == null ? "" : markText;
     }
 
     public StudentModelToDocumentGenerate(int index, String name, String studentNumber, String nationalMark,
                                           String mark, String ectsMark, LocalDate date, String dateText) {
-        this(index, name, studentNumber, nationalMark, mark, ectsMark, date, dateText, "");
+        this(index, name, studentNumber, nationalMark, mark, ectsMark, date, dateText, "", "");
+    }
+
+    public StudentModelToDocumentGenerate(int index, String name, String studentNumber, String nationalMark,
+                                          String mark, String ectsMark, LocalDate date, String dateText,
+                                          String markText) {
+        this(index, name, studentNumber, nationalMark, mark, ectsMark, date, dateText, "", markText);
     }
 }

--- a/src/main/java/com/esvar/dekanat/generate/pdf/BaseStatementPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/BaseStatementPdfGenerator.java
@@ -132,11 +132,6 @@ public abstract class BaseStatementPdfGenerator implements PdfGenerator {
         List<StudentModelToDocumentGenerate> students =
                 data.students() == null ? Collections.emptyList() : data.students();
 
-        if (students.size() > 1) {
-            Table mainTable = buildStudentsTable(students.subList(0, students.size() - 1), regular, bold);
-            document.add(mainTable);
-        }
-
         List<StudentModelToDocumentGenerate> lastRows = students.isEmpty()
                 ? Collections.emptyList()
                 : List.of(students.get(students.size() - 1));
@@ -145,13 +140,18 @@ public abstract class BaseStatementPdfGenerator implements PdfGenerator {
         tailSection.add(buildStudentsTable(lastRows, regular, bold));
         tailSection.add(buildFooter(data, regular, bold));
 
-        float remainingHeight = remainingHeight(renderer, document);
+        float availableHeight = remainingHeight(renderer, document);
         float tailHeight = measureHeight(tailSection, document);
 
-        if (tailHeight > remainingHeight) {
-            document.add(new AreaBreak(AreaBreakType.NEXT_PAGE));
+        if (students.size() <= 1 || tailHeight <= availableHeight) {
+            document.add(buildStudentsTable(students, regular, bold));
+            document.add(buildFooter(data, regular, bold));
+            return;
         }
 
+        Table mainTable = buildStudentsTable(students.subList(0, students.size() - 1), regular, bold);
+        document.add(mainTable);
+        document.add(new AreaBreak(AreaBreakType.NEXT_PAGE));
         document.add(tailSection);
     }
 
@@ -271,15 +271,16 @@ public abstract class BaseStatementPdfGenerator implements PdfGenerator {
         Table semControlTable = new Table(UnitValue.createPercentArray(new float[]{10, 10, 80}))
                 .useAllAvailableWidth();
         semControlTable.addCell(noBorderCell("за", regular, TextAlignment.LEFT));
-        semControlTable.addCell(underlinedCell(safeText(data.semesterNumber()), regular));
-        semControlTable.addCell(noBorderCell("-й навчальний семестр.", regular, TextAlignment.LEFT));
+        semControlTable.addCell(underlinedCell(safeText(data.semesterNumber()) + "-й", regular));
+        semControlTable.addCell(noBorderCell(" навчальний семестр.", regular, TextAlignment.LEFT));
         return semControlTable;
     }
 
     private Table buildControlTypeRow(StatementDocumentData data, PdfFont regular) {
         Table controlTypeTable = new Table(UnitValue.createPercentArray(new float[]{25, 60, 15}))
                 .useAllAvailableWidth();
-        controlTypeTable.addCell(noBorderCell("Тип контролю: ", regular, TextAlignment.LEFT));
+        String label = documentType == DocumentType.COURSE_PROJECT ? "Вид роботи: " : "Тип контролю: ";
+        controlTypeTable.addCell(noBorderCell(label, regular, TextAlignment.LEFT));
         controlTypeTable.addCell(underlinedCell(safeText(data.controlTypeName()), regular));
         controlTypeTable.addCell(noBorderCell("", regular, TextAlignment.LEFT));
         return controlTypeTable;

--- a/src/main/java/com/esvar/dekanat/generate/pdf/CourseProjectPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/CourseProjectPdfGenerator.java
@@ -116,6 +116,9 @@ public class CourseProjectPdfGenerator implements PdfGenerator {
         document.add(centered(formatDate(data), bold, DEFAULT_FONT_SIZE).setUnderline());
 
         document.add(buildDisciplineRow(data, regular));
+        if (!safeText(data.controlTypeName()).isBlank()) {
+            document.add(buildWorkTypeRow(data, regular));
+        }
         document.add(buildSemesterRow(data, regular));
         document.add(buildTeacherRow("Викладач", data.teacherFullName1(),
                 "( прізвище, ім’я та по батькові викладача, який виставляє підсумкову оцінку)", regular));
@@ -131,11 +134,6 @@ public class CourseProjectPdfGenerator implements PdfGenerator {
                                        MeasuringDocumentRenderer renderer) {
         List<StudentRow> students = data.students() == null ? Collections.emptyList() : data.students();
 
-        if (students.size() > 1) {
-            Table mainTable = buildStudentsTable(students.subList(0, students.size() - 1), regular, bold);
-            document.add(mainTable);
-        }
-
         List<StudentRow> lastRows = students.isEmpty()
                 ? Collections.emptyList()
                 : List.of(students.get(students.size() - 1));
@@ -144,13 +142,18 @@ public class CourseProjectPdfGenerator implements PdfGenerator {
         tailSection.add(buildStudentsTable(lastRows, regular, bold));
         tailSection.add(buildFooter(data, regular, bold));
 
-        float availableHeight = getAvailableHeight(document, renderer);
         float tailHeight = measureHeight(tailSection, document);
+        float availableHeight = getAvailableHeight(document, renderer);
 
-        if (tailHeight > availableHeight) {
-            document.add(new AreaBreak(AreaBreakType.NEXT_PAGE));
+        if (students.size() <= 1 || tailHeight <= availableHeight) {
+            document.add(buildStudentsTable(students, regular, bold));
+            document.add(buildFooter(data, regular, bold));
+            return;
         }
 
+        Table mainTable = buildStudentsTable(students.subList(0, students.size() - 1), regular, bold);
+        document.add(mainTable);
+        document.add(new AreaBreak(AreaBreakType.NEXT_PAGE));
         document.add(tailSection);
     }
 
@@ -265,12 +268,25 @@ public class CourseProjectPdfGenerator implements PdfGenerator {
         return disciplineTable;
     }
 
+    private Table buildWorkTypeRow(CourseProjectData data, PdfFont regular) {
+        Table workTypeTable = new Table(UnitValue.createPercentArray(new float[]{25, 60, 15}))
+                .useAllAvailableWidth();
+        workTypeTable.addCell(noBorderCell("Вид роботи: ", regular, TextAlignment.LEFT));
+        String workType = safeText(data.controlTypeName());
+        if (workType.isBlank()) {
+            workType = "Курсовий проєкт";
+        }
+        workTypeTable.addCell(underlinedCell(workType, regular));
+        workTypeTable.addCell(noBorderCell("", regular, TextAlignment.LEFT));
+        return workTypeTable;
+    }
+
     private Table buildSemesterRow(CourseProjectData data, PdfFont regular) {
         Table semControlTable = new Table(UnitValue.createPercentArray(new float[]{10, 10, 80}))
                 .useAllAvailableWidth();
         semControlTable.addCell(noBorderCell("за", regular, TextAlignment.LEFT));
-        semControlTable.addCell(underlinedCell(safeText(data.semesterNumber()), regular));
-        semControlTable.addCell(noBorderCell("-й навчальний семестр.", regular, TextAlignment.LEFT));
+        semControlTable.addCell(underlinedCell(safeText(data.semesterNumber()) + "-й", regular));
+        semControlTable.addCell(noBorderCell(" навчальний семестр.", regular, TextAlignment.LEFT));
         return semControlTable;
     }
 
@@ -445,8 +461,9 @@ public class CourseProjectPdfGenerator implements PdfGenerator {
     }
 
     private String resolveMarkText(StudentRow row) {
-        if (!safeText(row.markText()).isBlank()) {
-            return safeText(row.markText());
+        String textMark = safeText(row.markText());
+        if (!textMark.isBlank()) {
+            return textMark;
         }
         return safeText(row.mark());
     }
@@ -496,6 +513,7 @@ public class CourseProjectPdfGenerator implements PdfGenerator {
             String dateText,
             String disciplineName,
             String semesterNumber,
+            String controlTypeName,
             String teacherFullName1,
             String teacherFullName2,
             String dean,
@@ -520,6 +538,7 @@ public class CourseProjectPdfGenerator implements PdfGenerator {
                         null,
                         zalik.disciplineName(),
                         zalik.semesterNumber(),
+                        zalik.controlTypeName(),
                         zalik.firstTeacher(),
                         zalik.secondTeacher(),
                         zalik.dean(),
@@ -552,7 +571,7 @@ public class CourseProjectPdfGenerator implements PdfGenerator {
                     student.index(),
                     student.name(),
                     student.studentNumber(),
-                    student.nationalMark(),
+                    student.markText(),
                     student.mark(),
                     student.date(),
                     student.dateText(),

--- a/src/main/java/com/esvar/dekanat/generate/pdf/DocumentType.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/DocumentType.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 public enum DocumentType {
     CONTROL_WORK("control-work", "Відмітка про зарахування контрольної роботи («зараховано»)", false),
     COURSE_WORK("course-work", "Відмітка про зарахування курсової роботи", true),
-    COURSE_PROJECT("course-project", "Відмітка про зарахування курсового проєкту", true);
+    COURSE_PROJECT("course-project", "Оцінка за курсовий проєкт", true);
 
     private final String outputSuffix;
     private final String markColumnHeader;
@@ -42,6 +42,12 @@ public enum DocumentType {
     public String resolveMark(StudentModelToDocumentGenerate student) {
         if (student == null) {
             return "";
+        }
+        if (this == COURSE_PROJECT) {
+            String markText = Objects.toString(student.markText(), "");
+            if (!markText.isBlank()) {
+                return markText;
+            }
         }
         String mark = Objects.toString(student.nationalMark(), "");
         if (mark.isBlank()) {


### PR DESCRIPTION
## Summary
- add explicit "Вид роботи" row and fix semester formatting in course project statements
- use a dedicated mark text field for course project grades and update column header/label wording
- adjust pagination for the last student plus footer to avoid duplicate table headers when the tail fits on a page

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951142f387c8326a0168dc87b05b077)