### PR TITLE
Handle locked marks with explicit unlock flow

### DIFF
--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -11,6 +11,7 @@ import com.esvar.dekanat.security.SecurityService;
 import com.esvar.dekanat.service.*;
 import com.esvar.dekanat.service.SummaryReportService.SummaryReportGenerationException;
 import com.esvar.dekanat.service.SummaryReportService.SummaryReportResult;
+import com.esvar.dekanat.service.exception.MarkLockedException;
 import com.esvar.dekanat.utilites.ContentDispositionUtils;
 import com.esvar.dekanat.user.UserModel;
 import com.esvar.dekanat.user.UserRepository;
@@ -36,7 +37,6 @@ import com.vaadin.flow.component.progressbar.ProgressBar;
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.component.textfield.IntegerField;
-import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.data.value.ValueChangeMode;
@@ -50,6 +50,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -376,65 +377,83 @@ public class EnterMarksView extends Div {
 
         // Обробник кнопки "Зберегти" із використанням фабрики процесорів
         saveButton.addClickListener(event -> {
-            List<MarkDTO> markDTOList = getSelectedOrAllMarks();
+            try {
+                List<MarkDTO> markDTOList = getSelectedOrAllMarks();
 
-            String controlType = selectControlType.getValue();
-            MarkProcessor processor = MarkProcessorFactory.getProcessor(controlType, marksService, userRepository,
-                    securityService, studentService, marksPartsService, controlMethodService, controlPartsService);
+                String controlType = selectControlType.getValue();
+                MarkProcessor processor = MarkProcessorFactory.getProcessor(controlType, marksService, userRepository,
+                        securityService, studentService, marksPartsService, controlMethodService, controlPartsService);
 
-            List<MarksEntity> toSave = new ArrayList<>();
+                List<MarksEntity> toSave = new ArrayList<>();
 
-            for (MarkDTO markDTO : markDTOList) {
-                if (markDTO.isLocked()) {
-                    continue;
+                for (MarkDTO markDTO : markDTOList) {
+                    if (markDTO.isLocked()) {
+                        continue;
+                    }
+                    MarksEntity marksEntity = processor.processMark(markDTO, plansEntity, requireCurrentGroup(), controlType);
+                    if (!processor.isPersistedAfterProcessing()) {
+                        toSave.add(marksEntity);
+                    }
                 }
-                MarksEntity marksEntity = processor.processMark(markDTO, plansEntity, requireCurrentGroup(), controlType);
                 if (!processor.isPersistedAfterProcessing()) {
-                    toSave.add(marksEntity);
+                    marksService.saveMarks(toSave);
                 }
+            } catch (MarkLockedException e) {
+                showErrorNotification(e.getMessage());
+            } catch (Exception e) {
+                log.error("Не вдалося зберегти оцінки", e);
+                showErrorNotification("Не вдалося зберегти оцінки.");
+            } finally {
+                updateGrid();
             }
-            if (!processor.isPersistedAfterProcessing()) {
-                marksService.saveMarks(toSave);
-            }
-            updateGrid();
         });
 
         // Обробники кнопок "Затвердити" та "Розблокувати"
         approveButton.addClickListener(event -> {
-            List<MarkDTO> markDTOList = getSelectedOrAllMarks();
-            String controlType = selectControlType.getValue();
-            MarkProcessor processor = MarkProcessorFactory.getProcessor(controlType, marksService, userRepository,
-                    securityService, studentService, marksPartsService, controlMethodService, controlPartsService);
-            List<MarksEntity> toSave = new ArrayList<>();
-            for (MarkDTO markDTO : markDTOList) {
-                if (markDTO.isLocked()) {
-                    continue;
+            try {
+                List<MarkDTO> markDTOList = getSelectedOrAllMarks();
+                String controlType = selectControlType.getValue();
+                MarkProcessor processor = MarkProcessorFactory.getProcessor(controlType, marksService, userRepository,
+                        securityService, studentService, marksPartsService, controlMethodService, controlPartsService);
+                List<MarksEntity> toSave = new ArrayList<>();
+                for (MarkDTO markDTO : markDTOList) {
+                    if (markDTO.isLocked()) {
+                        continue;
+                    }
+                    MarksEntity marksEntity = processor.processMark(markDTO, plansEntity, requireCurrentGroup(), controlType);
+                    marksEntity.setLastUpdated(new Timestamp(System.currentTimeMillis()));
+                    marksEntity.setLastUpdatedBy(userRepository.findByEmail(securityService.getAuthenticatedUser().getUsername()).orElseThrow());
+                    marksEntity.setLocked(true);
+                    toSave.add(marksEntity);
                 }
-                MarksEntity marksEntity = processor.processMark(markDTO, plansEntity, requireCurrentGroup(), controlType);
-                marksEntity.setLastUpdated(new Timestamp(System.currentTimeMillis()));
-                marksEntity.setLastUpdatedBy(userRepository.findByEmail(securityService.getAuthenticatedUser().getUsername()).orElseThrow());
-                marksEntity.setLocked(true);
-                toSave.add(marksEntity);
+                marksService.saveMarks(toSave);
+            } catch (MarkLockedException e) {
+                showErrorNotification(e.getMessage());
+            } catch (Exception e) {
+                log.error("Не вдалося затвердити оцінки", e);
+                showErrorNotification("Не вдалося затвердити оцінки.");
+            } finally {
+                updateGrid();
             }
-            marksService.saveMarks(toSave);
-            updateGrid();
         });
 
         unlockButton.addClickListener(event -> {
-            List<MarkDTO> markDTOList = getSelectedOrAllMarks();
-            List<MarksEntity> toSave = new ArrayList<>();
-            for (MarkDTO markDTO : markDTOList) {
-                if (!markDTO.isLocked()) {
-                    continue;
+            try {
+                List<MarkDTO> markDTOList = getSelectedOrAllMarks();
+                for (MarkDTO markDTO : markDTOList) {
+                    if (!markDTO.isLocked() || markDTO.getId() == null) {
+                        continue;
+                    }
+                    marksService.unlockMark(markDTO.getId());
                 }
-                MarksEntity marksEntity = marksService.getMarkById(markDTO.getId());
-                marksEntity.setLastUpdated(new Timestamp(System.currentTimeMillis()));
-                marksEntity.setLastUpdatedBy(userRepository.findByEmail(securityService.getAuthenticatedUser().getUsername()).orElseThrow());
-                marksEntity.setLocked(false);
-                toSave.add(marksEntity);
+            } catch (AccessDeniedException e) {
+                showErrorNotification(e.getMessage());
+            } catch (Exception e) {
+                log.error("Не вдалося розблокувати оцінки", e);
+                showErrorNotification("Не вдалося розблокувати оцінки.");
+            } finally {
+                updateGrid();
             }
-            marksService.saveMarks(toSave);
-            updateGrid();
         });
 
         printReportButton.addClickListener(e -> showSecondTeacherDialog());
@@ -797,6 +816,11 @@ public class EnterMarksView extends Div {
         for (MarkDTO dto : list) {
             dto.setRowNum(i++);
         }
+    }
+
+    private void showErrorNotification(String message) {
+        Notification notification = Notification.show(message, 5000, Notification.Position.MIDDLE);
+        notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
     }
 
 

--- a/src/main/java/com/esvar/dekanat/service/MarksService.java
+++ b/src/main/java/com/esvar/dekanat/service/MarksService.java
@@ -1,6 +1,5 @@
 package com.esvar.dekanat.service;
 
-import com.esvar.dekanat.dto.MarkDTO;
 import com.esvar.dekanat.entity.ControlMethodEntity;
 import com.esvar.dekanat.entity.MarksEntity;
 import com.esvar.dekanat.entity.PlansEntity;
@@ -8,8 +7,12 @@ import com.esvar.dekanat.entity.StudentEntity;
 import com.esvar.dekanat.repository.ControlMethodRepository;
 import com.esvar.dekanat.repository.MarksRepository;
 import com.esvar.dekanat.security.SecurityService;
+import com.esvar.dekanat.service.exception.MarkLockedException;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +45,15 @@ public class MarksService {
      */
     @Transactional
     public MarksEntity saveMark(MarksEntity mark) {
+        return saveMarkInternal(mark, false);
+    }
+
+    @Transactional
+    public MarksEntity saveMarkAllowingLockedUpdate(MarksEntity mark) {
+        return saveMarkInternal(mark, true);
+    }
+
+    private MarksEntity saveMarkInternal(MarksEntity mark, boolean allowLockedOverride) {
         if (mark == null || mark.getStudent() == null || mark.getPlan() == null || mark.getControlMethod() == null) {
             throw new IllegalArgumentException("Студент, план і метод контролю повинні бути задані.");
         }
@@ -64,6 +76,9 @@ public class MarksService {
             );
 
             MarksEntity existing = existingOptional.orElseThrow(() -> new IllegalArgumentException("Оцінка не знайдена."));
+            if (existing.isLocked() && !allowLockedOverride) {
+                throw new MarkLockedException("Оцінка заблокована і не може бути змінена без розблокування.");
+            }
 
             existing.setFinalGrade(mark.getFinalGrade());
             existing.setLocked(mark.isLocked());
@@ -82,6 +97,38 @@ public class MarksService {
         }
         ratingService.updateRatingForStudent(saved.getStudent());
         return saved;
+    }
+
+    @Transactional
+    public MarksEntity unlockMark(Long markId) {
+        if (markId == null) {
+            throw new IllegalArgumentException("Ідентифікатор оцінки повинен бути заданий.");
+        }
+        MarksEntity existing = marksRepository.findById(markId)
+                .orElseThrow(() -> new IllegalArgumentException("Оцінка не знайдена."));
+        if (!canCurrentUserUnlockMarks()) {
+            throw new AccessDeniedException("У вас немає прав для розблокування оцінок.");
+        }
+        if (!existing.isLocked()) {
+            return existing;
+        }
+        existing.setLocked(false);
+        existing.setLastUpdated(new Timestamp(System.currentTimeMillis()));
+        existing.setLastUpdatedBy(
+                securityService.getCurrentUserModel()
+                        .orElseThrow(() -> new IllegalStateException("No authenticated user"))
+        );
+        return saveMarkInternal(existing, true);
+    }
+
+    private boolean canCurrentUserUnlockMarks() {
+        UserDetails userDetails = securityService.getAuthenticatedUser();
+        if (userDetails == null) {
+            throw new IllegalStateException("No authenticated user");
+        }
+        return userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(authority -> authority.startsWith("ROLE_ADMIN") || authority.startsWith("ROLE_DEKANAT"));
     }
 
 

--- a/src/main/java/com/esvar/dekanat/service/exception/MarkLockedException.java
+++ b/src/main/java/com/esvar/dekanat/service/exception/MarkLockedException.java
@@ -1,0 +1,7 @@
+package com.esvar.dekanat.service.exception;
+
+public class MarkLockedException extends RuntimeException {
+    public MarkLockedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a domain exception for locked marks and block overwrites unless an explicit unlock is requested
- add a role-validated unlock flow in the marks service and wire the UI unlock action to it
- surface locked mark errors to users in EnterMarksView via notifications

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b6a9d15208326a9f9e11fbfdbebff)