### PR TITLE
Remove duplicate spring test starter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,17 +125,6 @@
             <version>1.17.2</version>
         </dependency>
 
-
-        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-test -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <version>3.5.3</version>
-            <scope>test</scope>
-        </dependency>
-
-
-
     </dependencies>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
## Summary
- remove the duplicated spring-boot-starter-test declaration to rely on the parent-managed version

## Testing
- mvn dependency:tree *(fails: wrapper could not download Maven distribution; network fetch to repo.maven.apache.org failed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b76467ee08326a80dcbb9f36d40ba)