### PR TITLE
Add handwritten date placeholders to statement PDFs

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/pdf/BaseStatementPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/BaseStatementPdfGenerator.java
@@ -55,6 +55,7 @@ public abstract class BaseStatementPdfGenerator implements PdfGenerator {
     private static final Logger log = LoggerFactory.getLogger(BaseStatementPdfGenerator.class);
     private static final float BORDER_WIDTH = 0.5f;
     private static final float DEFAULT_FONT_SIZE = 11f;
+    private static final String MISSING_DATE_PLACEHOLDER = "____.__.____";
     private final DocumentType documentType;
 
     protected BaseStatementPdfGenerator(DocumentType documentType) {
@@ -453,7 +454,11 @@ public abstract class BaseStatementPdfGenerator implements PdfGenerator {
         if (row.date() != null) {
             return formatDate(row.date());
         }
-        return safeText(row.dateText());
+        String dateText = safeText(row.dateText());
+        if (!dateText.isBlank()) {
+            return dateText;
+        }
+        return MISSING_DATE_PLACEHOLDER;
     }
 
     private static String formatDate(LocalDate date) {

--- a/src/main/java/com/esvar/dekanat/generate/pdf/BaseZalikStylePdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/BaseZalikStylePdfGenerator.java
@@ -467,7 +467,7 @@ public abstract class BaseZalikStylePdfGenerator implements PdfGenerator {
         if (row.dateText() != null && !row.dateText().isBlank()) {
             return row.dateText();
         }
-        return "";
+        return "____.__.____";
     }
 
     private static String formatDate(LocalDate date) {

--- a/src/main/java/com/esvar/dekanat/generate/pdf/CourseProjectPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/CourseProjectPdfGenerator.java
@@ -457,7 +457,11 @@ public class CourseProjectPdfGenerator implements PdfGenerator {
         if (row.date() != null) {
             return row.date().format(DateTimeFormatter.ofPattern("dd.MM.yyyy"));
         }
-        return safeText(row.dateText());
+        String dateText = safeText(row.dateText());
+        if (!dateText.isBlank()) {
+            return dateText;
+        }
+        return "____.__.____";
     }
 
     private String resolveMarkText(StudentRow row) {

--- a/src/main/java/com/esvar/dekanat/generate/pdf/ExamPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/ExamPdfGenerator.java
@@ -526,7 +526,7 @@ public class ExamPdfGenerator implements PdfGenerator {
         if (row.dateText() != null && !row.dateText().isBlank()) {
             return row.dateText();
         }
-        return "";
+        return "____.__.____";
     }
 
     private static String formatDate(LocalDate date) {

--- a/src/main/java/com/esvar/dekanat/generate/pdf/ZalikSheetPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/ZalikSheetPdfGenerator.java
@@ -439,7 +439,7 @@ public final class ZalikSheetPdfGenerator implements PdfGenerator {
         if (row.dateText() != null && !row.dateText().isBlank()) {
             return row.dateText();
         }
-        return "";
+        return "____.__.____";
     }
 
     private static String formatDate(LocalDate date) {


### PR DESCRIPTION
## Summary
- add a handwritten-date placeholder when per-student dates are missing in statement-style PDFs
- apply the placeholder across exam, zalik, course project, and base statement generators

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956732baec4832699ea663c696502cf)