### PR TITLE
pdf: truncate long student names

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/pdf/BaseStatementPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/BaseStatementPdfGenerator.java
@@ -27,6 +27,8 @@ import com.itextpdf.layout.layout.LayoutArea;
 import com.itextpdf.layout.layout.LayoutContext;
 import com.itextpdf.layout.layout.LayoutResult;
 import com.itextpdf.layout.properties.AreaBreakType;
+import com.itextpdf.layout.properties.Overflow;
+import com.itextpdf.layout.properties.Property;
 import com.itextpdf.layout.properties.TextAlignment;
 import com.itextpdf.layout.properties.UnitValue;
 import com.itextpdf.layout.renderer.DocumentRenderer;
@@ -352,11 +354,15 @@ public abstract class BaseStatementPdfGenerator implements PdfGenerator {
     }
 
     private Cell bodyCell(String text, PdfFont font, TextAlignment alignment) {
+        Paragraph paragraph = new Paragraph(text)
+                .setFont(font)
+                .setFontSize(10f)
+                .setTextAlignment(alignment)
+                .setProperty(Property.NO_WRAP, true)
+                .setProperty(Property.OVERFLOW, Overflow.HIDDEN);
+
         return new Cell()
-                .add(new Paragraph(text)
-                        .setFont(font)
-                        .setFontSize(10f)
-                        .setTextAlignment(alignment))
+                .add(paragraph)
                 .setBorder(new SolidBorder(BORDER_WIDTH))
                 .setPadding(4f);
     }

--- a/src/main/java/com/esvar/dekanat/generate/pdf/BaseZalikStylePdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/BaseZalikStylePdfGenerator.java
@@ -25,6 +25,8 @@ import com.itextpdf.layout.element.Div;
 import com.itextpdf.layout.element.LineSeparator;
 import com.itextpdf.layout.element.Paragraph;
 import com.itextpdf.layout.element.Table;
+import com.itextpdf.layout.properties.Overflow;
+import com.itextpdf.layout.properties.Property;
 import com.itextpdf.layout.properties.TextAlignment;
 import com.itextpdf.layout.properties.UnitValue;
 import org.slf4j.Logger;
@@ -492,11 +494,15 @@ public abstract class BaseZalikStylePdfGenerator implements PdfGenerator {
     }
 
     private static Cell bodyCell(String text, PdfFont font, TextAlignment alignment) {
+        Paragraph paragraph = new Paragraph(safe(text))
+                .setFont(font)
+                .setFontSize(10f)
+                .setTextAlignment(alignment)
+                .setProperty(Property.NO_WRAP, true)
+                .setProperty(Property.OVERFLOW, Overflow.HIDDEN);
+
         return new Cell()
-                .add(new Paragraph(safe(text))
-                        .setFont(font)
-                        .setFontSize(10f)
-                        .setTextAlignment(alignment))
+                .add(paragraph)
                 .setBorder(new SolidBorder(0.5f))
                 .setPadding(4f);
     }
@@ -664,11 +670,15 @@ public abstract class BaseZalikStylePdfGenerator implements PdfGenerator {
     }
 
     private static Cell bodyCell(String text, PdfFont font, TextAlignment alignment, int rowSpan, int colSpan) {
+        Paragraph paragraph = new Paragraph(safe(text))
+                .setFont(font)
+                .setFontSize(10f)
+                .setTextAlignment(alignment)
+                .setProperty(Property.NO_WRAP, true)
+                .setProperty(Property.OVERFLOW, Overflow.HIDDEN);
+
         return new Cell(rowSpan, colSpan)
-                .add(new Paragraph(safe(text))
-                        .setFont(font)
-                        .setFontSize(10f)
-                        .setTextAlignment(alignment))
+                .add(paragraph)
                 .setBorder(new SolidBorder(0.5f))
                 .setPadding(4f);
     }
@@ -741,10 +751,14 @@ public abstract class BaseZalikStylePdfGenerator implements PdfGenerator {
     }
 
     private Cell defaultCell(String text, PdfFont font, TextAlignment alignment) {
-        return new Cell().add(new Paragraph(text == null ? "" : text)
-                        .setFont(font)
-                        .setFontSize(10)
-                        .setTextAlignment(alignment))
+        Paragraph paragraph = new Paragraph(text == null ? "" : text)
+                .setFont(font)
+                .setFontSize(10)
+                .setTextAlignment(alignment)
+                .setProperty(Property.NO_WRAP, true)
+                .setProperty(Property.OVERFLOW, Overflow.HIDDEN);
+
+        return new Cell().add(paragraph)
                 .setPadding(4);
     }
 

--- a/src/main/java/com/esvar/dekanat/generate/pdf/ZalikSheetPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/ZalikSheetPdfGenerator.java
@@ -23,6 +23,8 @@ import com.itextpdf.layout.element.Cell;
 import com.itextpdf.layout.element.LineSeparator;
 import com.itextpdf.layout.element.Paragraph;
 import com.itextpdf.layout.element.Table;
+import com.itextpdf.layout.properties.Overflow;
+import com.itextpdf.layout.properties.Property;
 import com.itextpdf.layout.properties.TextAlignment;
 import com.itextpdf.layout.properties.UnitValue;
 import org.springframework.stereotype.Component;
@@ -343,11 +345,15 @@ public final class ZalikSheetPdfGenerator implements PdfGenerator {
     }
 
     private static Cell bodyCell(String text, PdfFont font, TextAlignment alignment) {
+        Paragraph paragraph = new Paragraph(safe(text))
+                .setFont(font)
+                .setFontSize(BODY_FONT_SIZE)
+                .setTextAlignment(alignment)
+                .setProperty(Property.NO_WRAP, true)
+                .setProperty(Property.OVERFLOW, Overflow.HIDDEN);
+
         return new Cell()
-                .add(new Paragraph(safe(text))
-                        .setFont(font)
-                        .setFontSize(BODY_FONT_SIZE)
-                        .setTextAlignment(alignment))
+                .add(paragraph)
                 .setBorder(new SolidBorder(0.5f))
                 .setPadding(4f);
     }


### PR DESCRIPTION
## Summary
- prevent long student names in statement tables from wrapping by enforcing no-wrap with hidden overflow
- apply the truncation behavior across zalik-style, exam, and zalik sheet PDF generators to keep table rows on one line

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695671f93d908326b1417d3baa7780ca)