### PR TITLE
Set Flyway baseline-on-migrate for existing schema

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,7 @@ spring:
     enabled: true
     locations: classpath:db/migration
     clean-disabled: true
+    baseline-on-migrate: true
 
   # SMTP (відправка листів)
   mail:


### PR DESCRIPTION
## Summary
- enable Flyway `baseline-on-migrate` to allow migrations on existing non-empty schema without history table

## Testing
- not run (config change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b8163f4848326a16a124bfc027fca)