### PR TITLE
Refine module data handling in EnterMarksView

### DIFF
--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -753,18 +753,12 @@ public class EnterMarksView extends Div {
                     dto.setId(mark.getId());
                     dto.setStudentPIB(mark.getStudent().getFullName());
 
-                    // Використовуємо finalGrade для конвертації
-                    int finalGrade = mark.getFinalGrade();
-                    dto.setEnterMark(String.valueOf(finalGrade));
-                    dto.setNationalGrade(convertMarkToNationalGrade(finalGrade));
-                    dto.setECTSGrade(convertMarkToECTSGrade(finalGrade));
-
-                    // Отримуємо оцінки для першого і другого модулів
-                    String firstModule = marksService.getMarkForTypeControl(mark.getStudent(), plansEntity, CONTROL_TYPE_FIRST_MODULE);
-                    String secondModule = marksService.getMarkForTypeControl(mark.getStudent(), plansEntity, CONTROL_TYPE_SECOND_MODULE);
-                    dto.setMarkByFirstModule(firstModule);
-                    int sumModules = Integer.parseInt(firstModule) + Integer.parseInt(secondModule);
-                    dto.setTotalMarkByFirstAndSecondModule(String.valueOf(sumModules));
+                    ModuleData moduleData = resolveModuleDataForStudent(mark.getStudent());
+                    dto.setEnterMark(String.valueOf(mark.getFinalGrade()));
+                    dto.setMarkByFirstModule(moduleData.firstModule());
+                    dto.setTotalMarkByFirstAndSecondModule(String.valueOf(moduleData.total()));
+                    dto.setNationalGrade(convertMarkToNationalGrade(moduleData.total()));
+                    dto.setECTSGrade(convertMarkToECTSGrade(moduleData.total()));
 
                     dto.setLocked(mark.isLocked());
                     populateAuditInfo(dto, mark);


### PR DESCRIPTION
## Summary
- reuse resolveModuleDataForStudent when populating grid rows for exam- and module-based controls
- ensure module totals, national, and ECTS grades rely on normalized module data to avoid NumberFormatException on missing marks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b9b2fb7688326ab11ecd9d3bb6737)