### PR TITLE
Add technikum flag and paginate rating view

### DIFF
--- a/sql/technikum_flag_migration.sql
+++ b/sql/technikum_flag_migration.sql
@@ -1,0 +1,8 @@
+-- Позначка технікуму на рівні спеціальності
+ALTER TABLE specialty
+    ADD COLUMN IF NOT EXISTS is_technikum TINYINT(1) NOT NULL DEFAULT 0;
+
+-- Первинне заповнення для наявних записів (наближене визначення)
+UPDATE specialty
+SET is_technikum = 1
+WHERE LOWER(title) LIKE '%тех%' OR LOWER(abbreviation) LIKE '%тех%';

--- a/src/main/java/com/esvar/dekanat/dto/RatingFilterOptions.java
+++ b/src/main/java/com/esvar/dekanat/dto/RatingFilterOptions.java
@@ -1,0 +1,16 @@
+package com.esvar.dekanat.dto;
+
+import java.util.List;
+
+public record RatingFilterOptions(
+        List<GroupDTO> groups,
+        List<String> specialties,
+        List<Integer> courses,
+        List<Integer> groupNumbers,
+        List<Integer> years,
+        String defaultSpecialty,
+        Integer defaultCourse,
+        Integer defaultGroupNumber,
+        Integer defaultYear
+) {
+}

--- a/src/main/java/com/esvar/dekanat/entity/SpecialtyEntity.java
+++ b/src/main/java/com/esvar/dekanat/entity/SpecialtyEntity.java
@@ -24,6 +24,9 @@ public class SpecialtyEntity {
     @Column(nullable = false, length = 10)
     private String abbreviation;
 
+    @Column(name = "is_technikum", nullable = false)
+    private boolean technikum;
+
     @ManyToOne
     @JoinColumn(name = "faculty_id", nullable = false)
     private FacultyEntity faculty;
@@ -39,11 +42,12 @@ public class SpecialtyEntity {
         SpecialtyEntity that = (SpecialtyEntity) o;
         return Objects.equals(id, that.id)
                 && Objects.equals(title, that.title)
-                && Objects.equals(abbreviation, that.abbreviation);
+                && Objects.equals(abbreviation, that.abbreviation)
+                && technikum == that.technikum;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, title, abbreviation);
+        return Objects.hash(id, title, abbreviation, technikum);
     }
 }

--- a/src/main/java/com/esvar/dekanat/rating/RatingView.java
+++ b/src/main/java/com/esvar/dekanat/rating/RatingView.java
@@ -1,25 +1,42 @@
 package com.esvar.dekanat.rating;
 
-import com.esvar.dekanat.view.MainLayout;
-import com.esvar.dekanat.service.RatingService;
 import com.esvar.dekanat.dto.GroupDTO;
+import com.esvar.dekanat.dto.RatingFilterOptions;
+import com.esvar.dekanat.entity.StudentRatingEntity;
+import com.esvar.dekanat.service.RatingService;
+import com.esvar.dekanat.view.MainLayout;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.data.provider.CallbackDataProvider;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.Query;
+import com.vaadin.flow.data.provider.QuerySortOrder;
+import com.vaadin.flow.data.provider.SortDirection;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import jakarta.annotation.security.PermitAll;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.text.NumberFormat;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @PermitAll
 @PageTitle("Рейтинг | Деканат")
@@ -27,7 +44,10 @@ import java.util.stream.Collectors;
 public class RatingView extends Div {
 
     private final RatingService ratingService;
+    private final RatingFilterOptions filterOptions;
     private final List<GroupDTO> groups;
+    private final NumberFormat numberFormat;
+    private final CallbackDataProvider<RatingRow, Void> dataProvider;
 
     private final Select<String> specialtySelect = new Select<>();
     private final Select<Integer> courseSelect = new Select<>();
@@ -38,10 +58,16 @@ public class RatingView extends Div {
     private final Checkbox technikumCheckbox = new Checkbox("Технікум");
     private final Checkbox budgetCheckbox = new Checkbox("Бюджет");
     private final Grid<RatingRow> ratingGrid = new Grid<>(RatingRow.class, false);
+    private boolean suppressRefresh;
 
     public RatingView(RatingService ratingService) {
         this.ratingService = ratingService;
-        this.groups = ratingService.getGroups();
+        this.filterOptions = ratingService.getFilterOptions();
+        this.groups = filterOptions.groups();
+        this.numberFormat = NumberFormat.getNumberInstance(new Locale("uk", "UA"));
+        numberFormat.setMaximumFractionDigits(2);
+        numberFormat.setMinimumFractionDigits(2);
+        this.dataProvider = DataProvider.fromCallbacks(this::fetchRows, this::countRows);
         configureFilters();
         configureGrid();
         VerticalLayout checkboxColumn = new VerticalLayout(technikumCheckbox, budgetCheckbox);
@@ -68,7 +94,7 @@ public class RatingView extends Div {
 
     private void configureFilters() {
         specialtySelect.setLabel("Спеціальність");
-        specialtySelect.setItems(ratingService.getSpecialties());
+        specialtySelect.setItems(filterOptions.specialties());
         specialtySelect.setPlaceholder("Усі спеціальності");
         specialtySelect.setEmptySelectionAllowed(true);
         specialtySelect.addValueChangeListener(e -> {
@@ -79,7 +105,7 @@ public class RatingView extends Div {
         });
 
         courseSelect.setLabel("Курс");
-        courseSelect.setItems(ratingService.getCourses());
+        courseSelect.setItems(filterOptions.courses());
         courseSelect.setPlaceholder("Усі курси");
         courseSelect.setEmptySelectionAllowed(true);
         courseSelect.addValueChangeListener(e -> {
@@ -89,7 +115,7 @@ public class RatingView extends Div {
         });
 
         groupSelect.setLabel("Група");
-        groupSelect.setItems(ratingService.getGroupNumbers());
+        groupSelect.setItems(filterOptions.groupNumbers());
         groupSelect.setPlaceholder("Усі групи");
         groupSelect.setEmptySelectionAllowed(true);
         groupSelect.addValueChangeListener(e -> {
@@ -98,7 +124,7 @@ public class RatingView extends Div {
         });
 
         yearSelect.setLabel("Рік");
-        yearSelect.setItems(ratingService.getYears());
+        yearSelect.setItems(filterOptions.years());
         yearSelect.setPlaceholder("Оберіть рік");
         yearSelect.setEmptySelectionAllowed(true);
         yearSelect.addValueChangeListener(e -> search());
@@ -108,25 +134,62 @@ public class RatingView extends Div {
     }
 
     private void configureGrid() {
-        ratingGrid.addColumn(RatingRow::group).setHeader("Група");
-        ratingGrid.addColumn(RatingRow::student).setHeader("Студент");
-        ratingGrid.addColumn(RatingRow::average).setHeader("Середній бал");
-        ratingGrid.addColumn(RatingRow::count5).setHeader("Кількість 5");
-        ratingGrid.addColumn(RatingRow::percent5).setHeader("% 5");
-        ratingGrid.addColumn(RatingRow::count4).setHeader("Кількість 4");
-        ratingGrid.addColumn(RatingRow::percent4).setHeader("% 4");
-        ratingGrid.addColumn(RatingRow::count3).setHeader("Кількість 3");
-        ratingGrid.addColumn(RatingRow::percent3).setHeader("% 3");
+        ratingGrid.setMultiSort(true);
+        ratingGrid.setMultiSortPriority(Grid.MultiSortPriority.APPEND);
+
+        ratingGrid.addColumn(RatingRow::group)
+                .setHeader("Група")
+                .setKey("group")
+                .setSortable(true);
+        ratingGrid.addColumn(RatingRow::student)
+                .setHeader("Студент")
+                .setKey("student")
+                .setSortable(true);
+        ratingGrid.addColumn(row -> formatAverage(row.average()))
+                .setHeader("Середній бал")
+                .setKey("average")
+                .setSortable(true);
+        ratingGrid.addColumn(RatingRow::count5).setHeader("Кількість 5").setAutoWidth(true);
+        ratingGrid.addColumn(new ComponentRenderer<>(row -> percentageBadge(row.count5(), row.total())))
+                .setHeader("% 5")
+                .setAutoWidth(true);
+        ratingGrid.addColumn(RatingRow::count4).setHeader("Кількість 4").setAutoWidth(true);
+        ratingGrid.addColumn(new ComponentRenderer<>(row -> percentageBadge(row.count4(), row.total())))
+                .setHeader("% 4")
+                .setAutoWidth(true);
+        ratingGrid.addColumn(RatingRow::count3).setHeader("Кількість 3").setAutoWidth(true);
+        ratingGrid.addColumn(new ComponentRenderer<>(row -> percentageBadge(row.count3(), row.total())))
+                .setHeader("% 3")
+                .setAutoWidth(true);
         ratingGrid.setWidthFull();
+        ratingGrid.setPageSize(30);
+        ratingGrid.setDataProvider(dataProvider);
     }
 
     private void initializeDefaults() {
+        suppressRefresh = true;
         updateCourseOptions();
         updateGroupOptions();
         updateYearOptions();
-        if (yearSelect.getValue() == null && !yearSelect.getListDataView().getItems().isEmpty()) {
+
+        if (filterOptions.defaultSpecialty() != null) {
+            specialtySelect.setValue(filterOptions.defaultSpecialty());
+        }
+        updateCourseOptions();
+        if (filterOptions.defaultCourse() != null) {
+            courseSelect.setValue(filterOptions.defaultCourse());
+        }
+        updateGroupOptions();
+        if (filterOptions.defaultGroupNumber() != null) {
+            groupSelect.setValue(filterOptions.defaultGroupNumber());
+        }
+        updateYearOptions();
+        if (filterOptions.defaultYear() != null) {
+            yearSelect.setValue(filterOptions.defaultYear());
+        } else if (yearSelect.getValue() == null && !yearSelect.getListDataView().getItems().isEmpty()) {
             yearSelect.setValue(yearSelect.getListDataView().getItems().findFirst().orElse(null));
         }
+        suppressRefresh = false;
     }
 
     private void updateCourseOptions() {
@@ -185,55 +248,114 @@ public class RatingView extends Div {
     }
 
     private void search() {
-        List<RatingRow> rows = ratingService.searchRatings(
+        if (suppressRefresh) {
+            return;
+        }
+        ratingGrid.getDataProvider().refreshAll();
+    }
+
+    private Stream<RatingRow> fetchRows(Query<RatingRow, Void> query) {
+        Sort sort = resolveSort(query);
+        int limit = query.getLimit();
+        int page = limit == 0 ? 0 : query.getOffset() / limit;
+        Pageable pageable = PageRequest.of(page, Math.max(limit, 1));
+        Page<StudentRatingEntity> pageResult = ratingService.searchRatings(
+                specialtySelect.getValue(),
+                courseSelect.getValue(),
+                groupSelect.getValue(),
+                yearSelect.getValue(),
+                technikumCheckbox.getValue(),
+                budgetCheckbox.getValue(),
+                pageable,
+                sort
+        );
+        return pageResult.stream().map(this::toRow);
+    }
+
+    private int countRows(Query<RatingRow, Void> query) {
+        return Math.toIntExact(ratingService.countRatings(
                 specialtySelect.getValue(),
                 courseSelect.getValue(),
                 groupSelect.getValue(),
                 yearSelect.getValue(),
                 technikumCheckbox.getValue(),
                 budgetCheckbox.getValue()
-        ).stream()
-                .map(entity -> {
-                    BigDecimal avg = entity.getAverageScore();
-                    int total = entity.getTotalSubjects();
-                    String perc5 = formatPercent(entity.getCount5(), total);
-                    String perc4 = formatPercent(entity.getCount4(), total);
-                    String perc3 = formatPercent(entity.getCount3(), total);
-                    return new RatingRow(
-                            entity.getStudent().getFullName(),
-                            entity.getGroup().getGroupCode(),
-                            avg.setScale(2, RoundingMode.HALF_UP).toString(),
-                            entity.getCount5(),
-                            perc5,
-                            entity.getCount4(),
-                            perc4,
-                            entity.getCount3(),
-                            perc3
-                    );
-                })
-                .toList();
-        ratingGrid.setItems(rows);
-
+        ));
     }
 
-    private String formatPercent(int count, int total) {
-        if (total == 0) {
-            return "0";
+    private RatingRow toRow(StudentRatingEntity entity) {
+        return new RatingRow(
+                entity.getStudent().getFullName(),
+                entity.getGroup().getGroupCode(),
+                entity.getAverageScore(),
+                entity.getCount5(),
+                entity.getCount4(),
+                entity.getCount3(),
+                entity.getTotalSubjects()
+        );
+    }
+
+    private Sort resolveSort(Query<RatingRow, Void> query) {
+        Map<String, String> propertyMapping = Map.of(
+                "group", "group.groupCode",
+                "average", "averageScore",
+                "student", "student.surname"
+        );
+        Sort sort = Sort.unsorted();
+        for (QuerySortOrder order : query.getSortOrders()) {
+            String property = propertyMapping.get(order.getSorted());
+            if (property == null) {
+                continue;
+            }
+            Sort.Order sortOrder = order.getDirection() == SortDirection.ASCENDING
+                    ? Sort.Order.asc(property)
+                    : Sort.Order.desc(property);
+            sort = sort.and(sortOrder);
         }
-        BigDecimal percent = new BigDecimal(count * 100.0 / total);
-        return percent.setScale(2, RoundingMode.HALF_UP).toString();
+        if (sort.isUnsorted()) {
+            sort = Sort.by(Sort.Order.desc("averageScore"), Sort.Order.asc("group.groupCode"));
+        }
+        return sort;
+    }
+
+    private String formatAverage(BigDecimal average) {
+        BigDecimal safeAverage = average == null ? BigDecimal.ZERO : average.setScale(2, RoundingMode.HALF_UP);
+        return numberFormat.format(safeAverage);
+    }
+
+    private String formatPercentValue(int count, int total) {
+        if (total <= 0) {
+            return numberFormat.format(BigDecimal.ZERO) + " %";
+        }
+        BigDecimal percent = BigDecimal.valueOf(count)
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(total), 2, RoundingMode.HALF_UP);
+        return numberFormat.format(percent) + " %";
+    }
+
+    private Span percentageBadge(int count, int total) {
+        String text = formatPercentValue(count, total);
+        Span span = new Span(text);
+        span.getElement().getThemeList().add("badge");
+        double percentValue = total == 0 ? 0 : (double) count * 100 / total;
+        if (percentValue >= 80) {
+            span.getElement().getThemeList().add("success");
+        } else if (percentValue >= 60) {
+            span.getElement().getThemeList().add("contrast");
+        } else if (percentValue > 0) {
+            span.getElement().getThemeList().add("error");
+        }
+        return span;
     }
 
     private record RatingRow(
             String student,
             String group,
-            String average,
+            BigDecimal average,
             int count5,
-            String percent5,
             int count4,
-            String percent4,
             int count3,
-            String percent3
+            int total
     ) {
     }
 }

--- a/src/main/java/com/esvar/dekanat/repository/MarksRepository.java
+++ b/src/main/java/com/esvar/dekanat/repository/MarksRepository.java
@@ -48,6 +48,9 @@ public interface MarksRepository extends JpaRepository<MarksEntity, Long> {
 
     List<MarksEntity> findByStudentId(Long studentId);
 
+    @Query("SELECT DISTINCT m.student.id FROM MarksEntity m WHERE m.plan.id = :planId")
+    List<Long> findDistinctStudentIdsByPlanId(@Param("planId") Long planId);
+
     @Modifying
     @Query("DELETE FROM MarksEntity m WHERE m.plan.id = :planId")
     void deleteByPlanId(@Param("planId") Long planId);

--- a/src/main/java/com/esvar/dekanat/repository/StudentRatingRepository.java
+++ b/src/main/java/com/esvar/dekanat/repository/StudentRatingRepository.java
@@ -1,17 +1,17 @@
 package com.esvar.dekanat.repository;
 
 import com.esvar.dekanat.entity.StudentRatingEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface StudentRatingRepository extends JpaRepository<StudentRatingEntity, Long> {
 
-    @Query("""
+    @Query(value = """
         SELECT sr FROM StudentRatingEntity sr
             JOIN sr.student st
             LEFT JOIN StudentInfoEntity info ON info.student = st
@@ -20,10 +20,41 @@ public interface StudentRatingRepository extends JpaRepository<StudentRatingEnti
           AND (:groupNumber IS NULL OR sr.group.groupNumber = :groupNumber)
           AND (:year IS NULL OR sr.group.year = :year)
           AND (:budget = false OR info.typeOfIndividual = 'Держбюджет')
-          AND (:technikum = false OR LOWER(sr.specialty.title) LIKE '%тех%')
-        ORDER BY sr.averageScore DESC
+          AND (:technikum = false OR sr.specialty.technikum = true)
+        """,
+            countQuery = """
+        SELECT COUNT(sr) FROM StudentRatingEntity sr
+            JOIN sr.student st
+            LEFT JOIN StudentInfoEntity info ON info.student = st
+        WHERE (:specialty IS NULL OR sr.specialty.abbreviation = :specialty)
+          AND (:course IS NULL OR sr.course = :course)
+          AND (:groupNumber IS NULL OR sr.group.groupNumber = :groupNumber)
+          AND (:year IS NULL OR sr.group.year = :year)
+          AND (:budget = false OR info.typeOfIndividual = 'Держбюджет')
+          AND (:technikum = false OR sr.specialty.technikum = true)
         """)
-    List<StudentRatingEntity> searchRatings(
+    Page<StudentRatingEntity> searchRatings(
+            @Param("specialty") String specialty,
+            @Param("course") Integer course,
+            @Param("groupNumber") Integer groupNumber,
+            @Param("year") Integer year,
+            @Param("technikum") boolean technikum,
+            @Param("budget") boolean budget,
+            Pageable pageable
+    );
+
+    @Query("""
+        SELECT COUNT(sr) FROM StudentRatingEntity sr
+            JOIN sr.student st
+            LEFT JOIN StudentInfoEntity info ON info.student = st
+        WHERE (:specialty IS NULL OR sr.specialty.abbreviation = :specialty)
+          AND (:course IS NULL OR sr.course = :course)
+          AND (:groupNumber IS NULL OR sr.group.groupNumber = :groupNumber)
+          AND (:year IS NULL OR sr.group.year = :year)
+          AND (:budget = false OR info.typeOfIndividual = 'Держбюджет')
+          AND (:technikum = false OR sr.specialty.technikum = true)
+        """)
+    long countRatings(
             @Param("specialty") String specialty,
             @Param("course") Integer course,
             @Param("groupNumber") Integer groupNumber,

--- a/src/main/java/com/esvar/dekanat/service/GroupService.java
+++ b/src/main/java/com/esvar/dekanat/service/GroupService.java
@@ -2,6 +2,7 @@ package com.esvar.dekanat.service;
 
 import com.esvar.dekanat.dto.GroupDTO;
 import com.esvar.dekanat.dto.StudentOptionDTO;
+import com.esvar.dekanat.dto.RatingFilterOptions;
 import com.esvar.dekanat.entity.SpecialtyEntity;
 import com.esvar.dekanat.entity.StudentEntity;
 import com.esvar.dekanat.entity.StudentGroupEntity;
@@ -75,6 +76,51 @@ public class GroupService {
                 .distinct()
                 .sorted(Comparator.reverseOrder())
                 .toList();
+    }
+
+    public RatingFilterOptions getRatingFilterOptions() {
+        List<GroupDTO> availableGroups = getGroupsDTO();
+        List<String> specialties = availableGroups.stream()
+                .map(GroupDTO::getSpecialtyAbbreviation)
+                .distinct()
+                .sorted()
+                .toList();
+        List<Integer> courses = availableGroups.stream()
+                .map(GroupDTO::getCourse)
+                .distinct()
+                .sorted()
+                .toList();
+        List<Integer> groupNumbers = availableGroups.stream()
+                .map(GroupDTO::getGroupNumber)
+                .distinct()
+                .sorted()
+                .toList();
+        List<Integer> years = availableGroups.stream()
+                .map(GroupDTO::getYear)
+                .distinct()
+                .sorted(Comparator.reverseOrder())
+                .toList();
+
+        UserDetails user = securityService.getAuthenticatedUser();
+        boolean isDekanat = user != null && user.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().startsWith("ROLE_DEKANAT"));
+
+        String defaultSpecialty = isDekanat && specialties.size() == 1 ? specialties.get(0) : null;
+        Integer defaultCourse = isDekanat && courses.size() == 1 ? courses.get(0) : null;
+        Integer defaultGroupNumber = isDekanat && groupNumbers.size() == 1 ? groupNumbers.get(0) : null;
+        Integer defaultYear = years.isEmpty() ? null : years.get(0);
+
+        return new RatingFilterOptions(
+                availableGroups,
+                specialties,
+                courses,
+                groupNumbers,
+                years,
+                defaultSpecialty,
+                defaultCourse,
+                defaultGroupNumber,
+                defaultYear
+        );
     }
 
 

--- a/src/main/java/com/esvar/dekanat/service/MarksPartsService.java
+++ b/src/main/java/com/esvar/dekanat/service/MarksPartsService.java
@@ -7,6 +7,7 @@ import com.esvar.dekanat.security.SecurityService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -18,12 +19,18 @@ public class MarksPartsService {
     private final MarksRepository marksRepository;
     private final ControlPartsService controlPartsService;
     private final SecurityService securityService;
+    private final RatingService ratingService;
 
-    public MarksPartsService(MarksPartsRepository marksPartsRepository, MarksRepository marksRepository, ControlPartsService controlPartsService, SecurityService securityService) {
+    public MarksPartsService(MarksPartsRepository marksPartsRepository,
+                             MarksRepository marksRepository,
+                             ControlPartsService controlPartsService,
+                             SecurityService securityService,
+                             RatingService ratingService) {
         this.marksPartsRepository = marksPartsRepository;
         this.marksRepository = marksRepository;
         this.controlPartsService = controlPartsService;
         this.securityService = securityService;
+        this.ratingService = ratingService;
     }
 
     public int getNumberOfPartsForPlan(PlansEntity plan) {
@@ -126,6 +133,7 @@ public class MarksPartsService {
     @Transactional
     public void updateFinalGradesForPlan(PlansEntity plan, int newParts) {
         List<MarksEntity> marksList = marksRepository.findByPlan(plan);
+        Set<Long> studentIds = new HashSet<>();
         for (MarksEntity mark : marksList) {
             // Отримуємо всі частини оцінок, де partNumber менший або рівний newParts
             List<MarksPartsEntity> parts = marksPartsRepository.findByMarkIdAndPartNumberLessThanEqual(mark.getId(), newParts);
@@ -139,8 +147,10 @@ public class MarksPartsService {
                     securityService.getCurrentUserModel()
                             .orElseThrow(() -> new IllegalStateException("No authenticated user"))
             );
+            studentIds.add(mark.getStudent().getId());
             marksRepository.save(mark); // Оновлюємо запис у таблиці marks
         }
+        ratingService.updateRatingsForStudentIds(studentIds);
     }
 
     /**

--- a/src/main/java/com/esvar/dekanat/service/MarksService.java
+++ b/src/main/java/com/esvar/dekanat/service/MarksService.java
@@ -239,7 +239,9 @@ public class MarksService {
     @Transactional
     public void deleteByPlanId(Long planId) {
         if (planId != null) {
+            List<Long> affectedStudentIds = marksRepository.findDistinctStudentIdsByPlanId(planId);
             marksRepository.deleteByPlanId(planId);
+            ratingService.updateRatingsForStudentIds(affectedStudentIds);
         }
     }
 
@@ -247,6 +249,7 @@ public class MarksService {
     public void deleteByPlanIdAndStudentIds(Long planId, List<Long> studentIds) {
         if (planId != null && studentIds != null && !studentIds.isEmpty()) {
             marksRepository.deleteByPlanIdAndStudentIds(planId, studentIds);
+            ratingService.updateRatingsForStudentIds(studentIds);
         }
     }
 

--- a/src/main/java/com/esvar/dekanat/service/RatingService.java
+++ b/src/main/java/com/esvar/dekanat/service/RatingService.java
@@ -1,17 +1,23 @@
 package com.esvar.dekanat.service;
 
 import com.esvar.dekanat.dto.GroupDTO;
+import com.esvar.dekanat.dto.RatingFilterOptions;
 import com.esvar.dekanat.entity.MarksEntity;
 import com.esvar.dekanat.entity.StudentEntity;
 import com.esvar.dekanat.entity.StudentRatingEntity;
 import com.esvar.dekanat.repository.MarksRepository;
 import com.esvar.dekanat.repository.StudentRatingRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.Timestamp;
+import java.util.Collection;
 import java.util.List;
 @Service
 public class RatingService {
@@ -19,11 +25,16 @@ public class RatingService {
     private final GroupService groupService;
     private final StudentRatingRepository ratingRepository;
     private final MarksRepository marksRepository;
+    private final StudentService studentService;
 
-    public RatingService(GroupService groupService, StudentRatingRepository ratingRepository, MarksRepository marksRepository) {
+    public RatingService(GroupService groupService,
+                         StudentRatingRepository ratingRepository,
+                         MarksRepository marksRepository,
+                         StudentService studentService) {
         this.groupService = groupService;
         this.ratingRepository = ratingRepository;
         this.marksRepository = marksRepository;
+        this.studentService = studentService;
     }
 
     public List<GroupDTO> getGroups() {
@@ -58,13 +69,41 @@ public class RatingService {
         return groupService.getYears();
     }
 
-    public List<StudentRatingEntity> searchRatings(String specialty,
+    public RatingFilterOptions getFilterOptions() {
+        return groupService.getRatingFilterOptions();
+    }
+
+    public Page<StudentRatingEntity> searchRatings(String specialty,
                                                    Integer course,
                                                    Integer group,
                                                    Integer year,
                                                    boolean technikum,
-                                                   boolean budget) {
+                                                   boolean budget,
+                                                   Pageable pageable,
+                                                   Sort sort) {
+        Sort defaultSort = Sort.by(Sort.Order.desc("averageScore"), Sort.Order.asc("group.groupCode"));
+        Sort effectiveSort = sort == null || sort.isUnsorted() ? defaultSort : sort;
+        Pageable effectivePageable = pageable == null
+                ? PageRequest.of(0, 50, effectiveSort)
+                : PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), effectiveSort);
         return ratingRepository.searchRatings(
+                specialty,
+                course,
+                group,
+                year,
+                technikum,
+                budget,
+                effectivePageable
+        );
+    }
+
+    public long countRatings(String specialty,
+                             Integer course,
+                             Integer group,
+                             Integer year,
+                             boolean technikum,
+                             boolean budget) {
+        return ratingRepository.countRatings(
                 specialty,
                 course,
                 group,
@@ -118,5 +157,30 @@ public class RatingService {
         rating.setTotalSubjects(total);
         rating.setLastUpdated(new Timestamp(System.currentTimeMillis()));
         ratingRepository.save(rating);
+    }
+
+    @Transactional
+    public void updateRatingsForStudents(Collection<StudentEntity> students) {
+        if (students == null || students.isEmpty()) {
+            return;
+        }
+        students.forEach(this::updateRatingForStudent);
+    }
+
+    @Transactional
+    public void updateRatingsForStudentIds(Collection<Long> studentIds) {
+        if (studentIds == null || studentIds.isEmpty()) {
+            return;
+        }
+        studentService.getStudentsByIds(studentIds.stream().toList())
+                .forEach(this::updateRatingForStudent);
+    }
+
+    @Transactional
+    public void updateRatingsForGroup(Long groupId) {
+        if (groupId == null) {
+            return;
+        }
+        updateRatingsForStudents(studentService.getStudentByGroupId(groupId));
     }
 }

--- a/src/main/resources/sql/technikum_flag_migration.sql
+++ b/src/main/resources/sql/technikum_flag_migration.sql
@@ -1,0 +1,8 @@
+-- Позначка технікуму на рівні спеціальності
+ALTER TABLE specialty
+    ADD COLUMN IF NOT EXISTS is_technikum TINYINT(1) NOT NULL DEFAULT 0;
+
+-- Первинне заповнення для наявних записів (наближене визначення)
+UPDATE specialty
+SET is_technikum = 1
+WHERE LOWER(title) LIKE '%тех%' OR LOWER(abbreviation) LIKE '%тех%';

--- a/src/test/java/com/esvar/dekanat/service/GroupServiceRatingFilterOptionsTest.java
+++ b/src/test/java/com/esvar/dekanat/service/GroupServiceRatingFilterOptionsTest.java
@@ -1,0 +1,95 @@
+package com.esvar.dekanat.service;
+
+import com.esvar.dekanat.dto.RatingFilterOptions;
+import com.esvar.dekanat.entity.FacultyEntity;
+import com.esvar.dekanat.entity.SpecialtyEntity;
+import com.esvar.dekanat.entity.StudentGroupEntity;
+import com.esvar.dekanat.repository.GroupRepository;
+import com.esvar.dekanat.security.SecurityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GroupServiceRatingFilterOptionsTest {
+
+    @Mock
+    private GroupRepository groupRepository;
+    @Mock
+    private StudentService studentService;
+    @Mock
+    private SecurityService securityService;
+    @Mock
+    private FacultyService facultyService;
+
+    private GroupService groupService;
+
+    @BeforeEach
+    void setUp() {
+        groupService = new GroupService(groupRepository, studentService, securityService, facultyService);
+    }
+
+    @Test
+    void methodistGetsOnlyOwnFacultyOptions() {
+        FacultyEntity facultyOne = new FacultyEntity();
+        facultyOne.setId(1L);
+        SpecialtyEntity specialty = new SpecialtyEntity();
+        specialty.setId(1L);
+        specialty.setAbbreviation("SPEC");
+        specialty.setTitle("Спеціальність");
+        specialty.setTechnikum(false);
+        specialty.setFaculty(facultyOne);
+
+        StudentGroupEntity ownGroup = new StudentGroupEntity();
+        ownGroup.setId(10L);
+        ownGroup.setSpecialty(specialty);
+        ownGroup.setCourse(2);
+        ownGroup.setGroupNumber(3);
+        ownGroup.setYear(2024);
+        ownGroup.setGroupCode("SPEC-2-3-2024");
+
+        SpecialtyEntity foreignSpecialty = new SpecialtyEntity();
+        foreignSpecialty.setId(2L);
+        foreignSpecialty.setAbbreviation("FOREIGN");
+        foreignSpecialty.setTitle("Інша");
+        foreignSpecialty.setTechnikum(false);
+        StudentGroupEntity foreignGroup = new StudentGroupEntity();
+        foreignGroup.setId(20L);
+        foreignGroup.setSpecialty(foreignSpecialty);
+        foreignGroup.setCourse(1);
+        foreignGroup.setGroupNumber(1);
+        foreignGroup.setYear(2023);
+        foreignGroup.setGroupCode("FOREIGN-1-1-2023");
+
+        when(groupRepository.findAll()).thenReturn(List.of(ownGroup, foreignGroup));
+        when(studentService.getGroupIdsByFaculty(1L)).thenReturn(Set.of(ownGroup.getId()));
+
+        User methodist = new User("user@example.com", "pwd",
+                List.of(new SimpleGrantedAuthority("ROLE_DEKANAT")));
+        when(securityService.getAuthenticatedUser()).thenReturn(methodist);
+        when(securityService.getCurrentRoleType()).thenReturn("1");
+
+        RatingFilterOptions options = groupService.getRatingFilterOptions();
+
+        assertEquals(1, options.groups().size(), "Methodist should only see own faculty groups");
+        assertIterableEquals(List.of("SPEC"), options.specialties(), "Only own specialty should be visible");
+        assertIterableEquals(List.of(2), options.courses());
+        assertIterableEquals(List.of(3), options.groupNumbers());
+        assertIterableEquals(List.of(2024), options.years());
+        assertEquals("SPEC", options.defaultSpecialty());
+        assertEquals(2, options.defaultCourse());
+        assertEquals(3, options.defaultGroupNumber());
+        assertEquals(2024, options.defaultYear());
+    }
+}

--- a/src/test/java/com/esvar/dekanat/service/RatingServiceTest.java
+++ b/src/test/java/com/esvar/dekanat/service/RatingServiceTest.java
@@ -1,0 +1,101 @@
+package com.esvar.dekanat.service;
+
+import com.esvar.dekanat.entity.FacultyEntity;
+import com.esvar.dekanat.entity.MarksEntity;
+import com.esvar.dekanat.entity.SpecialtyEntity;
+import com.esvar.dekanat.entity.StudentEntity;
+import com.esvar.dekanat.entity.StudentGroupEntity;
+import com.esvar.dekanat.entity.StudentRatingEntity;
+import com.esvar.dekanat.repository.MarksRepository;
+import com.esvar.dekanat.repository.StudentRatingRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RatingServiceTest {
+
+    @Mock
+    private GroupService groupService;
+    @Mock
+    private StudentRatingRepository ratingRepository;
+    @Mock
+    private MarksRepository marksRepository;
+    @Mock
+    private StudentService studentService;
+
+    private RatingService ratingService;
+
+    @BeforeEach
+    void setUp() {
+        ratingService = new RatingService(groupService, ratingRepository, marksRepository, studentService);
+    }
+
+    @Test
+    void recalculatesCountsAndAverageFromMarks() {
+        FacultyEntity faculty = new FacultyEntity();
+        faculty.setId(1L);
+
+        SpecialtyEntity specialty = new SpecialtyEntity();
+        specialty.setId(5L);
+        specialty.setTitle("Тестова");
+        specialty.setAbbreviation("TST");
+        specialty.setTechnikum(false);
+        specialty.setFaculty(faculty);
+
+        StudentGroupEntity group = new StudentGroupEntity();
+        group.setId(7L);
+        group.setSpecialty(specialty);
+        group.setCourse(2);
+        group.setGroupNumber(4);
+        group.setYear(2024);
+        group.setGroupCode("TST-2-4-2024");
+
+        StudentEntity student = new StudentEntity();
+        student.setId(11L);
+        student.setFaculty(faculty);
+        student.setGroup(group);
+
+        List<MarksEntity> marks = List.of(
+                markWithGrade(95),
+                markWithGrade(80),
+                markWithGrade(65),
+                markWithGrade(50),
+                markWithGrade(0)
+        );
+        when(marksRepository.findByStudentId(student.getId())).thenReturn(marks);
+        when(ratingRepository.findById(student.getId())).thenReturn(java.util.Optional.empty());
+        when(ratingRepository.save(any(StudentRatingEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ratingService.updateRatingForStudent(student);
+
+        ArgumentCaptor<StudentRatingEntity> ratingCaptor = ArgumentCaptor.forClass(StudentRatingEntity.class);
+        verify(ratingRepository).save(ratingCaptor.capture());
+        StudentRatingEntity savedRating = ratingCaptor.getValue();
+
+        assertEquals(new BigDecimal("72.50"), savedRating.getAverageScore());
+        assertEquals(1, savedRating.getCount5());
+        assertEquals(1, savedRating.getCount4());
+        assertEquals(1, savedRating.getCount3());
+        assertEquals(4, savedRating.getTotalSubjects());
+        assertEquals(group, savedRating.getGroup());
+        assertEquals(specialty, savedRating.getSpecialty());
+    }
+
+    private MarksEntity markWithGrade(int grade) {
+        MarksEntity mark = new MarksEntity();
+        mark.setFinalGrade(grade);
+        return mark;
+    }
+}


### PR DESCRIPTION
## Summary
- add a technikum flag to specialties with migration scripts and update rating queries to use pageable filters
- switch RatingView to a lazy, multi-sort grid with localized number formatting, percent badges, and role-aware default filters
- refresh ratings after mark deletions/updates and cover filter scoping and rating recalculation with new unit tests

## Testing
- ./mvnw test *(fails to download Maven wrapper binaries from repo.maven.apache.org in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b9af1ff7c83269ec63a5bb0d33198)