### PR TITLE
Use student IDs for elective plan selections

### DIFF
--- a/src/main/java/com/esvar/dekanat/dto/StudentOptionDTO.java
+++ b/src/main/java/com/esvar/dekanat/dto/StudentOptionDTO.java
@@ -1,0 +1,4 @@
+package com.esvar.dekanat.dto;
+
+public record StudentOptionDTO(Long id, String displayName) {
+}

--- a/src/main/java/com/esvar/dekanat/plan/PlanView.java
+++ b/src/main/java/com/esvar/dekanat/plan/PlanView.java
@@ -7,6 +7,7 @@ package com.esvar.dekanat.plan;
 */
 
 import com.esvar.dekanat.dto.GroupDTO;
+import com.esvar.dekanat.dto.StudentOptionDTO;
 import com.esvar.dekanat.entity.*;
 import com.esvar.dekanat.mark.EnterMarksView;
 import com.esvar.dekanat.plan.dialog.PlanDialog;
@@ -188,10 +189,12 @@ public class PlanView extends Div {
     }
 
     private void openCreateDialog() {
-        String selectedGroup = selectGroup.getValue().getGroupCode();
+        GroupDTO selectedGroup = selectGroup.getValue();
         if (selectedGroup != null) {
-            List<String> students = groupService.getAllStudentsForSelectedGroup(selectedGroup);
+            List<StudentOptionDTO> students = groupService.getStudentOptionsForGroup(selectedGroup.getGroupCode());
             planDialog.updateStudentsList(students);
+        } else {
+            planDialog.updateStudentsList(Collections.emptyList());
         }
         planDialog.openForCreation();
     }
@@ -207,8 +210,8 @@ public class PlanView extends Div {
         String parts = String.valueOf(plan.getParts()); // За замовчуванням
 
 
-        List<String> selectedStudents = isElective
-                ? planService.getSelectedStudentsForPlan(plan) // Отримуємо студентів з student_plans
+        List<Long> selectedStudents = isElective
+                ? studentPlansService.getStudentIdsByPlan(plan) // Отримуємо студентів з student_plans
                 : new ArrayList<>();
 
         // Відкриваємо діалог для оновлення з передачею ID плану
@@ -218,7 +221,7 @@ public class PlanView extends Div {
 
     private void saveNewPlan(String discipline, int hours, boolean isElective,
                              String firstControl, String secondControl, String parts,
-                             String department, List<String> students) {
+                             String department, List<Long> students) {
         PlansEntity newPlan = new PlansEntity();
         newPlan.setDiscipline(disciplineService.getDisciplineByTitle(discipline));
         newPlan.setHours(hours);
@@ -238,19 +241,25 @@ public class PlanView extends Div {
         newPlan.setParts(Integer.parseInt(parts));
         newPlan.setFaculty(selectedGroup.getSpecialty().getFaculty());
         planService.savePlan(newPlan);
-        List<StudentEntity> targetStudents;
+        List<StudentGroupEntity> allowedGroups = selectedGroup == null ? Collections.emptyList() : List.of(selectedGroup);
+        List<Long> targetStudentIds;
         if (isElective && students != null && !students.isEmpty()) {
-            targetStudents = new ArrayList<>();
-            for (String studentName : students) {
-                targetStudents.add(studentService.getStudentByFullName(studentName));
-            }
+            targetStudentIds = new ArrayList<>(students);
         } else {
-            targetStudents = selectedGroup == null
+            targetStudentIds = selectedGroup == null
                     ? Collections.emptyList()
-                    : studentService.getStudentByGroupId(selectedGroup.getId());
+                    : studentService.getStudentByGroupId(selectedGroup.getId()).stream()
+                    .map(StudentEntity::getId)
+                    .toList();
         }
 
-        studentPlansService.synchronizePlanAssignments(newPlan, targetStudents);
+        List<StudentEntity> targetStudents;
+        try {
+            targetStudents = studentPlansService.synchronizePlanAssignments(newPlan, targetStudentIds, allowedGroups);
+        } catch (IllegalArgumentException ex) {
+            Notification.show(ex.getMessage());
+            return;
+        }
         marksInitializerService.initializeMarksForPlan(newPlan, targetStudents);
 
 
@@ -259,7 +268,7 @@ public class PlanView extends Div {
 
     private void updateExistingPlan(Long planId, String discipline, int hours, boolean isElective,
                                     String firstControl, String secondControl, String parts,
-                                    String department, List<String> students) {
+                                    String department, List<Long> students) {
         // Отримуємо план за ID
         PlansEntity updatedPlan = planService.getPlanById(planId);
         if (updatedPlan == null) return;
@@ -280,23 +289,31 @@ public class PlanView extends Div {
         // Зберігаємо оновлення
         planService.updatePlan(updatedPlan);
 
+        List<StudentGroupEntity> allowedGroups = new ArrayList<>(getAllowedGroupsForPlan(updatedPlan));
         List<StudentEntity> targetStudents;
-        if (isElective) {
-            List<StudentEntity> mapped = students == null
-                    ? Collections.emptyList()
-                    : students.stream()
-                    .map(studentService::getStudentByFullName)
-                    .collect(Collectors.toList());
-            targetStudents = studentPlansService.synchronizePlanAssignments(updatedPlan, mapped);
-        } else {
-            List<StudentEntity> groupStudents = getStudentsForPlanGroups(updatedPlan);
-            if (groupStudents.isEmpty()) {
-                StudentGroupEntity selectedGroup = getSelectedGroup();
-                groupStudents = selectedGroup == null
-                        ? Collections.emptyList()
-                        : studentService.getStudentByGroupId(selectedGroup.getId());
+        try {
+            if (isElective) {
+                List<Long> studentIds = students == null ? Collections.emptyList() : new ArrayList<>(students);
+                targetStudents = studentPlansService.synchronizePlanAssignments(updatedPlan, studentIds, allowedGroups);
+            } else {
+                List<StudentEntity> groupStudents = getStudentsForPlanGroups(updatedPlan);
+                if (groupStudents.isEmpty()) {
+                    StudentGroupEntity selectedGroup = getSelectedGroup();
+                    groupStudents = selectedGroup == null
+                            ? Collections.emptyList()
+                            : studentService.getStudentByGroupId(selectedGroup.getId());
+                    if (allowedGroups.isEmpty() && selectedGroup != null) {
+                        allowedGroups = new ArrayList<>(List.of(selectedGroup));
+                    }
+                }
+                List<Long> groupStudentIds = groupStudents.stream()
+                        .map(StudentEntity::getId)
+                        .toList();
+                targetStudents = studentPlansService.synchronizePlanAssignments(updatedPlan, groupStudentIds, allowedGroups);
             }
-            targetStudents = studentPlansService.synchronizePlanAssignments(updatedPlan, groupStudents);
+        } catch (IllegalArgumentException ex) {
+            Notification.show(ex.getMessage());
+            return;
         }
 
         List<Long> beforeIds = beforeStudents.stream().map(StudentEntity::getId).toList();
@@ -346,33 +363,34 @@ public class PlanView extends Div {
     }
 
     private void updateStudentListInDialog() {
-        String selectedGroup = selectGroup.getValue().getGroupCode();
-        if (selectedGroup != null) {
-            List<String> students = groupService.getAllStudentsForSelectedGroup(selectedGroup);
-            planDialog.updateStudentsList(students);
-        } else {
+        GroupDTO selectedGroup = selectGroup.getValue();
+        if (selectedGroup == null) {
             planDialog.updateStudentsList(new ArrayList<>());
+            return;
         }
+
+        List<StudentOptionDTO> students = groupService.getStudentOptionsForGroup(selectedGroup.getGroupCode());
+        planDialog.updateStudentsList(students);
     }
 
     private void updateGrid() {
-        String selectedGroup = selectGroup.getValue().getGroupCode();
+        GroupDTO selectedGroup = selectGroup.getValue();
         String selectedSession = sessionSelect.getValue();
         if (selectedGroup == null || selectedSession == null) {
             planGrid.setItems(planService.getAllPlansForGroupAndSemester(null, 0));
             return;
         }
 
-        planGrid.setItems(planService.getAllPlansForGroupAndSemester(groupService.getGroupByTitle(selectGroup.getValue().getGroupCode()), getSelectedSemester()));
+        planGrid.setItems(planService.getAllPlansForGroupAndSemester(groupService.getGroupByTitle(selectedGroup.getGroupCode()), getSelectedSemester()));
     }
 
     private int getSelectedSemester() {
-        String selectedGroup = selectGroup.getValue().getGroupCode();
+        GroupDTO selectedGroup = selectGroup.getValue();
         String selectedSession = sessionSelect.getValue();
         if (selectedGroup == null || selectedSession == null) {
             return 1; // За замовчуванням - перший семестр
         }
-        return getNumberSemester(selectedGroup, selectedSession);
+        return getNumberSemester(selectedGroup.getGroupCode(), selectedSession);
     }
 
     private int getNumberSemester(String groupTitle, String semester) {
@@ -385,14 +403,27 @@ public class PlanView extends Div {
     }
 
     private StudentGroupEntity getSelectedGroup() {
-        String selectedGroup = selectGroup.getValue().getGroupCode();
+        GroupDTO selectedGroup = selectGroup.getValue();
         if (selectedGroup == null) {
             return null;
         }
-        return groupService.getGroupByTitle(selectedGroup);
+        return groupService.getGroupByTitle(selectedGroup.getGroupCode());
     }
 
     private List<StudentEntity> getStudentsForPlanGroups(PlansEntity plan) {
+        List<StudentGroupEntity> groups = getPlanGroups(plan);
+        if (groups.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return groups.stream()
+                .flatMap(group -> studentService.getStudentByGroupId(group.getId()).stream())
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+
+    private List<StudentGroupEntity> getPlanGroups(PlansEntity plan) {
         if (plan == null || plan.getId() == null) {
             return Collections.emptyList();
         }
@@ -404,10 +435,18 @@ public class PlanView extends Div {
 
         return planWithGroups.getGroups().stream()
                 .filter(Objects::nonNull)
-                .flatMap(group -> studentService.getStudentByGroupId(group.getId()).stream())
-                .filter(Objects::nonNull)
                 .distinct()
                 .toList();
+    }
+
+    private List<StudentGroupEntity> getAllowedGroupsForPlan(PlansEntity plan) {
+        List<StudentGroupEntity> groups = getPlanGroups(plan);
+        if (!groups.isEmpty()) {
+            return groups;
+        }
+
+        StudentGroupEntity selectedGroup = getSelectedGroup();
+        return selectedGroup == null ? Collections.emptyList() : List.of(selectedGroup);
     }
 
     private void configureReportButtons() {

--- a/src/main/java/com/esvar/dekanat/plan/dialog/PlanDialog.java
+++ b/src/main/java/com/esvar/dekanat/plan/dialog/PlanDialog.java
@@ -1,5 +1,6 @@
 package com.esvar.dekanat.plan.dialog;
 
+import com.esvar.dekanat.dto.StudentOptionDTO;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.checkbox.Checkbox;
@@ -50,16 +51,16 @@ public class PlanDialog extends Dialog {
 
     // Компоненти для вибору студентів
     private final Checkbox checkAllStudents = new Checkbox("Обрати всіх");
-    private final CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
+    private final CheckboxGroup<StudentOptionDTO> checkboxGroup = new CheckboxGroup<>();
     private final VerticalLayout VLayoutStudent = new VerticalLayout();
     private final Div scrollableDiv = new Div();
     private Long PlanId;
 
-    private List<String> currentStudents; // Поточний список студентів
+    private List<StudentOptionDTO> currentStudents; // Поточний список студентів
 
     public PlanDialog(List<String> disciplines, List<String> departments,
                       List<String> firstControlTypes, List<String> secondControlTypes,
-                      List<String> students) {
+                      List<StudentOptionDTO> students) {
         this.currentStudents = sortStudents(students); // Зберігаємо поточний список студентів
 
 
@@ -103,6 +104,7 @@ public class PlanDialog extends Dialog {
 
         // Налаштування списку студентів
         checkboxGroup.setItems(currentStudents);
+        checkboxGroup.setItemLabelGenerator(StudentOptionDTO::displayName);
         checkboxGroup.setValue(new HashSet<>(currentStudents));
         checkboxGroup.setReadOnly(false); // Спочатку приховано
 
@@ -211,8 +213,10 @@ public class PlanDialog extends Dialog {
             String selectedParts = parts.getValue();
 
             // Отримуємо список студентів (лише для вибіркових дисциплін)
-            List<String> selectedStudents = choiceDiscipline.getValue().equals("Так")
-                    ? new ArrayList<>(checkboxGroup.getSelectedItems())
+            List<Long> selectedStudents = choiceDiscipline.getValue().equals("Так")
+                    ? checkboxGroup.getSelectedItems().stream()
+                    .map(StudentOptionDTO::id)
+                    .collect(Collectors.toCollection(ArrayList::new))
                     : null;
 
             // Викликаємо слухача збереження
@@ -236,8 +240,10 @@ public class PlanDialog extends Dialog {
             String secondControlType = secondControl.getValue();
             String selectedDepartment = department.getValue();
             String selectedParts = parts.getValue();
-            List<String> selectedStudents = isElective
-                    ? new ArrayList<>(checkboxGroup.getSelectedItems())
+            List<Long> selectedStudents = isElective
+                    ? checkboxGroup.getSelectedItems().stream()
+                    .map(StudentOptionDTO::id)
+                    .collect(Collectors.toCollection(ArrayList::new))
                     : null;
 
             // Викликаємо слухача оновлення з передачею planId
@@ -287,7 +293,7 @@ public class PlanDialog extends Dialog {
 
     public void openForUpdate(String disciplineName, int hoursValue, boolean isElective,
                               String firstControlType, String secondControlType, String partsValue,
-                              String departmentName, List<String> selectedStudents, Long planId) {
+                              String departmentName, List<Long> selectedStudentIds, Long planId) {
         this.isUpdateMode = true;
         discipline.setValue(disciplineName);
         hours.setValue(String.valueOf(hoursValue));
@@ -297,8 +303,11 @@ public class PlanDialog extends Dialog {
         parts.setValue(partsValue);
         department.setValue(departmentName);
 
-        if (isElective) {
-            checkboxGroup.setValue(new HashSet<>(selectedStudents));
+        if (isElective && selectedStudentIds != null) {
+            Set<StudentOptionDTO> selected = currentStudents.stream()
+                    .filter(option -> selectedStudentIds.contains(option.id()))
+                    .collect(Collectors.toCollection(HashSet::new));
+            checkboxGroup.setValue(selected);
         }
 
         update.setVisible(true);
@@ -322,10 +331,13 @@ public class PlanDialog extends Dialog {
         checkAllStudents.setValue(false);
     }
 
-    public void updateStudentsList(List<String> students) {
-        Set<String> previousSelection = new HashSet<>(checkboxGroup.getSelectedItems());
+    public void updateStudentsList(List<StudentOptionDTO> students) {
+        Set<Long> previousSelection = checkboxGroup.getSelectedItems().stream()
+                .map(StudentOptionDTO::id)
+                .collect(Collectors.toCollection(HashSet::new));
         this.currentStudents = sortStudents(students); // Оновлюємо внутрішній список студентів
         checkboxGroup.setItems(currentStudents); // Встановлюємо нові елементи для CheckboxGroup
+        checkboxGroup.setItemLabelGenerator(StudentOptionDTO::displayName);
 
         if (currentStudents.isEmpty()) {
             checkboxGroup.deselectAll();
@@ -334,8 +346,8 @@ public class PlanDialog extends Dialog {
         }
 
         if (isUpdateMode) {
-            Set<String> filteredSelection = previousSelection.stream()
-                    .filter(currentStudents::contains)
+            Set<StudentOptionDTO> filteredSelection = currentStudents.stream()
+                    .filter(option -> previousSelection.contains(option.id()))
                     .collect(Collectors.toCollection(HashSet::new));
 
             if (filteredSelection.isEmpty()) {
@@ -358,27 +370,27 @@ public class PlanDialog extends Dialog {
 
     public interface SavePlanListener {
         void onSave(String discipline, int hours, boolean isElective, String firstControl,
-                    String secondControl, String parts, String department, List<String> students);
+                    String secondControl, String parts, String department, List<Long> studentIds);
     }
 
     public interface UpdatePlanListener {
         void onUpdate(Long planId, String discipline, int hours, boolean isElective,
                       String firstControl, String secondControl, String parts,
-                      String department, List<String> students);
+                      String department, List<Long> studentIds);
     }
 
     public interface RemovePlanListener {
         void onRemove(Long planId); // Метод для видалення плану
     }
 
-    private List<String> sortStudents(List<String> students) {
+    private List<StudentOptionDTO> sortStudents(List<StudentOptionDTO> students) {
         return students.stream()
-                .sorted(ukrainianCollator)
+                .sorted(Comparator.comparing(StudentOptionDTO::displayName, ukrainianCollator))
                 .collect(Collectors.toCollection(ArrayList::new));
     }
 
-    private void updateCheckAllState(Collection<String> selectedStudents) {
-        Collection<String> safeSelection = selectedStudents != null ? selectedStudents : Collections.emptySet();
+    private void updateCheckAllState(Collection<StudentOptionDTO> selectedStudents) {
+        Collection<StudentOptionDTO> safeSelection = selectedStudents != null ? selectedStudents : Collections.emptySet();
         boolean allSelected = !currentStudents.isEmpty() && safeSelection.size() == currentStudents.size();
         boolean noneSelected = safeSelection.isEmpty();
 

--- a/src/main/java/com/esvar/dekanat/service/GroupService.java
+++ b/src/main/java/com/esvar/dekanat/service/GroupService.java
@@ -1,6 +1,7 @@
 package com.esvar.dekanat.service;
 
 import com.esvar.dekanat.dto.GroupDTO;
+import com.esvar.dekanat.dto.StudentOptionDTO;
 import com.esvar.dekanat.entity.SpecialtyEntity;
 import com.esvar.dekanat.entity.StudentEntity;
 import com.esvar.dekanat.entity.StudentGroupEntity;
@@ -69,6 +70,19 @@ public class GroupService {
     }
 
 
+
+    public List<StudentOptionDTO> getStudentOptionsForGroup(String groupSelectValue) {
+        Collator ukrainianCollator = Collator.getInstance(new Locale("uk", "UA"));
+        StudentGroupEntity group = groupRepository.findByGroupCode(groupSelectValue);
+        if (group == null) {
+            return Collections.emptyList();
+        }
+
+        return studentService.getStudentByGroupId(group.getId()).stream()
+                .map(student -> new StudentOptionDTO(student.getId(), student.getFullName()))
+                .sorted(Comparator.comparing(StudentOptionDTO::displayName, ukrainianCollator))
+                .toList();
+    }
 
     public List<String> getAllStudentsForSelectedGroup(String groupSelectValue) {
         Collator ukrainianCollator = Collator.getInstance(new Locale("uk", "UA"));

--- a/src/main/java/com/esvar/dekanat/service/StudentPlansService.java
+++ b/src/main/java/com/esvar/dekanat/service/StudentPlansService.java
@@ -2,6 +2,7 @@ package com.esvar.dekanat.service;
 
 import com.esvar.dekanat.entity.PlansEntity;
 import com.esvar.dekanat.entity.StudentEntity;
+import com.esvar.dekanat.entity.StudentGroupEntity;
 import com.esvar.dekanat.entity.StudentPlansEntity;
 import com.esvar.dekanat.entity.StudentPlansPK;
 import com.esvar.dekanat.repository.StudentPlansRepository;
@@ -9,7 +10,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -57,22 +64,12 @@ public class StudentPlansService{
      * Оновлює записи у таблиці student_plans для певного плану.
      *
      * @param updatedPlan PlansEntity - оновлений план.
-     * @param students    List<String> - список імен студентів.
+     * @param studentIds  List<Long> - список ID студентів.
+     * @param allowedGroups List<StudentGroupEntity> - групи, для яких дозволений вибір.
      */
     @Transactional
-    public List<StudentEntity> updateStudentPlans(PlansEntity updatedPlan, List<String> students) {
-        if (updatedPlan == null || updatedPlan.getId() == null) {
-            throw new IllegalArgumentException("План для оновлення повинен бути заданий.");
-        }
-
-        List<StudentEntity> mappedStudents = new ArrayList<>();
-        if (students != null) {
-            for (String studentName : students) {
-                mappedStudents.add(studentService.getStudentByFullName(studentName));
-            }
-        }
-
-        return synchronizePlanAssignments(updatedPlan, mappedStudents);
+    public List<StudentEntity> updateStudentPlans(PlansEntity updatedPlan, List<Long> studentIds, List<StudentGroupEntity> allowedGroups) {
+        return synchronizePlanAssignments(updatedPlan, studentIds, allowedGroups);
     }
 
 
@@ -106,13 +103,22 @@ public class StudentPlansService{
     }
 
     @Transactional
-    public List<StudentEntity> synchronizePlanAssignments(PlansEntity plan, List<StudentEntity> students) {
+    public List<StudentEntity> synchronizePlanAssignments(PlansEntity plan, List<Long> studentIds, List<StudentGroupEntity> allowedGroups) {
         if (plan == null || plan.getId() == null) {
             throw new IllegalArgumentException("План повинен бути заданий.");
         }
 
-        List<StudentEntity> targetStudents = students == null ? List.of() : students;
+        Set<Long> allowedGroupIds = buildAllowedGroupIds(plan, allowedGroups);
+        List<StudentEntity> targetStudents = resolveAndValidateStudents(studentIds, allowedGroupIds);
         return synchronizeInternal(plan, targetStudents);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> getStudentIdsByPlan(PlansEntity plan) {
+        if (plan == null || plan.getId() == null) {
+            return List.of();
+        }
+        return studentPlansRepository.findStudentIdsByPlanId(plan.getId());
     }
 
     private List<StudentEntity> synchronizeInternal(PlansEntity plan, List<StudentEntity> targetStudents) {
@@ -149,4 +155,58 @@ public class StudentPlansService{
         return targetStudents;
     }
 
+    private List<StudentEntity> resolveAndValidateStudents(List<Long> studentIds, Set<Long> allowedGroupIds) {
+        if (studentIds == null || studentIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<StudentEntity> students = studentService.getStudentsByIds(studentIds);
+        Map<Long, StudentEntity> studentsById = students.stream()
+                .collect(Collectors.toMap(StudentEntity::getId, Function.identity()));
+
+        List<Long> missingStudents = studentIds.stream()
+                .filter(id -> !studentsById.containsKey(id))
+                .toList();
+
+        if (!missingStudents.isEmpty()) {
+            throw new IllegalArgumentException("Не знайдено студентів з ID: " + missingStudents);
+        }
+
+        if (!allowedGroupIds.isEmpty()) {
+            List<StudentEntity> mismatchedStudents = studentsById.values().stream()
+                    .filter(student -> student.getGroup() == null || !allowedGroupIds.contains(student.getGroup().getId()))
+                    .toList();
+
+            if (!mismatchedStudents.isEmpty()) {
+                String invalidNames = mismatchedStudents.stream()
+                        .map(StudentEntity::getFullName)
+                        .collect(Collectors.joining(", "));
+                throw new IllegalArgumentException("Деякі студенти не належать до вибраної групи: " + invalidNames);
+            }
+        }
+
+        return studentIds.stream()
+                .map(studentsById::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toCollection(LinkedHashSet::new),
+                        ArrayList::new
+                ));
+    }
+
+    private Set<Long> buildAllowedGroupIds(PlansEntity plan, List<StudentGroupEntity> allowedGroups) {
+        if (allowedGroups != null && !allowedGroups.isEmpty()) {
+            return allowedGroups.stream()
+                    .filter(Objects::nonNull)
+                    .map(StudentGroupEntity::getId)
+                    .collect(Collectors.toCollection(HashSet::new));
+        }
+        if (plan.getGroups() == null || plan.getGroups().isEmpty()) {
+            return Set.of();
+        }
+        return plan.getGroups().stream()
+                .filter(Objects::nonNull)
+                .map(StudentGroupEntity::getId)
+                .collect(Collectors.toCollection(HashSet::new));
+    }
 }

--- a/src/main/java/com/esvar/dekanat/service/StudentService.java
+++ b/src/main/java/com/esvar/dekanat/service/StudentService.java
@@ -28,6 +28,13 @@ public class StudentService {
                 .collect(Collectors.toList());
     }
 
+    public List<StudentEntity> getStudentsByIds(List<Long> studentIds) {
+        if (studentIds == null || studentIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return studentRepository.findByIdIn(studentIds);
+    }
+
     public StudentEntity getStudentByFullName(String studentSurname, String studentName, String studentPatronymic) {
         NameParts parts = buildNameParts(studentSurname, studentName, studentPatronymic);
         if (!hasText(parts.surname()) || !hasText(parts.name())) {


### PR DESCRIPTION
## Summary
- update PlanDialog and PlanView to work with student ID options instead of free-form names when configuring elective plans
- expose group-scoped student option DTOs from GroupService and propagate them through the elective checkbox list
- validate student-plan synchronization by IDs and reject assignments outside the target groups with clear errors

## Testing
- ./mvnw -q -DskipTests compile *(fails: unable to download Maven wrapper dependencies due to network restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b6e68a80483268d4392100e2e3c11)