### PR TITLE
report: add session selection dialog and session-aware summary generation

### DIFF
--- a/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
+++ b/src/main/java/com/esvar/dekanat/mark/EnterMarksView.java
@@ -67,6 +67,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -1382,14 +1383,14 @@ public class EnterMarksView extends Div {
         firstModuleButton.setWidthFull();
         firstModuleButton.addClickListener(event -> {
             reportDialog.close();
-            generateFirstModuleSummaryReport();
+            openSessionSelectionDialog(this::generateFirstModuleSummaryReport);
         });
 
         Button secondModuleButton = new Button("Зведений для другого м.к.");
         secondModuleButton.setWidthFull();
         secondModuleButton.addClickListener(event -> {
             reportDialog.close();
-            generateSecondModuleSummaryReport();
+            openSessionSelectionDialog(this::generateSecondModuleSummaryReport);
         });
 
         Button semesterButton = new Button("Семестровий");
@@ -1409,9 +1410,9 @@ public class EnterMarksView extends Div {
         reportDialog.add(dialogContent);
     }
 
-    private void generateFirstModuleSummaryReport() {
+    private void generateFirstModuleSummaryReport(boolean isWinterSession) {
         try {
-            SummaryReportResult result = summaryReportService.generateFirstModuleReport(selectGroup.getValue());
+            SummaryReportResult result = summaryReportService.generateFirstModuleReport(selectGroup.getValue(), isWinterSession);
             String fileName = String.format("summary-first-module-%s.pdf", result.groupCode());
             openPdfReport(fileName, result.pdfBytes());
 
@@ -1425,9 +1426,9 @@ public class EnterMarksView extends Div {
         }
     }
 
-    private void generateSecondModuleSummaryReport() {
+    private void generateSecondModuleSummaryReport(boolean isWinterSession) {
         try {
-            SummaryReportResult result = summaryReportService.generateSecondModuleReport(selectGroup.getValue());
+            SummaryReportResult result = summaryReportService.generateSecondModuleReport(selectGroup.getValue(), isWinterSession);
             String fileName = String.format("summary-second-module-%s.pdf", result.groupCode());
             openPdfReport(fileName, result.pdfBytes());
 
@@ -1439,6 +1440,37 @@ public class EnterMarksView extends Div {
             log.error("Не вдалося згенерувати зведений звіт", ex);
             Notification.show("Не вдалося згенерувати звіт");
         }
+    }
+
+    private void openSessionSelectionDialog(Consumer<Boolean> onSessionSelected) {
+        Dialog sessionDialog = new Dialog();
+        sessionDialog.setHeaderTitle("Оберіть сесію");
+        sessionDialog.setCloseOnEsc(true);
+        sessionDialog.setCloseOnOutsideClick(true);
+
+        Button winterButton = new Button("Зимова");
+        winterButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        winterButton.setWidthFull();
+        winterButton.addClickListener(event -> {
+            sessionDialog.close();
+            onSessionSelected.accept(true);
+        });
+
+        Button summerButton = new Button("Літня");
+        summerButton.setWidthFull();
+        summerButton.addClickListener(event -> {
+            sessionDialog.close();
+            onSessionSelected.accept(false);
+        });
+
+        VerticalLayout content = new VerticalLayout(winterButton, summerButton);
+        content.setPadding(false);
+        content.setSpacing(true);
+        content.setWidth("260px");
+        content.setDefaultHorizontalComponentAlignment(FlexComponent.Alignment.STRETCH);
+
+        sessionDialog.add(content);
+        sessionDialog.open();
     }
 
     private void openPdfReport(String fileName, byte[] pdfBytes) {

--- a/src/main/java/com/esvar/dekanat/plan/PlanView.java
+++ b/src/main/java/com/esvar/dekanat/plan/PlanView.java
@@ -474,7 +474,7 @@ public class PlanView extends Div {
 
     private void generateFirstModuleSummaryReport() {
         try {
-            SummaryReportService.SummaryReportResult result = summaryReportService.generateFirstModuleReport(selectGroup.getValue());
+            SummaryReportService.SummaryReportResult result = summaryReportService.generateFirstModuleReport(selectGroup.getValue(), isWinterSessionSelected());
             String fileName = String.format("summary-first-module-%s.pdf", result.groupCode());
             openPdfReport(fileName, result.pdfBytes());
 
@@ -490,7 +490,7 @@ public class PlanView extends Div {
 
     private void generateSecondModuleSummaryReport() {
         try {
-            SummaryReportService.SummaryReportResult result = summaryReportService.generateSecondModuleReport(selectGroup.getValue());
+            SummaryReportService.SummaryReportResult result = summaryReportService.generateSecondModuleReport(selectGroup.getValue(), isWinterSessionSelected());
             String fileName = String.format("summary-second-module-%s.pdf", result.groupCode());
             openPdfReport(fileName, result.pdfBytes());
 
@@ -506,7 +506,7 @@ public class PlanView extends Div {
 
     private void generateSemesterSummaryReport() {
         try {
-            SummaryReportService.SummaryReportResult result = summaryReportService.generateSemesterReport(selectGroup.getValue());
+            SummaryReportService.SummaryReportResult result = summaryReportService.generateSemesterReport(selectGroup.getValue(), isWinterSessionSelected());
             String fileName = String.format("summary-semester-%s.pdf", result.groupCode());
             openPdfReport(fileName, result.pdfBytes());
 
@@ -536,6 +536,10 @@ public class PlanView extends Div {
 
         String resourceUrl = registration.getResourceUri().toString();
         ui.getPage().open(resourceUrl, "_blank");
+    }
+
+    private boolean isWinterSessionSelected() {
+        return "Зимова".equals(sessionSelect.getValue());
     }
 
     private Div createReportGenerationBlock() {

--- a/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
+++ b/src/main/java/com/esvar/dekanat/service/SummaryReportService.java
@@ -11,7 +11,6 @@ import com.esvar.dekanat.entity.StudentGroupEntity;
 import com.esvar.dekanat.entity.StudentPlansEntity;
 import com.esvar.dekanat.entity.EduProgramEntity;
 import com.esvar.dekanat.generate.summary.SummaryReportPdfGenerator;
-import com.esvar.dekanat.repository.SessionRepository;
 import com.esvar.dekanat.security.SecurityService;
 import com.esvar.dekanat.user.UserModel;
 import org.springframework.stereotype.Service;
@@ -49,7 +48,6 @@ public class SummaryReportService {
     private final SummaryReportPdfGenerator summaryReportPdfGenerator;
     private final SecurityService securityService;
     private final Collator ukrainianCollator = Collator.getInstance(new Locale("uk", "UA"));
-    private final SessionRepository sessionRepository;
 
     public SummaryReportService(GroupService groupService,
                                 StudentService studentService,
@@ -57,7 +55,7 @@ public class SummaryReportService {
                                 PlanService planService,
                                 MarksService marksService,
                                 SummaryReportPdfGenerator summaryReportPdfGenerator,
-                                SecurityService securityService, SessionRepository sessionRepository) {
+                                SecurityService securityService) {
         this.groupService = groupService;
         this.studentService = studentService;
         this.studentPlansService = studentPlansService;
@@ -65,25 +63,24 @@ public class SummaryReportService {
         this.marksService = marksService;
         this.summaryReportPdfGenerator = summaryReportPdfGenerator;
         this.securityService = securityService;
-        this.sessionRepository = sessionRepository;
     }
 
     @Transactional(readOnly = true)
-    public SummaryReportResult generateFirstModuleReport(GroupDTO selectedGroup) {
-        return generateReport(selectedGroup, List.of(CONTROL_TYPE_FIRST_MODULE), CONTROL_TYPE_FIRST_MODULE, true);
+    public SummaryReportResult generateFirstModuleReport(GroupDTO selectedGroup, boolean isWinterSession) {
+        return generateReport(selectedGroup, List.of(CONTROL_TYPE_FIRST_MODULE), CONTROL_TYPE_FIRST_MODULE, true, isWinterSession);
     }
 
     @Transactional(readOnly = true)
-    public SummaryReportResult generateSecondModuleReport(GroupDTO selectedGroup) {
-        return generateTwoModuleReport(selectedGroup);
+    public SummaryReportResult generateSecondModuleReport(GroupDTO selectedGroup, boolean isWinterSession) {
+        return generateTwoModuleReport(selectedGroup, isWinterSession);
     }
 
     @Transactional(readOnly = true)
-    public SummaryReportResult generateSemesterReport(GroupDTO selectedGroup) {
-        return generateReport(selectedGroup, SEMESTER_CONTROL_TYPES, CONTROL_TYPE_SEMESTER, true);
+    public SummaryReportResult generateSemesterReport(GroupDTO selectedGroup, boolean isWinterSession) {
+        return generateReport(selectedGroup, SEMESTER_CONTROL_TYPES, CONTROL_TYPE_SEMESTER, true, isWinterSession);
     }
 
-    private SummaryReportResult generateTwoModuleReport(GroupDTO selectedGroup) {
+    private SummaryReportResult generateTwoModuleReport(GroupDTO selectedGroup, boolean isWinterSession) {
         System.out.println("[SummaryReportService] Початок генерації звіту за два модулі");
         if (selectedGroup == null) {
             throw new SummaryReportGenerationException("Оберіть групу для формування звіту");
@@ -97,7 +94,7 @@ public class SummaryReportService {
             throw new SummaryReportGenerationException("У групі немає студентів");
         }
 
-        int semester = computeFirstModuleSemester(selectedGroup.getCourse());
+        int semester = computeFirstModuleSemester(selectedGroup.getCourse(), isWinterSession);
         Map<Long, TwoModulePlanAssignment> planAssignments = collectTwoModuleAssignments(group, semester, students);
         if (planAssignments.isEmpty()) {
             throw new SummaryReportGenerationException("Не знайдено дисциплін для обраного контролю");
@@ -143,7 +140,8 @@ public class SummaryReportService {
     private SummaryReportResult generateReport(GroupDTO selectedGroup,
                                                Collection<String> controlTypes,
                                                String controlTitle,
-                                               boolean includeSignature) {
+                                               boolean includeSignature,
+                                               boolean isWinterSession) {
         System.out.println("[SummaryReportService] Початок генерації звіту для контролю: " + controlTitle);
         if (selectedGroup == null) {
             System.out.println("[SummaryReportService] Не обрано групу для звіту");
@@ -163,7 +161,7 @@ public class SummaryReportService {
 
         System.out.println("[SummaryReportService] Знайдено студентів: " + students.size());
 
-        int semester = computeSemesterForControl(selectedGroup.getCourse(), controlTitle);
+        int semester = computeSemesterForControl(selectedGroup.getCourse(), controlTitle, isWinterSession);
         System.out.println("[SummaryReportService] Обчислено семестр для контролю: " + semester);
         Map<Long, PlanAssignment> planAssignments = collectPlanAssignments(group, semester, students, controlTypes);
         if (planAssignments.isEmpty()) {
@@ -221,18 +219,15 @@ public class SummaryReportService {
                 .orElse("");
     }
 
-    private int computeSecondModuleSemester(int course) {
-        if (sessionRepository.findAll().get(0).isWinter()){
-            return course * 2 -1;
-        }
-        return course * 2;
+    private int computeSecondModuleSemester(int course, boolean isWinterSession) {
+        return isWinterSession ? course * 2 - 1 : course * 2;
     }
 
-    private int computeSemesterForControl(int course, String controlTitle) {
+    private int computeSemesterForControl(int course, String controlTitle, boolean isWinterSession) {
         if (CONTROL_TYPE_SECOND_MODULE.equals(controlTitle) || CONTROL_TYPE_SEMESTER.equals(controlTitle)) {
-            return computeSecondModuleSemester(course);
+            return computeSecondModuleSemester(course, isWinterSession);
         }
-        return computeFirstModuleSemester(course);
+        return computeFirstModuleSemester(course, isWinterSession);
     }
 
     private String formatTeacherName(UserModel user) {
@@ -265,11 +260,11 @@ public class SummaryReportService {
                 .collect(Collectors.toList());
     }
 
-    private int computeFirstModuleSemester(int course) {
+    private int computeFirstModuleSemester(int course, boolean isWinterSession) {
         if (course <= 0) {
             return 1;
         }
-        return course * 2 - 1;
+        return isWinterSession ? course * 2 - 1 : course * 2;
     }
 
     private String buildReportTitle(String controlType) {


### PR DESCRIPTION
### Motivation
- Summary reports were being calculated only for the winter semester due to use of a global/fixed session state, so a minimal UI + service change is needed to let the user choose session at report generation time and compute semester correctly.

### Description
- Added a small session selection dialog in `EnterMarksView` titled `Оберіть сесію` with two buttons `Зимова` and `Літня`, and wired report actions to open that dialog before generating the report by adding `openSessionSelectionDialog` and delegating the chosen session to the generator.
- Made `SummaryReportService` session-aware by changing report entry points to accept a `boolean isWinterSession` parameter and updated semester computation helpers (`computeFirstModuleSemester`, `computeSecondModuleSemester`, `computeSemesterForControl`) to use that parameter instead of global session state. 
- Updated `PlanView` to pass the currently-selected session from its `sessionSelect` control into the service via `isWinterSessionSelected()` so both UI locations are consistent.
- Kept changes minimal and localized to view/service call flow and semester calculation; no changes to PDF templates/generators, database schema, or domain models.

### Testing
- Attempted a build compile with `./mvnw -q -DskipTests compile`, but the Maven wrapper failed to download the Maven binary in this environment due to a network fetch error, so full compilation could not be verified automatically.
- No automated unit or integration tests were run in this environment; changes are small and focused to ease manual deployment and quick sanity testing on the production server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3e9de3a7c8326ba80a52aa0281607)