### PR TITLE
Limit mail tab visibility to admins

### DIFF
--- a/src/main/java/com/esvar/dekanat/view/MainLayout.java
+++ b/src/main/java/com/esvar/dekanat/view/MainLayout.java
@@ -120,9 +120,12 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
                     createTab(VaadinIcon.USER_CARD, "Перегляд карток", CardView.class),
                     createTab(VaadinIcon.PENCIL, "Введення оцінок", EnterMarksView.class, seasonIcon),
                     createTab(VaadinIcon.BAR_CHART, "Рейтинг", RatingView.class),
-                    createTab(VaadinIcon.BOOK, "Успішність", SuccessView.class),
-                    createTab(VaadinIcon.ENVELOPE, "Пошта", MailInboxView.class)
+                    createTab(VaadinIcon.BOOK, "Успішність", SuccessView.class)
             );
+
+            if (isAdmin) {
+                tabs.add(createTab(VaadinIcon.ENVELOPE, "Пошта", MailInboxView.class));
+            }
 
             if (isAdmin) {
                 tabs.add(createTab(VaadinIcon.USERS, "Користувачі", UsersView.class));


### PR DESCRIPTION
## Summary
- show the mail inbox navigation tab only for admin users in the main layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bd3aa74988326a755b508dd522fac)