### PR TITLE
Fix overflow property chaining in zalik PDF generator

### DIFF
--- a/src/main/java/com/esvar/dekanat/generate/pdf/BaseZalikStylePdfGenerator.java
+++ b/src/main/java/com/esvar/dekanat/generate/pdf/BaseZalikStylePdfGenerator.java
@@ -497,9 +497,10 @@ public abstract class BaseZalikStylePdfGenerator implements PdfGenerator {
         Paragraph paragraph = new Paragraph(safe(text))
                 .setFont(font)
                 .setFontSize(10f)
-                .setTextAlignment(alignment)
-                .setProperty(Property.OVERFLOW_X, OverflowPropertyValue.HIDDEN)
-                .setProperty(Property.OVERFLOW_Y, OverflowPropertyValue.HIDDEN);
+                .setTextAlignment(alignment);
+
+        paragraph.setProperty(Property.OVERFLOW_X, OverflowPropertyValue.HIDDEN);
+        paragraph.setProperty(Property.OVERFLOW_Y, OverflowPropertyValue.HIDDEN);
 
         return new Cell()
                 .add(paragraph)
@@ -683,9 +684,10 @@ public abstract class BaseZalikStylePdfGenerator implements PdfGenerator {
         Paragraph paragraph = new Paragraph(safe(text))
                 .setFont(font)
                 .setFontSize(10f)
-                .setTextAlignment(alignment)
-                .setProperty(Property.OVERFLOW_X, OverflowPropertyValue.HIDDEN)
-                .setProperty(Property.OVERFLOW_Y, OverflowPropertyValue.HIDDEN);
+                .setTextAlignment(alignment);
+
+        paragraph.setProperty(Property.OVERFLOW_X, OverflowPropertyValue.HIDDEN);
+        paragraph.setProperty(Property.OVERFLOW_Y, OverflowPropertyValue.HIDDEN);
 
         return new Cell(rowSpan, colSpan)
                 .add(paragraph)
@@ -763,9 +765,10 @@ public abstract class BaseZalikStylePdfGenerator implements PdfGenerator {
         Paragraph paragraph = new Paragraph(text == null ? "" : text)
                 .setFont(font)
                 .setFontSize(10)
-                .setTextAlignment(alignment)
-                .setProperty(Property.OVERFLOW_X, OverflowPropertyValue.HIDDEN)
-                .setProperty(Property.OVERFLOW_Y, OverflowPropertyValue.HIDDEN);
+                .setTextAlignment(alignment);
+
+        paragraph.setProperty(Property.OVERFLOW_X, OverflowPropertyValue.HIDDEN);
+        paragraph.setProperty(Property.OVERFLOW_Y, OverflowPropertyValue.HIDDEN);
 
         return new Cell().add(paragraph)
                 .setPadding(4);


### PR DESCRIPTION
## Summary
- set paragraph overflow properties separately in zalik PDF generator to avoid method chaining issues
- preserve overflow hiding on body and summary cells

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695699775c7c8326ab26681685bc1d76)