### PR TITLE
Fix static helpers in zalik sheet PDF generator

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/pdf/BaseZalikStylePdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/BaseZalikStylePdfGenerator.java
@@ -25,8 +25,8 @@ import com.itextpdf.layout.element.Div;
 import com.itextpdf.layout.element.LineSeparator;
 import com.itextpdf.layout.element.Paragraph;
 import com.itextpdf.layout.element.Table;
-import com.itextpdf.layout.properties.Overflow;
 import com.itextpdf.layout.properties.Property;
+import com.itextpdf.layout.properties.OverflowPropertyValue;
 import com.itextpdf.layout.properties.TextAlignment;
 import com.itextpdf.layout.properties.UnitValue;
 import org.slf4j.Logger;
@@ -499,7 +499,7 @@ public abstract class BaseZalikStylePdfGenerator implements PdfGenerator {
                 .setFontSize(10f)
                 .setTextAlignment(alignment)
                 .setProperty(Property.NO_WRAP, true)
-                .setProperty(Property.OVERFLOW, Overflow.HIDDEN);
+                .setProperty(Property.OVERFLOW, OverflowPropertyValue.HIDDEN);
 
         return new Cell()
                 .add(paragraph)
@@ -675,7 +675,7 @@ public abstract class BaseZalikStylePdfGenerator implements PdfGenerator {
                 .setFontSize(10f)
                 .setTextAlignment(alignment)
                 .setProperty(Property.NO_WRAP, true)
-                .setProperty(Property.OVERFLOW, Overflow.HIDDEN);
+                .setProperty(Property.OVERFLOW, OverflowPropertyValue.HIDDEN);
 
         return new Cell(rowSpan, colSpan)
                 .add(paragraph)
@@ -756,7 +756,7 @@ public abstract class BaseZalikStylePdfGenerator implements PdfGenerator {
                 .setFontSize(10)
                 .setTextAlignment(alignment)
                 .setProperty(Property.NO_WRAP, true)
-                .setProperty(Property.OVERFLOW, Overflow.HIDDEN);
+                .setProperty(Property.OVERFLOW, OverflowPropertyValue.HIDDEN);
 
         return new Cell().add(paragraph)
                 .setPadding(4);

--- a/src/main/java/com/esvar/dekanat/generate/pdf/ZalikSheetPdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/ZalikSheetPdfGenerator.java
@@ -43,9 +43,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
-import static com.esvar.dekanat.generate.pdf.BaseStatementPdfGenerator.BORDER_WIDTH;
-import static com.esvar.dekanat.generate.pdf.BaseStatementPdfGenerator.safeText;
-
 /**
  * iText 7 generator for "ВІДОМІСТЬ ОБЛІКУ УСПІШНОСТІ" (залік/екзамен) sheets.
  *
@@ -61,6 +58,7 @@ public final class ZalikSheetPdfGenerator implements PdfGenerator {
     private static final float HEADER_FONT_SIZE = 12f;
     private static final float BODY_FONT_SIZE = 10f;
     private static final float SMALL_FONT_SIZE = 8f;
+    private static final float BORDER_WIDTH = 0.5f;
 
     @Override
     public String getName() {
@@ -348,8 +346,8 @@ public final class ZalikSheetPdfGenerator implements PdfGenerator {
                 .setPadding(3f);
     }
 
-    private Cell bodyCell(String text, PdfFont font, TextAlignment alignment) {
-        Paragraph p = new Paragraph(safeText(text));
+    private static Cell bodyCell(String text, PdfFont font, TextAlignment alignment) {
+        Paragraph p = new Paragraph(safe(text));
         p.setFont(font);
         p.setFontSize(10f);
         p.setTextAlignment(alignment);


### PR DESCRIPTION
## Summary
- add a local border width constant for the zalik PDF generator
- use the local safe helper instead of the BaseStatementPdfGenerator private method
- replace deprecated Overflow usage with OverflowPropertyValue in the base zalik generator

## Testing
- ./mvnw -DskipTests compile *(fails: unable to download Maven wrapper distribution)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69568354af288326864d5d3f5bd12954)