### PR TITLE
Specify Flyway starter version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-flyway</artifactId>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>


### PR DESCRIPTION
## Summary
- explicitly set the Spring Boot Flyway starter version to match the parent POM
- keep Maven source roots on defaults for IntelliJ detection

## Testing
- mvn clean compile *(fails in sandbox: Maven Central 403 while downloading parent POM)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b7e779da48326b8aa40b4bc6d236a)