### PR TITLE
Fix static helpers in zalik sheet PDF generator

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/pdf/ZalikSheetPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/ZalikSheetPdfGenerator.java
@@ -43,9 +43,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
-import static com.esvar.dekanat.generate.pdf.BaseStatementPdfGenerator.BORDER_WIDTH;
-import static com.esvar.dekanat.generate.pdf.BaseStatementPdfGenerator.safeText;
-
 /**
  * iText 7 generator for "ВІДОМІСТЬ ОБЛІКУ УСПІШНОСТІ" (залік/екзамен) sheets.
  *
@@ -61,6 +58,7 @@ public final class ZalikSheetPdfGenerator implements PdfGenerator {
     private static final float HEADER_FONT_SIZE = 12f;
     private static final float BODY_FONT_SIZE = 10f;
     private static final float SMALL_FONT_SIZE = 8f;
+    private static final float BORDER_WIDTH = 0.5f;
 
     @Override
     public String getName() {
@@ -348,8 +346,8 @@ public final class ZalikSheetPdfGenerator implements PdfGenerator {
                 .setPadding(3f);
     }
 
-    private Cell bodyCell(String text, PdfFont font, TextAlignment alignment) {
-        Paragraph p = new Paragraph(safeText(text));
+    private static Cell bodyCell(String text, PdfFont font, TextAlignment alignment) {
+        Paragraph p = new Paragraph(safe(text));
         p.setFont(font);
         p.setFontSize(10f);
         p.setTextAlignment(alignment);


### PR DESCRIPTION
## Summary
- add a local border width constant for the zalik PDF generator
- use the local safe helper instead of the BaseStatementPdfGenerator private method

## Testing
- ./mvnw -DskipTests compile *(fails: unable to download Maven wrapper distribution)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69568354af288326864d5d3f5bd12954)